### PR TITLE
Phase 2: Repository and Solution/Project Vertical Slice (#3)

### DIFF
--- a/CodeLlmWiki.slnx
+++ b/CodeLlmWiki.slnx
@@ -4,6 +4,8 @@
     <Project Path="src/CodeLlmWiki.Contracts/CodeLlmWiki.Contracts.csproj" />
     <Project Path="src/CodeLlmWiki.Ingestion/CodeLlmWiki.Ingestion.csproj" />
     <Project Path="src/CodeLlmWiki.Ontology/CodeLlmWiki.Ontology.csproj" />
+    <Project Path="src/CodeLlmWiki.Query/CodeLlmWiki.Query.csproj" />
+    <Project Path="src/CodeLlmWiki.Wiki/CodeLlmWiki.Wiki.csproj" />
   </Folder>
   <Folder Name="/tests/">
     <Project Path="tests/CodeLlmWiki.Cli.Tests/CodeLlmWiki.Cli.Tests.csproj" />

--- a/ontology/ontology.v1.yaml
+++ b/ontology/ontology.v1.yaml
@@ -2,3 +2,7 @@ version: "1.0.0"
 predicates:
   - id: "core:contains"
   - id: "core:references"
+  - id: "core:entityType"
+  - id: "core:hasName"
+  - id: "core:hasPath"
+  - id: "core:discoveryMethod"

--- a/src/CodeLlmWiki.Cli/Program.cs
+++ b/src/CodeLlmWiki.Cli/Program.cs
@@ -1,8 +1,12 @@
 using CodeLlmWiki.Cli;
+using CodeLlmWiki.Contracts.Identity;
 using CodeLlmWiki.Ingestion;
+using CodeLlmWiki.Ingestion.ProjectStructure;
 using CodeLlmWiki.Ontology;
 
-var runner = new IngestionRunner(new OntologyLoader(), new NoOpIngestionPipeline());
+var analyzer = new ProjectStructureAnalyzer(new StableIdGenerator());
+var pipeline = new ProjectStructureIngestionPipeline(analyzer);
+var runner = new IngestionRunner(new OntologyLoader(), pipeline);
 var app = new CliApplication(runner);
 var exitCode = await app.RunAsync(args, CancellationToken.None);
 

--- a/src/CodeLlmWiki.Contracts/Graph/CorePredicates.cs
+++ b/src/CodeLlmWiki.Contracts/Graph/CorePredicates.cs
@@ -1,0 +1,10 @@
+namespace CodeLlmWiki.Contracts.Graph;
+
+public static class CorePredicates
+{
+    public static readonly PredicateId Contains = new("core:contains");
+    public static readonly PredicateId EntityType = new("core:entityType");
+    public static readonly PredicateId HasName = new("core:hasName");
+    public static readonly PredicateId HasPath = new("core:hasPath");
+    public static readonly PredicateId DiscoveryMethod = new("core:discoveryMethod");
+}

--- a/src/CodeLlmWiki.Ingestion/CodeLlmWiki.Ingestion.csproj
+++ b/src/CodeLlmWiki.Ingestion/CodeLlmWiki.Ingestion.csproj
@@ -3,6 +3,12 @@
   <ItemGroup>
     <ProjectReference Include="..\CodeLlmWiki.Contracts\CodeLlmWiki.Contracts.csproj" />
     <ProjectReference Include="..\CodeLlmWiki.Ontology\CodeLlmWiki.Ontology.csproj" />
+    <ProjectReference Include="..\CodeLlmWiki.Query\CodeLlmWiki.Query.csproj" />
+    <ProjectReference Include="..\CodeLlmWiki.Wiki\CodeLlmWiki.Wiki.csproj" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.Build" Version="18.4.0" />
   </ItemGroup>
 
   <PropertyGroup>

--- a/src/CodeLlmWiki.Ingestion/IIngestionPipeline.cs
+++ b/src/CodeLlmWiki.Ingestion/IIngestionPipeline.cs
@@ -1,8 +1,6 @@
-using CodeLlmWiki.Contracts.Graph;
-
 namespace CodeLlmWiki.Ingestion;
 
 public interface IIngestionPipeline
 {
-    Task<IReadOnlyList<SemanticTriple>> ExecuteAsync(IngestionExecutionContext context, CancellationToken cancellationToken);
+    Task<IngestionPipelineResult> ExecuteAsync(IngestionExecutionContext context, CancellationToken cancellationToken);
 }

--- a/src/CodeLlmWiki.Ingestion/IngestionPipelineResult.cs
+++ b/src/CodeLlmWiki.Ingestion/IngestionPipelineResult.cs
@@ -1,0 +1,7 @@
+using CodeLlmWiki.Contracts.Graph;
+
+namespace CodeLlmWiki.Ingestion;
+
+public sealed record IngestionPipelineResult(
+    IReadOnlyList<SemanticTriple> Triples,
+    IReadOnlyList<IngestionDiagnostic> Diagnostics);

--- a/src/CodeLlmWiki.Ingestion/IngestionRunResult.cs
+++ b/src/CodeLlmWiki.Ingestion/IngestionRunResult.cs
@@ -1,6 +1,9 @@
+using CodeLlmWiki.Contracts.Graph;
+
 namespace CodeLlmWiki.Ingestion;
 
 public sealed record IngestionRunResult(
     IngestionRunStatus Status,
     int ExitCode,
-    IReadOnlyList<IngestionDiagnostic> Diagnostics);
+    IReadOnlyList<IngestionDiagnostic> Diagnostics,
+    IReadOnlyList<SemanticTriple> Triples);

--- a/src/CodeLlmWiki.Ingestion/IngestionRunner.cs
+++ b/src/CodeLlmWiki.Ingestion/IngestionRunner.cs
@@ -25,7 +25,7 @@ public sealed class IngestionRunner : IIngestionRunner
         if (!ontology.IsValid || ontology.Definition is null)
         {
             var errors = ontology.Issues.Select(x => new IngestionDiagnostic(x.Code, x.Message)).ToArray();
-            return new IngestionRunResult(IngestionRunStatus.Failed, 1, errors);
+            return new IngestionRunResult(IngestionRunStatus.Failed, 1, errors, []);
         }
 
         var fullRepositoryPath = Path.GetFullPath(request.RepositoryPath);
@@ -33,9 +33,8 @@ public sealed class IngestionRunner : IIngestionRunner
 
         var context = new IngestionExecutionContext(fullRepositoryPath, repositoryId, ontology.Definition);
 
-        await _pipeline.ExecuteAsync(context, cancellationToken);
-
-        var diagnostics = Array.Empty<IngestionDiagnostic>();
+        var pipelineResult = await _pipeline.ExecuteAsync(context, cancellationToken);
+        var diagnostics = pipelineResult.Diagnostics.ToArray();
         var status = diagnostics.Length == 0
             ? IngestionRunStatus.Succeeded
             : IngestionRunStatus.SucceededWithDiagnostics;
@@ -48,6 +47,6 @@ public sealed class IngestionRunner : IIngestionRunner
             _ => 1,
         };
 
-        return new IngestionRunResult(status, exitCode, diagnostics);
+        return new IngestionRunResult(status, exitCode, diagnostics, pipelineResult.Triples);
     }
 }

--- a/src/CodeLlmWiki.Ingestion/NoOpIngestionPipeline.cs
+++ b/src/CodeLlmWiki.Ingestion/NoOpIngestionPipeline.cs
@@ -1,11 +1,9 @@
-using CodeLlmWiki.Contracts.Graph;
-
 namespace CodeLlmWiki.Ingestion;
 
 public sealed class NoOpIngestionPipeline : IIngestionPipeline
 {
-    public Task<IReadOnlyList<SemanticTriple>> ExecuteAsync(IngestionExecutionContext context, CancellationToken cancellationToken)
+    public Task<IngestionPipelineResult> ExecuteAsync(IngestionExecutionContext context, CancellationToken cancellationToken)
     {
-        return Task.FromResult<IReadOnlyList<SemanticTriple>>([]);
+        return Task.FromResult(new IngestionPipelineResult([], []));
     }
 }

--- a/src/CodeLlmWiki.Ingestion/ProjectStructure/IProjectStructureAnalyzer.cs
+++ b/src/CodeLlmWiki.Ingestion/ProjectStructure/IProjectStructureAnalyzer.cs
@@ -1,0 +1,6 @@
+namespace CodeLlmWiki.Ingestion.ProjectStructure;
+
+public interface IProjectStructureAnalyzer
+{
+    Task<ProjectStructureAnalysisResult> AnalyzeAsync(string repositoryPath, CancellationToken cancellationToken);
+}

--- a/src/CodeLlmWiki.Ingestion/ProjectStructure/ProjectStructureAnalysisResult.cs
+++ b/src/CodeLlmWiki.Ingestion/ProjectStructure/ProjectStructureAnalysisResult.cs
@@ -1,0 +1,9 @@
+using CodeLlmWiki.Contracts.Graph;
+using CodeLlmWiki.Contracts.Identity;
+
+namespace CodeLlmWiki.Ingestion.ProjectStructure;
+
+public sealed record ProjectStructureAnalysisResult(
+    EntityId RepositoryId,
+    IReadOnlyList<SemanticTriple> Triples,
+    IReadOnlyList<IngestionDiagnostic> Diagnostics);

--- a/src/CodeLlmWiki.Ingestion/ProjectStructure/ProjectStructureAnalyzer.cs
+++ b/src/CodeLlmWiki.Ingestion/ProjectStructure/ProjectStructureAnalyzer.cs
@@ -1,0 +1,235 @@
+using System.Xml.Linq;
+using CodeLlmWiki.Contracts.Graph;
+using CodeLlmWiki.Contracts.Identity;
+using Microsoft.Build.Construction;
+using Microsoft.Build.Evaluation;
+
+namespace CodeLlmWiki.Ingestion.ProjectStructure;
+
+public sealed class ProjectStructureAnalyzer : IProjectStructureAnalyzer
+{
+    private readonly IStableIdGenerator _stableIdGenerator;
+
+    public ProjectStructureAnalyzer(IStableIdGenerator stableIdGenerator)
+    {
+        _stableIdGenerator = stableIdGenerator;
+    }
+
+    public Task<ProjectStructureAnalysisResult> AnalyzeAsync(string repositoryPath, CancellationToken cancellationToken)
+    {
+        var triples = new List<SemanticTriple>();
+        var diagnostics = new List<IngestionDiagnostic>();
+
+        var fullRepositoryPath = Path.GetFullPath(repositoryPath);
+        if (!Directory.Exists(fullRepositoryPath))
+        {
+            diagnostics.Add(new IngestionDiagnostic("repository:path:not-found", $"Repository path '{fullRepositoryPath}' does not exist."));
+            return Task.FromResult(new ProjectStructureAnalysisResult(default, triples, diagnostics));
+        }
+
+        var repositoryId = _stableIdGenerator.Create(new EntityKey("repository", fullRepositoryPath));
+        AddEntityTriples(triples, repositoryId, "repository", Path.GetFileName(fullRepositoryPath), ".");
+
+        var solutions = DiscoverSolutions(fullRepositoryPath, diagnostics);
+        var solutionProjectMap = new Dictionary<string, HashSet<string>>(StringComparer.OrdinalIgnoreCase);
+
+        foreach (var solutionPath in solutions)
+        {
+            var relativeSolutionPath = ToRelativePath(fullRepositoryPath, solutionPath);
+            var solutionId = _stableIdGenerator.Create(new EntityKey("solution", relativeSolutionPath));
+            AddEntityTriples(triples, solutionId, "solution", Path.GetFileNameWithoutExtension(solutionPath), relativeSolutionPath);
+            triples.Add(new SemanticTriple(new EntityNode(repositoryId), CorePredicates.Contains, new EntityNode(solutionId)));
+
+            var discoveredProjects = DiscoverProjectsFromSolution(solutionPath, diagnostics);
+            solutionProjectMap[solutionPath] = discoveredProjects;
+        }
+
+        var allProjectPaths = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+        foreach (var project in Directory.EnumerateFiles(fullRepositoryPath, "*.csproj", SearchOption.AllDirectories))
+        {
+            allProjectPaths.Add(Path.GetFullPath(project));
+        }
+
+        foreach (var solutionProjects in solutionProjectMap.Values)
+        {
+            foreach (var projectPath in solutionProjects)
+            {
+                allProjectPaths.Add(projectPath);
+            }
+        }
+
+        var orderedProjects = allProjectPaths
+            .OrderBy(path => ToRelativePath(fullRepositoryPath, path), StringComparer.Ordinal)
+            .ToArray();
+
+        var projectIdByPath = new Dictionary<string, EntityId>(StringComparer.OrdinalIgnoreCase);
+
+        foreach (var projectPath in orderedProjects)
+        {
+            var relativeProjectPath = ToRelativePath(fullRepositoryPath, projectPath);
+            var projectId = _stableIdGenerator.Create(new EntityKey("project", relativeProjectPath));
+            projectIdByPath[projectPath] = projectId;
+
+            var discovery = DiscoverProjectMetadata(projectPath, diagnostics);
+            AddEntityTriples(triples, projectId, "project", discovery.Name, relativeProjectPath);
+            triples.Add(new SemanticTriple(new EntityNode(projectId), CorePredicates.DiscoveryMethod, new LiteralNode(discovery.Method)));
+            triples.Add(new SemanticTriple(new EntityNode(repositoryId), CorePredicates.Contains, new EntityNode(projectId)));
+        }
+
+        foreach (var pair in solutionProjectMap.OrderBy(x => ToRelativePath(fullRepositoryPath, x.Key), StringComparer.Ordinal))
+        {
+            var relativeSolutionPath = ToRelativePath(fullRepositoryPath, pair.Key);
+            var solutionId = _stableIdGenerator.Create(new EntityKey("solution", relativeSolutionPath));
+
+            foreach (var projectPath in pair.Value.OrderBy(x => ToRelativePath(fullRepositoryPath, x), StringComparer.Ordinal))
+            {
+                if (projectIdByPath.TryGetValue(projectPath, out var projectId))
+                {
+                    triples.Add(new SemanticTriple(new EntityNode(solutionId), CorePredicates.Contains, new EntityNode(projectId)));
+                }
+            }
+        }
+
+        return Task.FromResult(new ProjectStructureAnalysisResult(repositoryId, triples, diagnostics));
+    }
+
+    private static void AddEntityTriples(
+        List<SemanticTriple> triples,
+        EntityId entityId,
+        string entityType,
+        string name,
+        string path)
+    {
+        var subject = new EntityNode(entityId);
+        triples.Add(new SemanticTriple(subject, CorePredicates.EntityType, new LiteralNode(entityType)));
+        triples.Add(new SemanticTriple(subject, CorePredicates.HasName, new LiteralNode(name)));
+        triples.Add(new SemanticTriple(subject, CorePredicates.HasPath, new LiteralNode(path)));
+    }
+
+    private static IReadOnlyList<string> DiscoverSolutions(string repositoryPath, List<IngestionDiagnostic> diagnostics)
+    {
+        var solutions = Directory.EnumerateFiles(repositoryPath, "*.sln", SearchOption.AllDirectories)
+            .Concat(Directory.EnumerateFiles(repositoryPath, "*.slnx", SearchOption.AllDirectories))
+            .Select(Path.GetFullPath)
+            .Distinct(StringComparer.OrdinalIgnoreCase)
+            .OrderBy(x => x, StringComparer.Ordinal)
+            .ToArray();
+
+        if (solutions.Length == 0)
+        {
+            diagnostics.Add(new IngestionDiagnostic("solution:not-found", "No solution files were found; continuing with repository project discovery."));
+        }
+
+        return solutions;
+    }
+
+    private static HashSet<string> DiscoverProjectsFromSolution(string solutionPath, List<IngestionDiagnostic> diagnostics)
+    {
+        return Path.GetExtension(solutionPath).Equals(".slnx", StringComparison.OrdinalIgnoreCase)
+            ? DiscoverProjectsFromSlnx(solutionPath, diagnostics)
+            : DiscoverProjectsFromSln(solutionPath, diagnostics);
+    }
+
+    private static HashSet<string> DiscoverProjectsFromSlnx(string slnxPath, List<IngestionDiagnostic> diagnostics)
+    {
+        var projects = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+        try
+        {
+            var document = XDocument.Load(slnxPath);
+            var root = document.Root;
+            if (root is null)
+            {
+                return projects;
+            }
+
+            foreach (var project in root.Elements("Project"))
+            {
+                var path = project.Attribute("Path")?.Value;
+                if (string.IsNullOrWhiteSpace(path))
+                {
+                    continue;
+                }
+
+                var fullPath = Path.GetFullPath(Path.Combine(Path.GetDirectoryName(slnxPath)!, path));
+                projects.Add(fullPath);
+            }
+        }
+        catch (Exception ex)
+        {
+            diagnostics.Add(new IngestionDiagnostic("solution:parse:failed", $"Failed to parse slnx '{slnxPath}': {ex.Message}"));
+        }
+
+        return projects;
+    }
+
+    private static HashSet<string> DiscoverProjectsFromSln(string slnPath, List<IngestionDiagnostic> diagnostics)
+    {
+        var projects = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+        try
+        {
+            var solution = SolutionFile.Parse(slnPath);
+            foreach (var project in solution.ProjectsInOrder)
+            {
+                if (!project.RelativePath.EndsWith(".csproj", StringComparison.OrdinalIgnoreCase))
+                {
+                    continue;
+                }
+
+                var fullPath = Path.GetFullPath(Path.Combine(Path.GetDirectoryName(slnPath)!, project.RelativePath));
+                projects.Add(fullPath);
+            }
+        }
+        catch (Exception ex)
+        {
+            diagnostics.Add(new IngestionDiagnostic("solution:parse:failed", $"Failed to parse sln '{slnPath}': {ex.Message}"));
+        }
+
+        return projects;
+    }
+
+    private static ProjectDiscoveryResult DiscoverProjectMetadata(string projectPath, List<IngestionDiagnostic> diagnostics)
+    {
+        diagnostics.Add(new IngestionDiagnostic("project:discovery:msbuild", $"Attempting MSBuild evaluation for '{projectPath}'."));
+
+        try
+        {
+            using var projectCollection = new ProjectCollection();
+            var project = projectCollection.LoadProject(projectPath);
+            var name = project.GetPropertyValue("AssemblyName");
+            if (string.IsNullOrWhiteSpace(name))
+            {
+                name = Path.GetFileNameWithoutExtension(projectPath);
+            }
+
+            return new ProjectDiscoveryResult(name, "msbuild");
+        }
+        catch (Exception ex)
+        {
+            var fallbackName = Path.GetFileNameWithoutExtension(projectPath);
+            try
+            {
+                var document = XDocument.Load(projectPath);
+                var assemblyName = document.Descendants("AssemblyName").FirstOrDefault()?.Value;
+                if (!string.IsNullOrWhiteSpace(assemblyName))
+                {
+                    fallbackName = assemblyName;
+                }
+            }
+            catch
+            {
+                // Keep filename fallback only.
+            }
+
+            diagnostics.Add(new IngestionDiagnostic("project:discovery:fallback", $"Project '{projectPath}' fell back from MSBuild discovery: {ex.Message}"));
+            return new ProjectDiscoveryResult(fallbackName, "fallback");
+        }
+    }
+
+    private static string ToRelativePath(string root, string path)
+    {
+        var relative = Path.GetRelativePath(root, path).Replace('\\', '/');
+        return relative;
+    }
+
+    private sealed record ProjectDiscoveryResult(string Name, string Method);
+}

--- a/src/CodeLlmWiki.Ingestion/ProjectStructure/ProjectStructureIngestionPipeline.cs
+++ b/src/CodeLlmWiki.Ingestion/ProjectStructure/ProjectStructureIngestionPipeline.cs
@@ -1,0 +1,17 @@
+namespace CodeLlmWiki.Ingestion.ProjectStructure;
+
+public sealed class ProjectStructureIngestionPipeline : IIngestionPipeline
+{
+    private readonly IProjectStructureAnalyzer _analyzer;
+
+    public ProjectStructureIngestionPipeline(IProjectStructureAnalyzer analyzer)
+    {
+        _analyzer = analyzer;
+    }
+
+    public async Task<IngestionPipelineResult> ExecuteAsync(IngestionExecutionContext context, CancellationToken cancellationToken)
+    {
+        var result = await _analyzer.AnalyzeAsync(context.RepositoryPath, cancellationToken);
+        return new IngestionPipelineResult(result.Triples, result.Diagnostics);
+    }
+}

--- a/src/CodeLlmWiki.Query/CodeLlmWiki.Query.csproj
+++ b/src/CodeLlmWiki.Query/CodeLlmWiki.Query.csproj
@@ -1,0 +1,13 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+  <ItemGroup>
+    <ProjectReference Include="..\CodeLlmWiki.Contracts\CodeLlmWiki.Contracts.csproj" />
+  </ItemGroup>
+
+  <PropertyGroup>
+    <TargetFramework>net10.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+  </PropertyGroup>
+
+</Project>

--- a/src/CodeLlmWiki.Query/ProjectStructure/IProjectStructureQueryService.cs
+++ b/src/CodeLlmWiki.Query/ProjectStructure/IProjectStructureQueryService.cs
@@ -1,0 +1,8 @@
+using CodeLlmWiki.Contracts.Identity;
+
+namespace CodeLlmWiki.Query.ProjectStructure;
+
+public interface IProjectStructureQueryService
+{
+    ProjectStructureWikiModel GetModel(EntityId repositoryId);
+}

--- a/src/CodeLlmWiki.Query/ProjectStructure/ProjectNode.cs
+++ b/src/CodeLlmWiki.Query/ProjectStructure/ProjectNode.cs
@@ -1,0 +1,5 @@
+using CodeLlmWiki.Contracts.Identity;
+
+namespace CodeLlmWiki.Query.ProjectStructure;
+
+public sealed record ProjectNode(EntityId Id, string Name, string Path, string DiscoveryMethod);

--- a/src/CodeLlmWiki.Query/ProjectStructure/ProjectStructureQueryService.cs
+++ b/src/CodeLlmWiki.Query/ProjectStructure/ProjectStructureQueryService.cs
@@ -1,0 +1,150 @@
+using CodeLlmWiki.Contracts.Graph;
+using CodeLlmWiki.Contracts.Identity;
+
+namespace CodeLlmWiki.Query.ProjectStructure;
+
+public sealed class ProjectStructureQueryService : IProjectStructureQueryService
+{
+    private readonly IReadOnlyList<SemanticTriple> _triples;
+
+    public ProjectStructureQueryService(IReadOnlyList<SemanticTriple> triples)
+    {
+        _triples = triples;
+    }
+
+    public ProjectStructureWikiModel GetModel(EntityId repositoryId)
+    {
+        var metadataById = BuildEntityMetadata(_triples);
+        var contains = BuildContainsEdges(_triples);
+
+        if (!metadataById.TryGetValue(repositoryId, out var repoMeta) || !repoMeta.IsType("repository"))
+        {
+            throw new InvalidOperationException($"Repository '{repositoryId}' was not found in graph triples.");
+        }
+
+        var solutionIds = contains
+            .Where(x => x.Subject == repositoryId)
+            .Select(x => x.Object)
+            .Where(id => metadataById.TryGetValue(id, out var meta) && meta.IsType("solution"))
+            .Distinct()
+            .OrderBy(id => metadataById[id].Path, StringComparer.Ordinal)
+            .ToArray();
+
+        var solutions = solutionIds
+            .Select(solutionId =>
+            {
+                var meta = metadataById[solutionId];
+                var projectIds = contains
+                    .Where(x => x.Subject == solutionId)
+                    .Select(x => x.Object)
+                    .Where(id => metadataById.TryGetValue(id, out var pMeta) && pMeta.IsType("project"))
+                    .Distinct()
+                    .OrderBy(id => metadataById[id].Path, StringComparer.Ordinal)
+                    .ToArray();
+
+                return new SolutionNode(solutionId, meta.Name, meta.Path, projectIds);
+            })
+            .ToArray();
+
+        var projectIds = contains
+            .Where(x => x.Subject == repositoryId)
+            .Select(x => x.Object)
+            .Where(id => metadataById.TryGetValue(id, out var meta) && meta.IsType("project"))
+            .Concat(solutions.SelectMany(x => x.ProjectIds))
+            .Distinct()
+            .OrderBy(id => metadataById[id].Path, StringComparer.Ordinal)
+            .ToArray();
+
+        var projects = projectIds
+            .Select(projectId =>
+            {
+                var meta = metadataById[projectId];
+                return new ProjectNode(projectId, meta.Name, meta.Path, meta.DiscoveryMethod);
+            })
+            .ToArray();
+
+        var repository = new RepositoryNode(repositoryId, repoMeta.Name, repoMeta.Path);
+        return new ProjectStructureWikiModel(repository, solutions, projects);
+    }
+
+    private static Dictionary<EntityId, EntityMetadata> BuildEntityMetadata(IReadOnlyList<SemanticTriple> triples)
+    {
+        var byId = new Dictionary<EntityId, EntityMetadata>();
+
+        foreach (var triple in triples)
+        {
+            if (triple.Subject is not EntityNode subject)
+            {
+                continue;
+            }
+
+            if (triple.Object is not LiteralNode literal)
+            {
+                continue;
+            }
+
+            if (!byId.TryGetValue(subject.Id, out var meta))
+            {
+                meta = new EntityMetadata(subject.Id);
+                byId[subject.Id] = meta;
+            }
+
+            var value = literal.Value?.ToString() ?? string.Empty;
+
+            if (triple.Predicate == CorePredicates.EntityType)
+            {
+                meta.EntityType = value;
+            }
+            else if (triple.Predicate == CorePredicates.HasName)
+            {
+                meta.Name = value;
+            }
+            else if (triple.Predicate == CorePredicates.HasPath)
+            {
+                meta.Path = value;
+            }
+            else if (triple.Predicate == CorePredicates.DiscoveryMethod)
+            {
+                meta.DiscoveryMethod = value;
+            }
+        }
+
+        return byId;
+    }
+
+    private static IReadOnlyList<ContainsEdge> BuildContainsEdges(IReadOnlyList<SemanticTriple> triples)
+    {
+        return triples
+            .Where(x => x.Predicate == CorePredicates.Contains)
+            .Where(x => x.Subject is EntityNode && x.Object is EntityNode)
+            .Select(x => new ContainsEdge(((EntityNode)x.Subject).Id, ((EntityNode)x.Object).Id))
+            .Distinct()
+            .ToArray();
+    }
+
+    private sealed class EntityMetadata
+    {
+        public EntityMetadata(EntityId id)
+        {
+            Id = id;
+            Name = id.Value;
+            Path = id.Value;
+            DiscoveryMethod = string.Empty;
+            EntityType = string.Empty;
+        }
+
+        public EntityId Id { get; }
+
+        public string EntityType { get; set; }
+
+        public string Name { get; set; }
+
+        public string Path { get; set; }
+
+        public string DiscoveryMethod { get; set; }
+
+        public bool IsType(string entityType) => EntityType.Equals(entityType, StringComparison.OrdinalIgnoreCase);
+    }
+
+    private sealed record ContainsEdge(EntityId Subject, EntityId Object);
+}

--- a/src/CodeLlmWiki.Query/ProjectStructure/ProjectStructureWikiModel.cs
+++ b/src/CodeLlmWiki.Query/ProjectStructure/ProjectStructureWikiModel.cs
@@ -1,0 +1,6 @@
+namespace CodeLlmWiki.Query.ProjectStructure;
+
+public sealed record ProjectStructureWikiModel(
+    RepositoryNode Repository,
+    IReadOnlyList<SolutionNode> Solutions,
+    IReadOnlyList<ProjectNode> Projects);

--- a/src/CodeLlmWiki.Query/ProjectStructure/RepositoryNode.cs
+++ b/src/CodeLlmWiki.Query/ProjectStructure/RepositoryNode.cs
@@ -1,0 +1,5 @@
+using CodeLlmWiki.Contracts.Identity;
+
+namespace CodeLlmWiki.Query.ProjectStructure;
+
+public sealed record RepositoryNode(EntityId Id, string Name, string Path);

--- a/src/CodeLlmWiki.Query/ProjectStructure/SolutionNode.cs
+++ b/src/CodeLlmWiki.Query/ProjectStructure/SolutionNode.cs
@@ -1,0 +1,5 @@
+using CodeLlmWiki.Contracts.Identity;
+
+namespace CodeLlmWiki.Query.ProjectStructure;
+
+public sealed record SolutionNode(EntityId Id, string Name, string Path, IReadOnlyList<EntityId> ProjectIds);

--- a/src/CodeLlmWiki.Wiki/CodeLlmWiki.Wiki.csproj
+++ b/src/CodeLlmWiki.Wiki/CodeLlmWiki.Wiki.csproj
@@ -1,0 +1,13 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+  <ItemGroup>
+    <ProjectReference Include="..\CodeLlmWiki.Query\CodeLlmWiki.Query.csproj" />
+  </ItemGroup>
+
+  <PropertyGroup>
+    <TargetFramework>net10.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+  </PropertyGroup>
+
+</Project>

--- a/src/CodeLlmWiki.Wiki/ProjectStructure/IProjectStructureWikiRenderer.cs
+++ b/src/CodeLlmWiki.Wiki/ProjectStructure/IProjectStructureWikiRenderer.cs
@@ -1,0 +1,8 @@
+using CodeLlmWiki.Query.ProjectStructure;
+
+namespace CodeLlmWiki.Wiki.ProjectStructure;
+
+public interface IProjectStructureWikiRenderer
+{
+    IReadOnlyList<WikiPage> Render(ProjectStructureWikiModel model);
+}

--- a/src/CodeLlmWiki.Wiki/ProjectStructure/ProjectStructureWikiRenderer.cs
+++ b/src/CodeLlmWiki.Wiki/ProjectStructure/ProjectStructureWikiRenderer.cs
@@ -1,0 +1,92 @@
+using System.Text;
+using CodeLlmWiki.Query.ProjectStructure;
+
+namespace CodeLlmWiki.Wiki.ProjectStructure;
+
+public sealed class ProjectStructureWikiRenderer : IProjectStructureWikiRenderer
+{
+    public IReadOnlyList<WikiPage> Render(ProjectStructureWikiModel model)
+    {
+        var pages = new List<WikiPage>
+        {
+            RenderRepositoryPage(model),
+        };
+
+        pages.AddRange(model.Solutions
+            .OrderBy(x => x.Path, StringComparer.Ordinal)
+            .Select(solution => RenderSolutionPage(solution, model.Projects)));
+
+        pages.AddRange(model.Projects
+            .OrderBy(x => x.Path, StringComparer.Ordinal)
+            .Select(RenderProjectPage));
+
+        return pages;
+    }
+
+    private static WikiPage RenderRepositoryPage(ProjectStructureWikiModel model)
+    {
+        var sb = new StringBuilder();
+        sb.AppendLine($"# Repository: {model.Repository.Name}");
+        sb.AppendLine();
+        sb.AppendLine($"- Path: `{model.Repository.Path}`");
+        sb.AppendLine($"- Solutions: {model.Solutions.Count}");
+        sb.AppendLine($"- Projects: {model.Projects.Count}");
+        sb.AppendLine();
+        sb.AppendLine("## Solutions");
+
+        foreach (var solution in model.Solutions.OrderBy(x => x.Path, StringComparer.Ordinal))
+        {
+            sb.AppendLine($"- `{solution.Path}`");
+        }
+
+        return new WikiPage(
+            RelativePath: $"repositories/{ToSlug(model.Repository.Id.Value)}.md",
+            Title: model.Repository.Name,
+            Markdown: sb.ToString().TrimEnd());
+    }
+
+    private static WikiPage RenderSolutionPage(SolutionNode solution, IReadOnlyList<ProjectNode> projects)
+    {
+        var projectById = projects.ToDictionary(x => x.Id, x => x);
+
+        var sb = new StringBuilder();
+        sb.AppendLine($"# Solution: {solution.Name}");
+        sb.AppendLine();
+        sb.AppendLine($"- Path: `{solution.Path}`");
+        sb.AppendLine($"- Projects: {solution.ProjectIds.Count}");
+        sb.AppendLine();
+        sb.AppendLine("## Projects");
+
+        foreach (var projectId in solution.ProjectIds)
+        {
+            if (projectById.TryGetValue(projectId, out var project))
+            {
+                sb.AppendLine($"- `{project.Path}`");
+            }
+        }
+
+        return new WikiPage(
+            RelativePath: $"solutions/{ToSlug(solution.Id.Value)}.md",
+            Title: solution.Name,
+            Markdown: sb.ToString().TrimEnd());
+    }
+
+    private static WikiPage RenderProjectPage(ProjectNode project)
+    {
+        var sb = new StringBuilder();
+        sb.AppendLine($"# Project: {project.Name}");
+        sb.AppendLine();
+        sb.AppendLine($"- Path: `{project.Path}`");
+        sb.AppendLine($"- Discovery: `{project.DiscoveryMethod}`");
+
+        return new WikiPage(
+            RelativePath: $"projects/{ToSlug(project.Id.Value)}.md",
+            Title: project.Name,
+            Markdown: sb.ToString().TrimEnd());
+    }
+
+    private static string ToSlug(string value)
+    {
+        return value.Replace(':', '-').Replace('/', '-');
+    }
+}

--- a/src/CodeLlmWiki.Wiki/ProjectStructure/WikiPage.cs
+++ b/src/CodeLlmWiki.Wiki/ProjectStructure/WikiPage.cs
@@ -1,0 +1,3 @@
+namespace CodeLlmWiki.Wiki.ProjectStructure;
+
+public sealed record WikiPage(string RelativePath, string Title, string Markdown);

--- a/tests/CodeLlmWiki.Cli.Tests/CliApplicationTests.cs
+++ b/tests/CodeLlmWiki.Cli.Tests/CliApplicationTests.cs
@@ -41,7 +41,8 @@ public sealed class CliApplicationTests
             NextResult = new IngestionRunResult(
                 IngestionRunStatus.SucceededWithDiagnostics,
                 2,
-                [new IngestionDiagnostic("warn:0001", "warning")]),
+                [new IngestionDiagnostic("warn:0001", "warning")],
+                []),
         };
 
         var app = new CliApplication(runner);
@@ -67,6 +68,7 @@ public sealed class CliApplicationTests
         public IngestionRunResult NextResult { get; set; } = new(
             IngestionRunStatus.Succeeded,
             0,
+            [],
             []);
 
         public Task<IngestionRunResult> RunAsync(IngestionRunRequest request, CancellationToken cancellationToken)

--- a/tests/CodeLlmWiki.Ingestion.Tests/CodeLlmWiki.Ingestion.Tests.csproj
+++ b/tests/CodeLlmWiki.Ingestion.Tests/CodeLlmWiki.Ingestion.Tests.csproj
@@ -21,6 +21,8 @@
   <ItemGroup>
     <ProjectReference Include="..\..\src\CodeLlmWiki.Ingestion\CodeLlmWiki.Ingestion.csproj" />
     <ProjectReference Include="..\..\src\CodeLlmWiki.Contracts\CodeLlmWiki.Contracts.csproj" />
+    <ProjectReference Include="..\..\src\CodeLlmWiki.Query\CodeLlmWiki.Query.csproj" />
+    <ProjectReference Include="..\..\src\CodeLlmWiki.Wiki\CodeLlmWiki.Wiki.csproj" />
   </ItemGroup>
 
 </Project>

--- a/tests/CodeLlmWiki.Ingestion.Tests/IngestionRunnerTests.cs
+++ b/tests/CodeLlmWiki.Ingestion.Tests/IngestionRunnerTests.cs
@@ -68,7 +68,7 @@ public sealed class IngestionRunnerTests
     {
         public bool WasCalled { get; private set; }
 
-        public Task<IReadOnlyList<SemanticTriple>> ExecuteAsync(IngestionExecutionContext context, CancellationToken cancellationToken)
+        public Task<IngestionPipelineResult> ExecuteAsync(IngestionExecutionContext context, CancellationToken cancellationToken)
         {
             WasCalled = true;
 
@@ -77,7 +77,7 @@ public sealed class IngestionRunnerTests
                 new PredicateId("core:contains"),
                 new LiteralNode("noop"));
 
-            return Task.FromResult<IReadOnlyList<SemanticTriple>>(new[] { triple });
+            return Task.FromResult(new IngestionPipelineResult([triple], []));
         }
     }
 }

--- a/tests/CodeLlmWiki.Ingestion.Tests/ProjectStructureVerticalSliceTests.cs
+++ b/tests/CodeLlmWiki.Ingestion.Tests/ProjectStructureVerticalSliceTests.cs
@@ -1,0 +1,111 @@
+using CodeLlmWiki.Contracts.Identity;
+using CodeLlmWiki.Ingestion.ProjectStructure;
+using CodeLlmWiki.Query.ProjectStructure;
+using CodeLlmWiki.Wiki.ProjectStructure;
+
+namespace CodeLlmWiki.Ingestion.Tests;
+
+public sealed class ProjectStructureVerticalSliceTests
+{
+    [Fact]
+    public async Task AnalyzeAsync_IngestsRepositorySolutionsAndProjectsIntoTriples()
+    {
+        var fixture = await ProjectStructureFixture.CreateAsync();
+
+        var analyzer = new ProjectStructureAnalyzer(new StableIdGenerator());
+        var analysis = await analyzer.AnalyzeAsync(fixture.RepositoryPath, CancellationToken.None);
+
+        Assert.NotEqual(default, analysis.RepositoryId);
+        Assert.NotEmpty(analysis.Triples);
+
+        var query = new ProjectStructureQueryService(analysis.Triples);
+        var model = query.GetModel(analysis.RepositoryId);
+
+        Assert.Equal("sample-repo", model.Repository.Name);
+        Assert.Single(model.Solutions);
+        Assert.Equal(2, model.Projects.Count);
+    }
+
+    [Fact]
+    public async Task AnalyzeAsync_UsesMsBuildFirstAndFallsBackWithDiagnostics()
+    {
+        var fixture = await ProjectStructureFixture.CreateAsync();
+
+        var analyzer = new ProjectStructureAnalyzer(new StableIdGenerator());
+        var analysis = await analyzer.AnalyzeAsync(fixture.RepositoryPath, CancellationToken.None);
+
+        Assert.Contains(analysis.Diagnostics, x => x.Code == "project:discovery:fallback");
+        Assert.Contains(analysis.Diagnostics, x => x.Code == "project:discovery:msbuild");
+    }
+
+    [Fact]
+    public async Task Render_IsDeterministic_ForRepositorySolutionAndProjectPages()
+    {
+        var fixture = await ProjectStructureFixture.CreateAsync();
+        var analyzer = new ProjectStructureAnalyzer(new StableIdGenerator());
+        var analysis = await analyzer.AnalyzeAsync(fixture.RepositoryPath, CancellationToken.None);
+
+        var query = new ProjectStructureQueryService(analysis.Triples);
+        var model = query.GetModel(analysis.RepositoryId);
+
+        var renderer = new ProjectStructureWikiRenderer();
+
+        var first = renderer.Render(model);
+        var second = renderer.Render(model);
+
+        Assert.Equal(first.Count, second.Count);
+        Assert.Equal(first.Select(x => x.RelativePath), second.Select(x => x.RelativePath));
+        Assert.Equal(first.Select(x => x.Markdown), second.Select(x => x.Markdown));
+        Assert.Equal(4, first.Count);
+    }
+
+    private sealed class ProjectStructureFixture
+    {
+        private ProjectStructureFixture(string repositoryPath)
+        {
+            RepositoryPath = repositoryPath;
+        }
+
+        public string RepositoryPath { get; }
+
+        public static async Task<ProjectStructureFixture> CreateAsync()
+        {
+            var root = Path.Combine(Path.GetTempPath(), $"codellmwiki-{Guid.NewGuid():N}", "sample-repo");
+            Directory.CreateDirectory(root);
+
+            var solutionPath = Path.Combine(root, "Sample.slnx");
+            var slnx = """
+                       <Solution>
+                         <Project Path="src/Valid/Valid.csproj" />
+                         <Project Path="src/Broken/Broken.csproj" />
+                       </Solution>
+                       """;
+            await File.WriteAllTextAsync(solutionPath, slnx);
+
+            var validDir = Path.Combine(root, "src", "Valid");
+            Directory.CreateDirectory(validDir);
+            var validCsproj = """
+                              <Project Sdk="Microsoft.NET.Sdk">
+                                <PropertyGroup>
+                                  <TargetFramework>net10.0</TargetFramework>
+                                </PropertyGroup>
+                              </Project>
+                              """;
+            await File.WriteAllTextAsync(Path.Combine(validDir, "Valid.csproj"), validCsproj);
+
+            var brokenDir = Path.Combine(root, "src", "Broken");
+            Directory.CreateDirectory(brokenDir);
+            var brokenCsproj = """
+                               <Project Sdk="Microsoft.NET.Sdk">
+                                 <PropertyGroup>
+                                   <TargetFramework>net10.0</TargetFramework>
+                                 </PropertyGroup>
+                                 <ItemGroup>
+                               </Project>
+                               """;
+            await File.WriteAllTextAsync(Path.Combine(brokenDir, "Broken.csproj"), brokenCsproj);
+
+            return new ProjectStructureFixture(root);
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- implements repository/solution/project analyzer that emits semantic triples
- adds MSBuild-first project discovery with fallback parsing and diagnostics
- adds query boundary (`ProjectStructureQueryService`) to retrieve repository/solution/project view models
- adds deterministic wiki renderer for repository/solution/project pages
- wires CLI ingestion pipeline to the project-structure analyzer slice

## Validation
- `dotnet build CodeLlmWiki.slnx -v minimal`
- `dotnet test CodeLlmWiki.slnx -v minimal`
- `dotnet run --project src/CodeLlmWiki.Cli -- ingest --path . --allow-partial-success true`

Closes #3
