### PR TITLE
Phase 1: Executable Skeleton and Contracts (#2)

### DIFF
--- a/CodeLlmWiki.slnx
+++ b/CodeLlmWiki.slnx
@@ -1,0 +1,12 @@
+<Solution>
+  <Folder Name="/src/">
+    <Project Path="src/CodeLlmWiki.Cli/CodeLlmWiki.Cli.csproj" />
+    <Project Path="src/CodeLlmWiki.Contracts/CodeLlmWiki.Contracts.csproj" />
+    <Project Path="src/CodeLlmWiki.Ingestion/CodeLlmWiki.Ingestion.csproj" />
+    <Project Path="src/CodeLlmWiki.Ontology/CodeLlmWiki.Ontology.csproj" />
+  </Folder>
+  <Folder Name="/tests/">
+    <Project Path="tests/CodeLlmWiki.Cli.Tests/CodeLlmWiki.Cli.Tests.csproj" />
+    <Project Path="tests/CodeLlmWiki.Ingestion.Tests/CodeLlmWiki.Ingestion.Tests.csproj" />
+  </Folder>
+</Solution>

--- a/docs/adr/0001-ontology-versioning-governance.md
+++ b/docs/adr/0001-ontology-versioning-governance.md
@@ -1,0 +1,18 @@
+# ADR 0001: Ontology Versioning Governance
+
+## Status
+Accepted
+
+## Context
+The ontology is a strict contract for ingestion, query, and wiki generation. Breaking predicate/entity changes must be explicit.
+
+## Decision
+The ontology is canonical in machine-readable form and follows semantic versioning:
+- Major: breaking contract changes
+- Minor: additive non-breaking changes
+- Patch: clarifications and metadata-only fixes
+
+Breaking changes require a migration note.
+
+## Consequences
+Consumers can reason about compatibility and CI can enforce schema evolution discipline.

--- a/docs/adr/0002-stable-identity-strategy.md
+++ b/docs/adr/0002-stable-identity-strategy.md
@@ -1,0 +1,13 @@
+# ADR 0002: Stable Identity Strategy
+
+## Status
+Accepted
+
+## Context
+Entity identity must be stable across runs and deterministic for graph linking.
+
+## Decision
+Use natural keys as canonical identity inputs and derive deterministic IDs from those keys.
+
+## Consequences
+Cross-run comparisons, stable links, and deterministic graph regeneration are supported.

--- a/docs/adr/0003-query-boundary-contract.md
+++ b/docs/adr/0003-query-boundary-contract.md
@@ -1,0 +1,13 @@
+# ADR 0003: Query Boundary Contract
+
+## Status
+Accepted
+
+## Context
+Wiki generation and future MCP clients must not be coupled to graph internals.
+
+## Decision
+Consumers access analysis data through a formal query/read contract, not direct graph internals.
+
+## Consequences
+Internal graph implementations can evolve without forcing consumer rewrites.

--- a/docs/adr/0004-front-matter-policy.md
+++ b/docs/adr/0004-front-matter-policy.md
@@ -1,0 +1,13 @@
+# ADR 0004: Front Matter Policy
+
+## Status
+Accepted
+
+## Context
+Wiki pages need consistent provenance metadata without overwhelming human readability.
+
+## Decision
+Common front matter remains minimal, mandatory, and stable. Rich analysis content belongs in page bodies.
+
+## Consequences
+Obsidian/LLM indexing stays predictable while pages remain human-first.

--- a/docs/adr/0005-cli-exit-semantics.md
+++ b/docs/adr/0005-cli-exit-semantics.md
@@ -1,0 +1,18 @@
+# ADR 0005: CLI Exit Semantics
+
+## Status
+Accepted
+
+## Context
+CI requires strict signaling for success, partial success, and failure.
+
+## Decision
+Exit semantics:
+- Success: `0`
+- Completed with diagnostics: non-zero by default
+- Failure: non-zero
+
+A dedicated allow-partial policy can map partial-success to `0` when explicitly configured.
+
+## Consequences
+Pipelines are strict by default, with explicit opt-in for exploratory or local workflows.

--- a/ontology/ontology.v1.yaml
+++ b/ontology/ontology.v1.yaml
@@ -1,0 +1,4 @@
+version: "1.0.0"
+predicates:
+  - id: "core:contains"
+  - id: "core:references"

--- a/plans/plans/001-phase-1-dotnet-project-structure-plan.md
+++ b/plans/plans/001-phase-1-dotnet-project-structure-plan.md
@@ -1,0 +1,145 @@
+# Plan: Phase 1 .NET Repository Structure Ingestion and Wiki Output
+
+> Source PRD: `plans/prds/001-phase-1-dotnet-project-structure-prd.md`
+
+## Architectural decisions
+
+Durable decisions that apply across all phases:
+
+- **Execution surface**: CLI-first with one verb, short/long options, versioned config file plus CLI overrides.
+- **Run boundary**: One repository per ingestion run.
+- **Provenance**: `HEAD` commit is canonical; dirty working tree is recorded as diagnostics.
+- **Data model**: Strict semantic triples, including first-class literal/value nodes.
+- **Ontology**: Canonical machine-readable ontology file with semantic versioning and migration discipline.
+- **Ontology namespaces**: Language-agnostic core predicates plus `dotnet:*` extension predicates.
+- **Identity**: Stable natural keys with deterministic derived IDs.
+- **.NET discovery strategy**: MSBuild evaluation first, fallback parsing on evaluation failure.
+- **Git file history**: Full timeline, rename-aware identity, true merge commits only.
+- **Mainline merge target**: Resolve from `origin/HEAD`, fallback `main`, then `master`.
+- **Output model**: Run-scoped artifacts and success-gated atomic promotion to `latest`.
+- **Wiki contract**: Deterministic full regeneration with five page types (repository, solution, project, package, file).
+- **Front matter**: Mandatory minimal common fields, minimal entity-specific fields, richer details in body sections.
+- **Query boundary**: Wiki generation consumes formal query interfaces, not graph internals.
+- **Validation/quality**: Schema and ontology validation, golden integration tests, generated-artifact freshness gate in CI.
+- **Governance**: ADRs required for major contracts and kept current with changes.
+- **Performance envelope**: Target up to ~500k LOC / 20k tracked files in <=10 minutes and <=2 GB memory.
+
+---
+
+## Phase 1: Executable Skeleton and Contracts
+
+**User stories**: 1, 2, 3, 11, 12, 13, 14, 15, 41, 45
+
+### What to build
+
+Deliver a runnable CLI skeleton that can execute a no-op ingestion pipeline end-to-end while enforcing the core contracts: ontology loading/versioning, stable identity model, triple data model, and ADR-backed governance. This phase establishes the stable seams all later slices build on.
+
+### Acceptance criteria
+
+- [ ] CLI command executes with config file and option overrides, and returns deterministic run status.
+- [ ] Ontology source-of-truth is loaded and validated before ingestion work begins.
+- [ ] Core graph identity/triple contracts are defined and usable by downstream modules.
+- [ ] ADR set exists for ontology, identity, query boundary, front matter policy, and exit semantics.
+
+---
+
+## Phase 2: Repository and Solution/Project Vertical Slice
+
+**User stories**: 4, 7, 8, 16, 19, 34, 40
+
+### What to build
+
+Implement the first real vertical slice that ingests repository structure and solution/project topology into triples, exposes the data through the query contract, and renders minimal repository/solution/project pages. The slice must support partial completion with diagnostics and remain demoable end-to-end.
+
+### Acceptance criteria
+
+- [ ] Repository root, solutions, and projects are ingested from real repositories into triples.
+- [ ] MSBuild-first discovery works, with fallback behavior producing diagnostics when needed.
+- [ ] Query service can retrieve repository/solution/project views used by wiki generation.
+- [ ] Wiki pages for repository/solution/project render deterministically from query results.
+
+---
+
+## Phase 3: Package Graph Vertical Slice
+
+**User stories**: 9, 10, 19, 34, 35
+
+### What to build
+
+Extend ingestion/query/wiki to include package dependencies as graph facts, capturing declared dependencies always and resolved versions when locally available. This slice must preserve strict ontology boundaries and demonstrate clean extension of the existing query and wiki contracts.
+
+### Acceptance criteria
+
+- [ ] Declared package dependencies are represented and queryable for each project.
+- [ ] Resolved package versions are ingested when local artifacts are available, with explicit diagnostics otherwise.
+- [ ] Package wiki pages are generated and linked from project pages.
+- [ ] Ontology/version validation passes with package predicates added under approved namespaces.
+
+---
+
+## Phase 4: File Inventory and Classification Vertical Slice
+
+**User stories**: 5, 6, 19, 22, 33
+
+### What to build
+
+Add repository-wide file ingestion for all git-tracked `HEAD` files, including classification metadata and file-level pages focused on structural metadata (no code excerpts). The slice should provide useful filtering context for humans and LLMs while keeping pages concise.
+
+### Acceptance criteria
+
+- [ ] All git-tracked files at `HEAD` are represented in the graph.
+- [ ] File classification facts are populated and exposed through query interfaces.
+- [ ] File wiki pages render metadata-first content with no source code excerpts.
+- [ ] Front matter remains minimal and body sections carry richer human-readable context.
+
+---
+
+## Phase 5: Git History and Merge-to-Mainline Vertical Slice
+
+**User stories**: 27, 28, 29, 30, 31, 32, 43, 44
+
+### What to build
+
+Integrate git-history depth into file entities: full rename-aware timelines, summary metrics, and merge-to-mainline events constrained to true merge commits. Render branch derivation context and file-specific merge-source commit counts on file pages.
+
+### Acceptance criteria
+
+- [ ] Full per-file commit history is ingested with rename continuity.
+- [ ] File summaries include edit count and last-change provenance fields.
+- [ ] Merge-to-mainline entries include timestamp, author, target branch context, and file-specific source-branch commit count.
+- [ ] Submodule presence is represented as opaque dependency facts without recursive ingestion.
+
+---
+
+## Phase 6: Deterministic Wiki + GraphML Publication
+
+**User stories**: 20, 21, 23, 24, 25, 26, 34
+
+### What to build
+
+Complete output publication behavior: deterministic full regeneration of wiki outputs, GraphML serialization, run-scoped artifact layout, machine-readable run manifest, and atomic success-gated `latest` promotion. This slice makes the system operationally consumable.
+
+### Acceptance criteria
+
+- [ ] All five wiki entity page types generate deterministically from query interfaces.
+- [ ] GraphML export is emitted for each run and aligned with graph facts.
+- [ ] Run manifest includes status, timings, counts, diagnostics summary, and artifact references.
+- [ ] `latest` is updated atomically only when generation and validation succeed.
+
+---
+
+## Phase 7: Validation, Golden Tests, and CI Gates
+
+**User stories**: 17, 18, 36, 37, 38, 39
+
+### What to build
+
+Harden delivery with behavioral tests and enforcement gates: unit coverage for stable module interfaces, golden end-to-end snapshots for wiki and GraphML, exit code semantics verification, and CI checks that fail on stale generated artifacts or contract violations.
+
+### Acceptance criteria
+
+- [ ] Unit tests verify external behavior for core modules without coupling to internals.
+- [ ] Golden integration tests validate deterministic wiki and GraphML outputs for fixture repositories.
+- [ ] CLI exit behavior is verified for success, partial-success, and override modes.
+- [ ] CI fails when generated artifacts are stale or ontology/front matter validation fails.
+

--- a/plans/prds/001-phase-1-dotnet-project-structure-prd.md
+++ b/plans/prds/001-phase-1-dotnet-project-structure-prd.md
@@ -1,0 +1,140 @@
+# PRD 001: Phase 1 .NET Repository Structure Ingestion and Wiki Output
+
+Date: 2026-04-18  
+Status: Draft (approved baseline, subject to iteration)  
+Phase: First development phase
+
+## Problem Statement
+
+As maintainers of .NET repositories, we need a reliable way to extract and share accurate structural context about a codebase. Today, that context is fragmented across solution files, project files, package declarations, Git history, and implicit build behavior, making it expensive for both humans and LLMs to understand system shape quickly.
+
+We need a deterministic, repeatable process that ingests repository structure and history into a strict graph model, then publishes human-first wiki output that remains synchronized with implementation decisions and ontology evolution.
+
+## Solution
+
+Build a CLI-first ingestion system in .NET 10 that performs one-repository-per-run analysis, with a strict semantic-triple graph model backed by QuikGraph and serialized to GraphML. Phase 1 focuses on project structure only: repository, solutions, projects, packages, and files with Git history.
+
+The ingestion will use `HEAD` as the canonical source commit for deterministic output while recording diagnostics when the working tree is dirty. It will gather:
+
+1. Repository and solution/project topology.
+2. Package dependencies (declared, plus resolved when locally available).
+3. Full per-file commit timeline with summaries, rename-aware history, and true merge-commit-to-mainline events.
+
+The output will be:
+
+1. Run-scoped artifacts per ingestion run.
+2. A deterministic markdown wiki (human-first) with minimal front matter and rich body content.
+3. GraphML export for graph-capable downstream tooling.
+4. A machine-readable run manifest for CI/operations.
+
+Wiki generation will consume a formal query interface contract rather than graph internals, preserving modularity for future MCP and ad hoc querying.
+
+## User Stories
+
+1. As a platform engineer, I want to run one CLI command to ingest a repository, so that I can generate structural documentation consistently.
+2. As a developer, I want long and short CLI options, so that command usage is fast and ergonomic.
+3. As a team lead, I want one repository analyzed per run, so that identity and provenance remain unambiguous.
+4. As an architect, I want repository-root modeling with solutions/projects beneath it, so that non-solution project assets are not missed.
+5. As a maintainer, I want all git-tracked files included in analysis, so that operationally important non-code files are still documented.
+6. As a maintainer, I want files classified (for example .NET source vs non-source), so that I can filter wiki/query views cleanly.
+7. As a build engineer, I want MSBuild evaluation used as primary discovery, so that conditional/imported project and package data is accurate.
+8. As a developer, I want fallback parsing when MSBuild evaluation fails, so that ingestion still produces useful partial output.
+9. As a dependency owner, I want declared package dependencies captured, so that intent is visible even without restore artifacts.
+10. As a dependency owner, I want resolved package versions captured when available locally, so that effective dependency reality is visible.
+11. As a repository owner, I want strict ontology governance, so that query contracts remain stable over time.
+12. As a consumer of generated docs, I want semantic versioning for ontology changes, so that breaking changes are explicit and managed.
+13. As a graph consumer, I want stable natural-key identity, so that entities are comparable across runs.
+14. As a graph consumer, I want deterministic derived IDs, so that links and references remain stable and machine-friendly.
+15. As an analyst, I want literal values represented as triple nodes, so that querying remains uniform across fact types.
+16. As a maintainer, I want ingestion to complete with diagnostics when partial failures occur, so that documentation flow is not blocked.
+17. As a CI owner, I want partial completion to return non-zero by default, so that pipelines stay strict unless explicitly overridden.
+18. As an engineer, I want a local override for partial-success acceptance, so that exploratory runs are possible during investigation.
+19. As a user of generated docs, I want pages for repository, solution, project, package, and file entities, so that phase-1 context is complete.
+20. As an Obsidian user, I want minimal mandatory common front matter, so that metadata remains useful without dominating pages.
+21. As an LLM consumer, I want consistent common front matter across all entity pages, so that retrieval is reliable.
+22. As a documentation consumer, I want richer details in page bodies rather than front matter, so that readability remains high.
+23. As a developer, I want deterministic full regeneration of generated pages each run, so that output drift is eliminated.
+24. As a developer, I want run-scoped output directories, so that I can compare and audit historical runs.
+25. As an operator, I want atomic promotion to a `latest` pointer only on success, so that consumers never see partial artifacts.
+26. As a maintainer, I want a machine-readable run manifest, so that CI and tooling can reason about status and diagnostics programmatically.
+27. As a repository reader, I want each page to state branch derivation context, so that I understand source-of-truth lineage.
+28. As a file-level reader, I want edit count and last-change summaries, so that I can identify potential hotspots quickly.
+29. As a file-level reader, I want rename-aware file history, so that refactors do not reset historical understanding.
+30. As a file-level reader, I want merge-to-mainline history entries for true merge commits, so that delivery cadence is visible.
+31. As a file-level reader, I want merge history to include timestamp and author, so that accountability and chronology are clear.
+32. As a file-level reader, I want source-branch commit counts for that specific file only, so that the metric stays file-relevant.
+33. As a documentation reader, I want metadata-first file pages without code excerpts in phase 1, so that pages stay concise and focused.
+34. As a query consumer, I want wiki generation to use a formal query service contract, so that downstream interfaces can evolve safely.
+35. As a future platform architect, I want a language-agnostic ontology core with .NET extension namespace, so that Python/frontend analyzers can be added without redesign.
+36. As a team member, I want generated artifact freshness enforced in CI, so that committed docs cannot drift from implementation.
+37. As a QA engineer, I want golden-file integration tests for graph and wiki outputs, so that regressions are caught end-to-end.
+38. As a developer, I want unit tests around modules with stable interfaces, so that behavior is validated without over-coupling to implementation details.
+39. As a performance owner, I want a defined phase-1 performance envelope, so that we can detect unacceptable regressions early.
+40. As a product owner, I want a vertical slice delivered end-to-end first, so that we validate architecture with working output before adding deeper analysis.
+41. As an engineering manager, I want ADRs for major contracts, so that decisions and change history stay explicit and current.
+42. As a future integrator, I want query compatibility with MCP-style ad hoc access in later phases, so that graph insights are reusable beyond wiki generation.
+43. As an operations engineer, I want run diagnostics persisted as structured facts, so that trust boundaries are visible in outputs.
+44. As an architect, I want submodules captured as opaque dependencies in phase 1, so that repository boundary rules stay consistent.
+45. As a maintainability-focused team, I want module boundaries to enforce deep interfaces, so that implementation can evolve behind stable contracts.
+
+## Implementation Decisions
+
+1. Use a CLI-first architecture with a single ingestion verb and option aliases.
+2. Use one repository per run.
+3. Use `HEAD` as canonical provenance commit for phase 1.
+4. Record working-tree dirtiness as diagnostics without changing provenance commit identity.
+5. Model repository as root with discovered solutions and projects as children.
+6. Include all git-tracked files at `HEAD`; classify files for filtering.
+7. Capture package dependencies as declared plus resolved when locally available.
+8. Use MSBuild evaluation as primary for .NET structure/package discovery; fallback parsing when needed.
+9. Represent data as strict semantic triples with first-class literal/value nodes.
+10. Back graph representation with QuikGraph and support GraphML serialization.
+11. Enforce strict, versioned ontology governance with a canonical machine-readable ontology file.
+12. Use language-agnostic core ontology predicates and `dotnet:*` extension namespace.
+13. Use stable natural keys for entity identity; allow deterministic derived IDs.
+14. Persist full per-file commit timeline plus summary fields.
+15. Follow renames to preserve logical file identity across path changes.
+16. Track true merge commits to mainline only; do not infer squash/rebase merges in phase 1.
+17. Resolve mainline branch from default remote head first, then fallback branch names.
+18. Generate five page types in phase 1: repository, solution, project, package, file.
+19. Keep common front matter minimal and fixed to seven mandatory fields.
+20. Keep page-specific front matter minimal and stable; place richer detail in page body sections.
+21. Regenerate all generated wiki pages deterministically every run.
+22. Write artifacts to run-scoped output and atomically promote a success-only `latest` view.
+23. Emit a machine-readable run manifest with status, counts, timings, diagnostics, and artifact locations.
+24. Expose graph read access through a formal query interface used by wiki generation.
+25. Return non-zero exit code for partial-success runs by default, with explicit override option.
+26. Require ADRs for major contracts: ontology, identity, query interface, front matter schema, and CLI exit semantics.
+27. Target deep module seams: CLI, ingestion orchestration, .NET analyzer, graph, query, wiki, validation.
+
+## Testing Decisions
+
+1. A good test validates externally observable behavior and contracts, not internal implementation details.
+2. Unit tests will focus on deep modules with stable public interfaces and deterministic behavior.
+3. Integration tests will validate end-to-end ingestion and generation through golden outputs.
+4. Golden tests will cover GraphML and wiki output determinism for representative fixture repositories.
+5. Validation tests will enforce ontology schema compliance and front matter schema compliance.
+6. CLI behavior tests will verify exit codes, option parsing, config override behavior, and partial-success semantics.
+7. Git-history behavior tests will verify rename handling, merge-to-mainline extraction, and file-specific branch commit counts.
+8. Publication tests will verify atomic promotion and no partial publication into `latest`.
+9. CI will include an up-to-date generated-artifacts gate to detect stale committed outputs.
+10. Prior-art guidance: no existing in-repo test suite currently exists; establish patterns from this phase as project standard.
+
+## Out of Scope
+
+1. Full semantic code analysis (types, inheritance, call graphs, property read/write flows).
+2. Endpoint discovery and endpoint-specific metadata extraction.
+3. Complexity metrics (cyclomatic, cognitive, Halstead, maintainability index, CBO, LOC analysis beyond basic structural counts).
+4. Domain-term extraction and semantic lexicon linking.
+5. Cross-repository/system dependency traversal and whole-estate architecture maps.
+6. Non-.NET analyzers (Python, React, Vue, Angular).
+7. Inference of squash/rebase merges as merge events.
+8. Rendering source code excerpts within file pages.
+
+## Further Notes
+
+1. Human readability is primary for wiki pages; stability and determinism remain hard constraints.
+2. Canonical page paths are ID-based in phase 1, with human-readable titles and navigation metadata; this may evolve later.
+3. This PRD is intentionally focused on one complete vertical slice before deeper analyzer expansion.
+4. Decision and change history must remain current through ADR updates and ontology/version governance.
+5. Expected baseline performance target for phase 1: repositories up to approximately 500k LOC / 20k tracked files, <=10 minutes runtime, <=2 GB memory.

--- a/src/CodeLlmWiki.Cli/CliApplication.cs
+++ b/src/CodeLlmWiki.Cli/CliApplication.cs
@@ -1,0 +1,81 @@
+using System.Text.Json;
+using CodeLlmWiki.Cli.Commands;
+using CodeLlmWiki.Cli.Config;
+using CodeLlmWiki.Ingestion;
+using CommandLine;
+
+namespace CodeLlmWiki.Cli;
+
+public sealed class CliApplication
+{
+    private const string DefaultOntologyPath = "ontology/ontology.v1.yaml";
+    private readonly IIngestionRunner _runner;
+
+    public CliApplication(IIngestionRunner runner)
+    {
+        _runner = runner;
+    }
+
+    public Task<int> RunAsync(string[] args, CancellationToken cancellationToken)
+    {
+        var parser = new Parser(settings =>
+        {
+            settings.HelpWriter = Console.Out;
+            settings.CaseInsensitiveEnumValues = true;
+        });
+
+        return parser.ParseArguments<IngestOptions>(args)
+            .MapResult(
+                ingest => RunIngestAsync(ingest, cancellationToken),
+                _ => Task.FromResult(1));
+    }
+
+    private async Task<int> RunIngestAsync(IngestOptions options, CancellationToken cancellationToken)
+    {
+        var config = await LoadConfigAsync(options.ConfigPath, cancellationToken);
+
+        var allowPartial = ParseNullableBool(options.AllowPartialSuccess)
+            ?? config.AllowPartialSuccess
+            ?? false;
+
+        var ontologyPath = options.OntologyPath
+            ?? config.OntologyPath
+            ?? DefaultOntologyPath;
+
+        var request = new IngestionRunRequest(
+            RepositoryPath: options.RepositoryPath,
+            ConfigPath: options.ConfigPath,
+            OntologyPath: ontologyPath,
+            AllowPartialSuccess: allowPartial);
+
+        var result = await _runner.RunAsync(request, cancellationToken);
+
+        return result.ExitCode;
+    }
+
+    private static async Task<IngestionCliConfig> LoadConfigAsync(string? configPath, CancellationToken cancellationToken)
+    {
+        if (string.IsNullOrWhiteSpace(configPath) || !File.Exists(configPath))
+        {
+            return IngestionCliConfig.Empty;
+        }
+
+        await using var stream = File.OpenRead(configPath);
+
+        var config = await JsonSerializer.DeserializeAsync<IngestionCliConfig>(stream, cancellationToken: cancellationToken);
+
+        return config ?? IngestionCliConfig.Empty;
+    }
+
+    private static bool? ParseNullableBool(string? value)
+    {
+        if (string.IsNullOrWhiteSpace(value))
+        {
+            return null;
+        }
+
+        return bool.TryParse(value, out var parsed)
+            ? parsed
+            : null;
+    }
+}

--- a/src/CodeLlmWiki.Cli/CodeLlmWiki.Cli.csproj
+++ b/src/CodeLlmWiki.Cli/CodeLlmWiki.Cli.csproj
@@ -1,0 +1,18 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+  <ItemGroup>
+    <ProjectReference Include="..\CodeLlmWiki.Ingestion\CodeLlmWiki.Ingestion.csproj" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <PackageReference Include="CommandLineParser" Version="2.9.1" />
+  </ItemGroup>
+
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>net10.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+  </PropertyGroup>
+
+</Project>

--- a/src/CodeLlmWiki.Cli/Commands/IngestOptions.cs
+++ b/src/CodeLlmWiki.Cli/Commands/IngestOptions.cs
@@ -1,0 +1,19 @@
+using CommandLine;
+
+namespace CodeLlmWiki.Cli.Commands;
+
+[Verb("ingest", HelpText = "Ingest repository structure into graph contracts.")]
+public sealed class IngestOptions
+{
+    [Option('p', "path", Required = true, HelpText = "Path to the repository root.")]
+    public string RepositoryPath { get; init; } = string.Empty;
+
+    [Option('c', "config", Required = false, HelpText = "Path to JSON config file.")]
+    public string? ConfigPath { get; init; }
+
+    [Option('o', "ontology", Required = false, HelpText = "Path to ontology yaml file.")]
+    public string? OntologyPath { get; init; }
+
+    [Option('a', "allow-partial-success", Required = false, HelpText = "Overrides partial-success exit policy.")]
+    public string? AllowPartialSuccess { get; init; }
+}

--- a/src/CodeLlmWiki.Cli/Config/IngestionCliConfig.cs
+++ b/src/CodeLlmWiki.Cli/Config/IngestionCliConfig.cs
@@ -1,0 +1,6 @@
+namespace CodeLlmWiki.Cli.Config;
+
+public sealed record IngestionCliConfig(string? OntologyPath, bool? AllowPartialSuccess)
+{
+    public static readonly IngestionCliConfig Empty = new(null, null);
+}

--- a/src/CodeLlmWiki.Cli/Program.cs
+++ b/src/CodeLlmWiki.Cli/Program.cs
@@ -1,0 +1,9 @@
+using CodeLlmWiki.Cli;
+using CodeLlmWiki.Ingestion;
+using CodeLlmWiki.Ontology;
+
+var runner = new IngestionRunner(new OntologyLoader(), new NoOpIngestionPipeline());
+var app = new CliApplication(runner);
+var exitCode = await app.RunAsync(args, CancellationToken.None);
+
+Environment.Exit(exitCode);

--- a/src/CodeLlmWiki.Contracts/CodeLlmWiki.Contracts.csproj
+++ b/src/CodeLlmWiki.Contracts/CodeLlmWiki.Contracts.csproj
@@ -1,0 +1,9 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net10.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+  </PropertyGroup>
+
+</Project>

--- a/src/CodeLlmWiki.Contracts/Graph/EntityNode.cs
+++ b/src/CodeLlmWiki.Contracts/Graph/EntityNode.cs
@@ -1,0 +1,5 @@
+using CodeLlmWiki.Contracts.Identity;
+
+namespace CodeLlmWiki.Contracts.Graph;
+
+public sealed record EntityNode(EntityId Id) : GraphNode;

--- a/src/CodeLlmWiki.Contracts/Graph/GraphNode.cs
+++ b/src/CodeLlmWiki.Contracts/Graph/GraphNode.cs
@@ -1,0 +1,3 @@
+namespace CodeLlmWiki.Contracts.Graph;
+
+public abstract record GraphNode;

--- a/src/CodeLlmWiki.Contracts/Graph/LiteralNode.cs
+++ b/src/CodeLlmWiki.Contracts/Graph/LiteralNode.cs
@@ -1,0 +1,3 @@
+namespace CodeLlmWiki.Contracts.Graph;
+
+public sealed record LiteralNode(object? Value, string? Datatype = null, string? Language = null) : GraphNode;

--- a/src/CodeLlmWiki.Contracts/Graph/PredicateId.cs
+++ b/src/CodeLlmWiki.Contracts/Graph/PredicateId.cs
@@ -1,0 +1,6 @@
+namespace CodeLlmWiki.Contracts.Graph;
+
+public readonly record struct PredicateId(string Value)
+{
+    public override string ToString() => Value;
+}

--- a/src/CodeLlmWiki.Contracts/Graph/SemanticTriple.cs
+++ b/src/CodeLlmWiki.Contracts/Graph/SemanticTriple.cs
@@ -1,0 +1,3 @@
+namespace CodeLlmWiki.Contracts.Graph;
+
+public sealed record SemanticTriple(GraphNode Subject, PredicateId Predicate, GraphNode Object);

--- a/src/CodeLlmWiki.Contracts/Identity/EntityId.cs
+++ b/src/CodeLlmWiki.Contracts/Identity/EntityId.cs
@@ -1,0 +1,6 @@
+namespace CodeLlmWiki.Contracts.Identity;
+
+public readonly record struct EntityId(string Value)
+{
+    public override string ToString() => Value;
+}

--- a/src/CodeLlmWiki.Contracts/Identity/EntityKey.cs
+++ b/src/CodeLlmWiki.Contracts/Identity/EntityKey.cs
@@ -1,0 +1,3 @@
+namespace CodeLlmWiki.Contracts.Identity;
+
+public sealed record EntityKey(string EntityType, string NaturalKey);

--- a/src/CodeLlmWiki.Contracts/Identity/IStableIdGenerator.cs
+++ b/src/CodeLlmWiki.Contracts/Identity/IStableIdGenerator.cs
@@ -1,0 +1,6 @@
+namespace CodeLlmWiki.Contracts.Identity;
+
+public interface IStableIdGenerator
+{
+    EntityId Create(EntityKey key);
+}

--- a/src/CodeLlmWiki.Contracts/Identity/StableIdGenerator.cs
+++ b/src/CodeLlmWiki.Contracts/Identity/StableIdGenerator.cs
@@ -1,0 +1,15 @@
+using System.Security.Cryptography;
+using System.Text;
+
+namespace CodeLlmWiki.Contracts.Identity;
+
+public sealed class StableIdGenerator : IStableIdGenerator
+{
+    public EntityId Create(EntityKey key)
+    {
+        var raw = $"{key.EntityType}:{key.NaturalKey}";
+        var bytes = SHA256.HashData(Encoding.UTF8.GetBytes(raw));
+        var id = Convert.ToHexString(bytes).ToLowerInvariant();
+        return new EntityId($"{key.EntityType}:{id}");
+    }
+}

--- a/src/CodeLlmWiki.Ingestion/CodeLlmWiki.Ingestion.csproj
+++ b/src/CodeLlmWiki.Ingestion/CodeLlmWiki.Ingestion.csproj
@@ -1,0 +1,14 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+  <ItemGroup>
+    <ProjectReference Include="..\CodeLlmWiki.Contracts\CodeLlmWiki.Contracts.csproj" />
+    <ProjectReference Include="..\CodeLlmWiki.Ontology\CodeLlmWiki.Ontology.csproj" />
+  </ItemGroup>
+
+  <PropertyGroup>
+    <TargetFramework>net10.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+  </PropertyGroup>
+
+</Project>

--- a/src/CodeLlmWiki.Ingestion/IIngestionPipeline.cs
+++ b/src/CodeLlmWiki.Ingestion/IIngestionPipeline.cs
@@ -1,0 +1,8 @@
+using CodeLlmWiki.Contracts.Graph;
+
+namespace CodeLlmWiki.Ingestion;
+
+public interface IIngestionPipeline
+{
+    Task<IReadOnlyList<SemanticTriple>> ExecuteAsync(IngestionExecutionContext context, CancellationToken cancellationToken);
+}

--- a/src/CodeLlmWiki.Ingestion/IIngestionRunner.cs
+++ b/src/CodeLlmWiki.Ingestion/IIngestionRunner.cs
@@ -1,0 +1,6 @@
+namespace CodeLlmWiki.Ingestion;
+
+public interface IIngestionRunner
+{
+    Task<IngestionRunResult> RunAsync(IngestionRunRequest request, CancellationToken cancellationToken);
+}

--- a/src/CodeLlmWiki.Ingestion/IngestionDiagnostic.cs
+++ b/src/CodeLlmWiki.Ingestion/IngestionDiagnostic.cs
@@ -1,0 +1,3 @@
+namespace CodeLlmWiki.Ingestion;
+
+public sealed record IngestionDiagnostic(string Code, string Message);

--- a/src/CodeLlmWiki.Ingestion/IngestionExecutionContext.cs
+++ b/src/CodeLlmWiki.Ingestion/IngestionExecutionContext.cs
@@ -1,0 +1,9 @@
+using CodeLlmWiki.Contracts.Identity;
+using CodeLlmWiki.Ontology.Model;
+
+namespace CodeLlmWiki.Ingestion;
+
+public sealed record IngestionExecutionContext(
+    string RepositoryPath,
+    EntityId RepositoryId,
+    OntologyDefinition Ontology);

--- a/src/CodeLlmWiki.Ingestion/IngestionRunRequest.cs
+++ b/src/CodeLlmWiki.Ingestion/IngestionRunRequest.cs
@@ -1,0 +1,7 @@
+namespace CodeLlmWiki.Ingestion;
+
+public sealed record IngestionRunRequest(
+    string RepositoryPath,
+    string? ConfigPath,
+    string OntologyPath,
+    bool AllowPartialSuccess);

--- a/src/CodeLlmWiki.Ingestion/IngestionRunResult.cs
+++ b/src/CodeLlmWiki.Ingestion/IngestionRunResult.cs
@@ -1,0 +1,6 @@
+namespace CodeLlmWiki.Ingestion;
+
+public sealed record IngestionRunResult(
+    IngestionRunStatus Status,
+    int ExitCode,
+    IReadOnlyList<IngestionDiagnostic> Diagnostics);

--- a/src/CodeLlmWiki.Ingestion/IngestionRunStatus.cs
+++ b/src/CodeLlmWiki.Ingestion/IngestionRunStatus.cs
@@ -1,0 +1,8 @@
+namespace CodeLlmWiki.Ingestion;
+
+public enum IngestionRunStatus
+{
+    Succeeded = 0,
+    SucceededWithDiagnostics = 1,
+    Failed = 2,
+}

--- a/src/CodeLlmWiki.Ingestion/IngestionRunner.cs
+++ b/src/CodeLlmWiki.Ingestion/IngestionRunner.cs
@@ -1,0 +1,53 @@
+using CodeLlmWiki.Contracts.Identity;
+using CodeLlmWiki.Ontology;
+
+namespace CodeLlmWiki.Ingestion;
+
+public sealed class IngestionRunner : IIngestionRunner
+{
+    private readonly IOntologyLoader _ontologyLoader;
+    private readonly IIngestionPipeline _pipeline;
+    private readonly IStableIdGenerator _stableIdGenerator;
+
+    public IngestionRunner(
+        IOntologyLoader ontologyLoader,
+        IIngestionPipeline pipeline,
+        IStableIdGenerator? stableIdGenerator = null)
+    {
+        _ontologyLoader = ontologyLoader;
+        _pipeline = pipeline;
+        _stableIdGenerator = stableIdGenerator ?? new StableIdGenerator();
+    }
+
+    public async Task<IngestionRunResult> RunAsync(IngestionRunRequest request, CancellationToken cancellationToken)
+    {
+        var ontology = await _ontologyLoader.LoadAsync(request.OntologyPath, cancellationToken);
+        if (!ontology.IsValid || ontology.Definition is null)
+        {
+            var errors = ontology.Issues.Select(x => new IngestionDiagnostic(x.Code, x.Message)).ToArray();
+            return new IngestionRunResult(IngestionRunStatus.Failed, 1, errors);
+        }
+
+        var fullRepositoryPath = Path.GetFullPath(request.RepositoryPath);
+        var repositoryId = _stableIdGenerator.Create(new EntityKey("repository", fullRepositoryPath));
+
+        var context = new IngestionExecutionContext(fullRepositoryPath, repositoryId, ontology.Definition);
+
+        await _pipeline.ExecuteAsync(context, cancellationToken);
+
+        var diagnostics = Array.Empty<IngestionDiagnostic>();
+        var status = diagnostics.Length == 0
+            ? IngestionRunStatus.Succeeded
+            : IngestionRunStatus.SucceededWithDiagnostics;
+
+        var exitCode = status switch
+        {
+            IngestionRunStatus.Succeeded => 0,
+            IngestionRunStatus.SucceededWithDiagnostics when request.AllowPartialSuccess => 0,
+            IngestionRunStatus.SucceededWithDiagnostics => 2,
+            _ => 1,
+        };
+
+        return new IngestionRunResult(status, exitCode, diagnostics);
+    }
+}

--- a/src/CodeLlmWiki.Ingestion/NoOpIngestionPipeline.cs
+++ b/src/CodeLlmWiki.Ingestion/NoOpIngestionPipeline.cs
@@ -1,0 +1,11 @@
+using CodeLlmWiki.Contracts.Graph;
+
+namespace CodeLlmWiki.Ingestion;
+
+public sealed class NoOpIngestionPipeline : IIngestionPipeline
+{
+    public Task<IReadOnlyList<SemanticTriple>> ExecuteAsync(IngestionExecutionContext context, CancellationToken cancellationToken)
+    {
+        return Task.FromResult<IReadOnlyList<SemanticTriple>>([]);
+    }
+}

--- a/src/CodeLlmWiki.Ontology/CodeLlmWiki.Ontology.csproj
+++ b/src/CodeLlmWiki.Ontology/CodeLlmWiki.Ontology.csproj
@@ -1,0 +1,17 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+  <ItemGroup>
+    <ProjectReference Include="..\CodeLlmWiki.Contracts\CodeLlmWiki.Contracts.csproj" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <PackageReference Include="YamlDotNet" Version="17.0.1" />
+  </ItemGroup>
+
+  <PropertyGroup>
+    <TargetFramework>net10.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+  </PropertyGroup>
+
+</Project>

--- a/src/CodeLlmWiki.Ontology/IOntologyLoader.cs
+++ b/src/CodeLlmWiki.Ontology/IOntologyLoader.cs
@@ -1,0 +1,8 @@
+using CodeLlmWiki.Ontology.Model;
+
+namespace CodeLlmWiki.Ontology;
+
+public interface IOntologyLoader
+{
+    Task<OntologyLoadResult> LoadAsync(string ontologyPath, CancellationToken cancellationToken);
+}

--- a/src/CodeLlmWiki.Ontology/Internal/OntologyDocumentDto.cs
+++ b/src/CodeLlmWiki.Ontology/Internal/OntologyDocumentDto.cs
@@ -1,0 +1,8 @@
+namespace CodeLlmWiki.Ontology.Internal;
+
+internal sealed class OntologyDocumentDto
+{
+    public string? Version { get; init; }
+
+    public List<OntologyPredicateDto>? Predicates { get; init; }
+}

--- a/src/CodeLlmWiki.Ontology/Internal/OntologyPredicateDto.cs
+++ b/src/CodeLlmWiki.Ontology/Internal/OntologyPredicateDto.cs
@@ -1,0 +1,6 @@
+namespace CodeLlmWiki.Ontology.Internal;
+
+internal sealed class OntologyPredicateDto
+{
+    public string? Id { get; init; }
+}

--- a/src/CodeLlmWiki.Ontology/Model/OntologyDefinition.cs
+++ b/src/CodeLlmWiki.Ontology/Model/OntologyDefinition.cs
@@ -1,0 +1,3 @@
+namespace CodeLlmWiki.Ontology.Model;
+
+public sealed record OntologyDefinition(string Version, IReadOnlyList<OntologyPredicate> Predicates);

--- a/src/CodeLlmWiki.Ontology/Model/OntologyLoadResult.cs
+++ b/src/CodeLlmWiki.Ontology/Model/OntologyLoadResult.cs
@@ -1,0 +1,6 @@
+namespace CodeLlmWiki.Ontology.Model;
+
+public sealed record OntologyLoadResult(OntologyDefinition? Definition, IReadOnlyList<OntologyValidationIssue> Issues)
+{
+    public bool IsValid => Definition is not null && Issues.Count == 0;
+}

--- a/src/CodeLlmWiki.Ontology/Model/OntologyPredicate.cs
+++ b/src/CodeLlmWiki.Ontology/Model/OntologyPredicate.cs
@@ -1,0 +1,3 @@
+namespace CodeLlmWiki.Ontology.Model;
+
+public sealed record OntologyPredicate(string Id);

--- a/src/CodeLlmWiki.Ontology/Model/OntologyValidationIssue.cs
+++ b/src/CodeLlmWiki.Ontology/Model/OntologyValidationIssue.cs
@@ -1,0 +1,3 @@
+namespace CodeLlmWiki.Ontology.Model;
+
+public sealed record OntologyValidationIssue(string Code, string Message);

--- a/src/CodeLlmWiki.Ontology/OntologyLoader.cs
+++ b/src/CodeLlmWiki.Ontology/OntologyLoader.cs
@@ -1,0 +1,72 @@
+using CodeLlmWiki.Ontology.Model;
+using CodeLlmWiki.Ontology.Internal;
+using YamlDotNet.Serialization;
+using YamlDotNet.Serialization.NamingConventions;
+
+namespace CodeLlmWiki.Ontology;
+
+public sealed class OntologyLoader : IOntologyLoader
+{
+    private readonly IDeserializer _deserializer;
+
+    public OntologyLoader()
+    {
+        _deserializer = new DeserializerBuilder()
+            .WithNamingConvention(CamelCaseNamingConvention.Instance)
+            .IgnoreUnmatchedProperties()
+            .Build();
+    }
+
+    public async Task<OntologyLoadResult> LoadAsync(string ontologyPath, CancellationToken cancellationToken)
+    {
+        var issues = new List<OntologyValidationIssue>();
+
+        if (string.IsNullOrWhiteSpace(ontologyPath))
+        {
+            issues.Add(new OntologyValidationIssue("ontology:path:missing", "Ontology path is required."));
+            return new OntologyLoadResult(null, issues);
+        }
+
+        if (!File.Exists(ontologyPath))
+        {
+            issues.Add(new OntologyValidationIssue("ontology:path:not-found", $"Ontology file '{ontologyPath}' does not exist."));
+            return new OntologyLoadResult(null, issues);
+        }
+
+        try
+        {
+            var yaml = await File.ReadAllTextAsync(ontologyPath, cancellationToken);
+            var dto = _deserializer.Deserialize<OntologyDocumentDto>(yaml) ?? new OntologyDocumentDto();
+
+            var predicates = (dto.Predicates ?? [])
+                .Select(x => new OntologyPredicate(x.Id?.Trim() ?? string.Empty))
+                .ToList();
+
+            var definition = new OntologyDefinition(dto.Version?.Trim() ?? string.Empty, predicates);
+            Validate(definition, issues);
+
+            return new OntologyLoadResult(issues.Count == 0 ? definition : null, issues);
+        }
+        catch (Exception ex)
+        {
+            issues.Add(new OntologyValidationIssue("ontology:parse:failed", ex.Message));
+            return new OntologyLoadResult(null, issues);
+        }
+    }
+
+    private static void Validate(OntologyDefinition definition, List<OntologyValidationIssue> issues)
+    {
+        if (string.IsNullOrWhiteSpace(definition.Version))
+        {
+            issues.Add(new OntologyValidationIssue("ontology:version:missing", "Ontology version is required."));
+        }
+
+        for (var i = 0; i < definition.Predicates.Count; i++)
+        {
+            if (string.IsNullOrWhiteSpace(definition.Predicates[i].Id))
+            {
+                issues.Add(new OntologyValidationIssue("ontology:predicate:id-missing", $"Predicate at index {i} has an empty id."));
+            }
+        }
+    }
+}

--- a/tests/CodeLlmWiki.Cli.Tests/CliApplicationTests.cs
+++ b/tests/CodeLlmWiki.Cli.Tests/CliApplicationTests.cs
@@ -1,0 +1,78 @@
+using CodeLlmWiki.Cli;
+using CodeLlmWiki.Ingestion;
+
+namespace CodeLlmWiki.Cli.Tests;
+
+public sealed class CliApplicationTests
+{
+    [Fact]
+    public async Task RunAsync_AppliesCommandLineOverrideOverConfigValue()
+    {
+        var configPath = WriteTempFile(
+            """
+            {
+              "ontologyPath": "./ontology/ontology.v1.yaml",
+              "allowPartialSuccess": false
+            }
+            """);
+
+        var runner = new CapturingRunner();
+        var app = new CliApplication(runner);
+
+        var exitCode = await app.RunAsync(
+            [
+                "ingest",
+                "--path", ".",
+                "--config", configPath,
+                "--allow-partial-success", "true",
+            ],
+            CancellationToken.None);
+
+        Assert.Equal(0, exitCode);
+        Assert.NotNull(runner.LastRequest);
+        Assert.True(runner.LastRequest!.AllowPartialSuccess);
+    }
+
+    [Fact]
+    public async Task RunAsync_ReturnsRunnerExitCodeDeterministically()
+    {
+        var runner = new CapturingRunner
+        {
+            NextResult = new IngestionRunResult(
+                IngestionRunStatus.SucceededWithDiagnostics,
+                2,
+                [new IngestionDiagnostic("warn:0001", "warning")]),
+        };
+
+        var app = new CliApplication(runner);
+
+        var first = await app.RunAsync(["ingest", "--path", "."], CancellationToken.None);
+        var second = await app.RunAsync(["ingest", "--path", "."], CancellationToken.None);
+
+        Assert.Equal(2, first);
+        Assert.Equal(2, second);
+    }
+
+    private static string WriteTempFile(string content)
+    {
+        var path = Path.Combine(Path.GetTempPath(), $"{Guid.NewGuid():N}.json");
+        File.WriteAllText(path, content);
+        return path;
+    }
+
+    private sealed class CapturingRunner : IIngestionRunner
+    {
+        public IngestionRunRequest? LastRequest { get; private set; }
+
+        public IngestionRunResult NextResult { get; set; } = new(
+            IngestionRunStatus.Succeeded,
+            0,
+            []);
+
+        public Task<IngestionRunResult> RunAsync(IngestionRunRequest request, CancellationToken cancellationToken)
+        {
+            LastRequest = request;
+            return Task.FromResult(NextResult);
+        }
+    }
+}

--- a/tests/CodeLlmWiki.Cli.Tests/CodeLlmWiki.Cli.Tests.csproj
+++ b/tests/CodeLlmWiki.Cli.Tests/CodeLlmWiki.Cli.Tests.csproj
@@ -1,0 +1,26 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net10.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <IsPackable>false</IsPackable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="coverlet.collector" Version="6.0.4" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.14.1" />
+    <PackageReference Include="xunit" Version="2.9.3" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="3.1.4" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <Using Include="Xunit" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\src\CodeLlmWiki.Cli\CodeLlmWiki.Cli.csproj" />
+    <ProjectReference Include="..\..\src\CodeLlmWiki.Ingestion\CodeLlmWiki.Ingestion.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/tests/CodeLlmWiki.Ingestion.Tests/CodeLlmWiki.Ingestion.Tests.csproj
+++ b/tests/CodeLlmWiki.Ingestion.Tests/CodeLlmWiki.Ingestion.Tests.csproj
@@ -1,0 +1,26 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net10.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <IsPackable>false</IsPackable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="coverlet.collector" Version="6.0.4" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.14.1" />
+    <PackageReference Include="xunit" Version="2.9.3" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="3.1.4" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <Using Include="Xunit" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\src\CodeLlmWiki.Ingestion\CodeLlmWiki.Ingestion.csproj" />
+    <ProjectReference Include="..\..\src\CodeLlmWiki.Contracts\CodeLlmWiki.Contracts.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/tests/CodeLlmWiki.Ingestion.Tests/ContractsUsageTests.cs
+++ b/tests/CodeLlmWiki.Ingestion.Tests/ContractsUsageTests.cs
@@ -1,0 +1,33 @@
+using CodeLlmWiki.Contracts.Graph;
+using CodeLlmWiki.Contracts.Identity;
+
+namespace CodeLlmWiki.Ingestion.Tests;
+
+public sealed class ContractsUsageTests
+{
+    [Fact]
+    public void StableIdGenerator_IsDeterministicForSameNaturalKey()
+    {
+        var generator = new StableIdGenerator();
+        var key = new EntityKey("project", "src/MyProject/MyProject.csproj");
+
+        var first = generator.Create(key);
+        var second = generator.Create(key);
+
+        Assert.Equal(first, second);
+    }
+
+    [Fact]
+    public void SemanticTriple_SupportsEntityAndLiteralNodes()
+    {
+        var subject = new EntityNode(new EntityId("ent:class-a"));
+        var predicate = new PredicateId("core:contains");
+        var obj = new LiteralNode("ClassA");
+
+        var triple = new SemanticTriple(subject, predicate, obj);
+
+        Assert.Equal(subject, triple.Subject);
+        Assert.Equal(predicate, triple.Predicate);
+        Assert.Equal(obj, triple.Object);
+    }
+}

--- a/tests/CodeLlmWiki.Ingestion.Tests/IngestionRunnerTests.cs
+++ b/tests/CodeLlmWiki.Ingestion.Tests/IngestionRunnerTests.cs
@@ -1,0 +1,83 @@
+using CodeLlmWiki.Contracts.Graph;
+using CodeLlmWiki.Ingestion;
+using CodeLlmWiki.Ontology;
+
+namespace CodeLlmWiki.Ingestion.Tests;
+
+public sealed class IngestionRunnerTests
+{
+    [Fact]
+    public async Task RunAsync_ReturnsFailureAndDoesNotExecutePipeline_WhenOntologyIsInvalid()
+    {
+        var pipeline = new CapturingPipeline();
+        var runner = new IngestionRunner(new OntologyLoader(), pipeline);
+
+        var ontologyPath = WriteTempFile(
+            """
+            version: ""
+            predicates: []
+            """);
+
+        var request = new IngestionRunRequest(
+            RepositoryPath: ".",
+            ConfigPath: null,
+            OntologyPath: ontologyPath,
+            AllowPartialSuccess: false);
+
+        var result = await runner.RunAsync(request, CancellationToken.None);
+
+        Assert.Equal(IngestionRunStatus.Failed, result.Status);
+        Assert.False(pipeline.WasCalled);
+        Assert.NotEmpty(result.Diagnostics);
+    }
+
+    [Fact]
+    public async Task RunAsync_ReturnsSuccess_WhenOntologyIsValidAndPipelineCompletes()
+    {
+        var pipeline = new CapturingPipeline();
+        var runner = new IngestionRunner(new OntologyLoader(), pipeline);
+
+        var ontologyPath = WriteTempFile(
+            """
+            version: "1.0.0"
+            predicates:
+              - id: "core:contains"
+            """);
+
+        var request = new IngestionRunRequest(
+            RepositoryPath: ".",
+            ConfigPath: null,
+            OntologyPath: ontologyPath,
+            AllowPartialSuccess: false);
+
+        var result = await runner.RunAsync(request, CancellationToken.None);
+
+        Assert.Equal(IngestionRunStatus.Succeeded, result.Status);
+        Assert.True(pipeline.WasCalled);
+        Assert.Equal(0, result.ExitCode);
+    }
+
+    private static string WriteTempFile(string content)
+    {
+        var path = Path.Combine(Path.GetTempPath(), $"{Guid.NewGuid():N}.yaml");
+        File.WriteAllText(path, content);
+        return path;
+    }
+
+    private sealed class CapturingPipeline : IIngestionPipeline
+    {
+        public bool WasCalled { get; private set; }
+
+        public Task<IReadOnlyList<SemanticTriple>> ExecuteAsync(IngestionExecutionContext context, CancellationToken cancellationToken)
+        {
+            WasCalled = true;
+
+            var triple = new SemanticTriple(
+                new EntityNode(context.RepositoryId),
+                new PredicateId("core:contains"),
+                new LiteralNode("noop"));
+
+            return Task.FromResult<IReadOnlyList<SemanticTriple>>(new[] { triple });
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- scaffolds .NET 10 solution/modules for CLI, contracts, ontology, ingestion, and tests
- implements issue #2 vertical slice: runnable `ingest` CLI, ontology load/validate gate, stable identity + triple contracts, no-op pipeline
- adds ADR set for ontology, identity, query boundary, front matter policy, and exit semantics
- adds PRD + phase plan docs under `plans/`

## Validation
- `dotnet build CodeLlmWiki.slnx -v minimal`
- `dotnet test CodeLlmWiki.slnx -v minimal`
- `dotnet run --project src/CodeLlmWiki.Cli -- ingest --path .`

Closes #2
