### PR TITLE
Phase 3: Package Graph Vertical Slice (#4)

### DIFF
--- a/ontology/ontology.v1.yaml
+++ b/ontology/ontology.v1.yaml
@@ -6,3 +6,6 @@ predicates:
   - id: "core:hasName"
   - id: "core:hasPath"
   - id: "core:discoveryMethod"
+  - id: "core:referencesPackage"
+  - id: "core:hasDeclaredVersion"
+  - id: "core:hasResolvedVersion"

--- a/src/CodeLlmWiki.Contracts/Graph/CorePredicates.cs
+++ b/src/CodeLlmWiki.Contracts/Graph/CorePredicates.cs
@@ -3,8 +3,11 @@ namespace CodeLlmWiki.Contracts.Graph;
 public static class CorePredicates
 {
     public static readonly PredicateId Contains = new("core:contains");
+    public static readonly PredicateId ReferencesPackage = new("core:referencesPackage");
     public static readonly PredicateId EntityType = new("core:entityType");
     public static readonly PredicateId HasName = new("core:hasName");
     public static readonly PredicateId HasPath = new("core:hasPath");
     public static readonly PredicateId DiscoveryMethod = new("core:discoveryMethod");
+    public static readonly PredicateId HasDeclaredVersion = new("core:hasDeclaredVersion");
+    public static readonly PredicateId HasResolvedVersion = new("core:hasResolvedVersion");
 }

--- a/src/CodeLlmWiki.Ingestion/ProjectStructure/ProjectStructureAnalyzer.cs
+++ b/src/CodeLlmWiki.Ingestion/ProjectStructure/ProjectStructureAnalyzer.cs
@@ -1,4 +1,5 @@
 using System.Xml.Linq;
+using System.Text.Json;
 using CodeLlmWiki.Contracts.Graph;
 using CodeLlmWiki.Contracts.Identity;
 using Microsoft.Build.Construction;
@@ -74,6 +75,25 @@ public sealed class ProjectStructureAnalyzer : IProjectStructureAnalyzer
             AddEntityTriples(triples, projectId, "project", discovery.Name, relativeProjectPath);
             triples.Add(new SemanticTriple(new EntityNode(projectId), CorePredicates.DiscoveryMethod, new LiteralNode(discovery.Method)));
             triples.Add(new SemanticTriple(new EntityNode(repositoryId), CorePredicates.Contains, new EntityNode(projectId)));
+
+            var resolvedByPackage = DiscoverResolvedPackages(projectPath, diagnostics);
+
+            foreach (var package in discovery.DeclaredPackages.OrderBy(x => x.PackageId, StringComparer.OrdinalIgnoreCase))
+            {
+                var packageId = _stableIdGenerator.Create(new EntityKey("package", package.PackageId.ToLowerInvariant()));
+                AddEntityTriples(triples, packageId, "package", package.PackageId, package.PackageId);
+                triples.Add(new SemanticTriple(new EntityNode(projectId), CorePredicates.ReferencesPackage, new EntityNode(packageId)));
+
+                if (!string.IsNullOrWhiteSpace(package.DeclaredVersion))
+                {
+                    triples.Add(new SemanticTriple(new EntityNode(packageId), CorePredicates.HasDeclaredVersion, new LiteralNode(package.DeclaredVersion)));
+                }
+
+                if (resolvedByPackage.TryGetValue(package.PackageId, out var resolvedVersion) && !string.IsNullOrWhiteSpace(resolvedVersion))
+                {
+                    triples.Add(new SemanticTriple(new EntityNode(packageId), CorePredicates.HasResolvedVersion, new LiteralNode(resolvedVersion)));
+                }
+            }
         }
 
         foreach (var pair in solutionProjectMap.OrderBy(x => ToRelativePath(fullRepositoryPath, x.Key), StringComparer.Ordinal))
@@ -201,11 +221,19 @@ public sealed class ProjectStructureAnalyzer : IProjectStructureAnalyzer
                 name = Path.GetFileNameWithoutExtension(projectPath);
             }
 
-            return new ProjectDiscoveryResult(name, "msbuild");
+            var declaredPackages = project.GetItems("PackageReference")
+                .Select(item => new PackageReferenceInfo(
+                    item.EvaluatedInclude.Trim(),
+                    ReadVersion(item.GetMetadataValue("Version"))))
+                .Where(x => !string.IsNullOrWhiteSpace(x.PackageId))
+                .ToArray();
+
+            return new ProjectDiscoveryResult(name, "msbuild", declaredPackages);
         }
         catch (Exception ex)
         {
             var fallbackName = Path.GetFileNameWithoutExtension(projectPath);
+            var fallbackPackages = Array.Empty<PackageReferenceInfo>();
             try
             {
                 var document = XDocument.Load(projectPath);
@@ -214,6 +242,22 @@ public sealed class ProjectStructureAnalyzer : IProjectStructureAnalyzer
                 {
                     fallbackName = assemblyName;
                 }
+
+                fallbackPackages = document
+                    .Descendants("PackageReference")
+                    .Select(node =>
+                    {
+                        var include = node.Attribute("Include")?.Value
+                            ?? node.Attribute("Update")?.Value
+                            ?? string.Empty;
+
+                        var version = node.Attribute("Version")?.Value
+                            ?? node.Elements("Version").FirstOrDefault()?.Value;
+
+                        return new PackageReferenceInfo(include.Trim(), ReadVersion(version));
+                    })
+                    .Where(x => !string.IsNullOrWhiteSpace(x.PackageId))
+                    .ToArray();
             }
             catch
             {
@@ -221,8 +265,63 @@ public sealed class ProjectStructureAnalyzer : IProjectStructureAnalyzer
             }
 
             diagnostics.Add(new IngestionDiagnostic("project:discovery:fallback", $"Project '{projectPath}' fell back from MSBuild discovery: {ex.Message}"));
-            return new ProjectDiscoveryResult(fallbackName, "fallback");
+            return new ProjectDiscoveryResult(fallbackName, "fallback", fallbackPackages);
         }
+    }
+
+    private static Dictionary<string, string> DiscoverResolvedPackages(string projectPath, List<IngestionDiagnostic> diagnostics)
+    {
+        var result = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
+        var assetsPath = Path.Combine(Path.GetDirectoryName(projectPath)!, "obj", "project.assets.json");
+
+        if (!File.Exists(assetsPath))
+        {
+            diagnostics.Add(new IngestionDiagnostic("package:resolved:not-available", $"Resolved package data not available for '{projectPath}'."));
+            return result;
+        }
+
+        try
+        {
+            using var stream = File.OpenRead(assetsPath);
+            using var document = JsonDocument.Parse(stream);
+
+            if (!document.RootElement.TryGetProperty("libraries", out var libraries) || libraries.ValueKind != JsonValueKind.Object)
+            {
+                diagnostics.Add(new IngestionDiagnostic("package:resolved:not-available", $"Resolved package libraries are missing in '{assetsPath}'."));
+                return result;
+            }
+
+            foreach (var library in libraries.EnumerateObject())
+            {
+                if (!library.Value.TryGetProperty("type", out var typeElement) ||
+                    !string.Equals(typeElement.GetString(), "package", StringComparison.OrdinalIgnoreCase))
+                {
+                    continue;
+                }
+
+                var nameAndVersion = library.Name.Split('/', 2, StringSplitOptions.TrimEntries);
+                if (nameAndVersion.Length != 2)
+                {
+                    continue;
+                }
+
+                result[nameAndVersion[0]] = nameAndVersion[1];
+            }
+
+            diagnostics.Add(new IngestionDiagnostic("package:resolved:available", $"Resolved package data loaded for '{projectPath}'."));
+            return result;
+        }
+        catch (Exception ex)
+        {
+            diagnostics.Add(new IngestionDiagnostic("package:resolved:not-available", $"Failed to parse resolved package data for '{projectPath}': {ex.Message}"));
+            return result;
+        }
+    }
+
+    private static string? ReadVersion(string? version)
+    {
+        var value = version?.Trim();
+        return string.IsNullOrWhiteSpace(value) ? null : value;
     }
 
     private static string ToRelativePath(string root, string path)
@@ -231,5 +330,7 @@ public sealed class ProjectStructureAnalyzer : IProjectStructureAnalyzer
         return relative;
     }
 
-    private sealed record ProjectDiscoveryResult(string Name, string Method);
+    private sealed record ProjectDiscoveryResult(string Name, string Method, IReadOnlyList<PackageReferenceInfo> DeclaredPackages);
+
+    private sealed record PackageReferenceInfo(string PackageId, string? DeclaredVersion);
 }

--- a/src/CodeLlmWiki.Query/ProjectStructure/PackageNode.cs
+++ b/src/CodeLlmWiki.Query/ProjectStructure/PackageNode.cs
@@ -1,0 +1,9 @@
+using CodeLlmWiki.Contracts.Identity;
+
+namespace CodeLlmWiki.Query.ProjectStructure;
+
+public sealed record PackageNode(
+    EntityId Id,
+    string Name,
+    IReadOnlyList<string> DeclaredVersions,
+    IReadOnlyList<string> ResolvedVersions);

--- a/src/CodeLlmWiki.Query/ProjectStructure/ProjectNode.cs
+++ b/src/CodeLlmWiki.Query/ProjectStructure/ProjectNode.cs
@@ -2,4 +2,9 @@ using CodeLlmWiki.Contracts.Identity;
 
 namespace CodeLlmWiki.Query.ProjectStructure;
 
-public sealed record ProjectNode(EntityId Id, string Name, string Path, string DiscoveryMethod);
+public sealed record ProjectNode(
+    EntityId Id,
+    string Name,
+    string Path,
+    string DiscoveryMethod,
+    IReadOnlyList<EntityId> PackageIds);

--- a/src/CodeLlmWiki.Query/ProjectStructure/ProjectStructureQueryService.cs
+++ b/src/CodeLlmWiki.Query/ProjectStructure/ProjectStructureQueryService.cs
@@ -16,6 +16,8 @@ public sealed class ProjectStructureQueryService : IProjectStructureQueryService
     {
         var metadataById = BuildEntityMetadata(_triples);
         var contains = BuildContainsEdges(_triples);
+        var packageReferences = BuildPackageReferences(_triples);
+        var versionsByPackage = BuildPackageVersions(_triples);
 
         if (!metadataById.TryGetValue(repositoryId, out var repoMeta) || !repoMeta.IsType("repository"))
         {
@@ -59,12 +61,43 @@ public sealed class ProjectStructureQueryService : IProjectStructureQueryService
             .Select(projectId =>
             {
                 var meta = metadataById[projectId];
-                return new ProjectNode(projectId, meta.Name, meta.Path, meta.DiscoveryMethod);
+                var packageIds = packageReferences
+                    .Where(x => x.ProjectId == projectId)
+                    .Select(x => x.PackageId)
+                    .Distinct()
+                    .OrderBy(x => metadataById.TryGetValue(x, out var packageMeta) ? packageMeta.Name : x.Value, StringComparer.Ordinal)
+                    .ToArray();
+
+                return new ProjectNode(projectId, meta.Name, meta.Path, meta.DiscoveryMethod, packageIds);
+            })
+            .ToArray();
+
+        var packageIds = projects
+            .SelectMany(x => x.PackageIds)
+            .Distinct()
+            .OrderBy(x => metadataById.TryGetValue(x, out var packageMeta) ? packageMeta.Name : x.Value, StringComparer.Ordinal)
+            .ToArray();
+
+        var packages = packageIds
+            .Select(packageId =>
+            {
+                var meta = metadataById.TryGetValue(packageId, out var packageMeta)
+                    ? packageMeta
+                    : new EntityMetadata(packageId);
+
+                versionsByPackage.TryGetValue(packageId, out var versions);
+                versions ??= new PackageVersionMetadata([], []);
+
+                return new PackageNode(
+                    packageId,
+                    meta.Name,
+                    versions.DeclaredVersions.OrderBy(x => x, StringComparer.Ordinal).ToArray(),
+                    versions.ResolvedVersions.OrderBy(x => x, StringComparer.Ordinal).ToArray());
             })
             .ToArray();
 
         var repository = new RepositoryNode(repositoryId, repoMeta.Name, repoMeta.Path);
-        return new ProjectStructureWikiModel(repository, solutions, projects);
+        return new ProjectStructureWikiModel(repository, solutions, projects, packages);
     }
 
     private static Dictionary<EntityId, EntityMetadata> BuildEntityMetadata(IReadOnlyList<SemanticTriple> triples)
@@ -122,6 +155,60 @@ public sealed class ProjectStructureQueryService : IProjectStructureQueryService
             .ToArray();
     }
 
+    private static IReadOnlyList<PackageReferenceEdge> BuildPackageReferences(IReadOnlyList<SemanticTriple> triples)
+    {
+        return triples
+            .Where(x => x.Predicate == CorePredicates.ReferencesPackage)
+            .Where(x => x.Subject is EntityNode && x.Object is EntityNode)
+            .Select(x => new PackageReferenceEdge(((EntityNode)x.Subject).Id, ((EntityNode)x.Object).Id))
+            .Distinct()
+            .ToArray();
+    }
+
+    private static Dictionary<EntityId, PackageVersionMetadata> BuildPackageVersions(IReadOnlyList<SemanticTriple> triples)
+    {
+        var byPackageId = new Dictionary<EntityId, PackageVersionMetadata>();
+
+        foreach (var triple in triples)
+        {
+            if (triple.Subject is not EntityNode subject || triple.Object is not LiteralNode literal)
+            {
+                continue;
+            }
+
+            if (triple.Predicate != CorePredicates.HasDeclaredVersion &&
+                triple.Predicate != CorePredicates.HasResolvedVersion)
+            {
+                continue;
+            }
+
+            if (!byPackageId.TryGetValue(subject.Id, out var versions))
+            {
+                versions = new PackageVersionMetadata(
+                    new HashSet<string>(StringComparer.OrdinalIgnoreCase),
+                    new HashSet<string>(StringComparer.OrdinalIgnoreCase));
+                byPackageId[subject.Id] = versions;
+            }
+
+            var value = literal.Value?.ToString();
+            if (string.IsNullOrWhiteSpace(value))
+            {
+                continue;
+            }
+
+            if (triple.Predicate == CorePredicates.HasDeclaredVersion)
+            {
+                versions.DeclaredVersions.Add(value);
+            }
+            else
+            {
+                versions.ResolvedVersions.Add(value);
+            }
+        }
+
+        return byPackageId;
+    }
+
     private sealed class EntityMetadata
     {
         public EntityMetadata(EntityId id)
@@ -147,4 +234,9 @@ public sealed class ProjectStructureQueryService : IProjectStructureQueryService
     }
 
     private sealed record ContainsEdge(EntityId Subject, EntityId Object);
+    private sealed record PackageReferenceEdge(EntityId ProjectId, EntityId PackageId);
+
+    private sealed record PackageVersionMetadata(
+        HashSet<string> DeclaredVersions,
+        HashSet<string> ResolvedVersions);
 }

--- a/src/CodeLlmWiki.Query/ProjectStructure/ProjectStructureWikiModel.cs
+++ b/src/CodeLlmWiki.Query/ProjectStructure/ProjectStructureWikiModel.cs
@@ -3,4 +3,5 @@ namespace CodeLlmWiki.Query.ProjectStructure;
 public sealed record ProjectStructureWikiModel(
     RepositoryNode Repository,
     IReadOnlyList<SolutionNode> Solutions,
-    IReadOnlyList<ProjectNode> Projects);
+    IReadOnlyList<ProjectNode> Projects,
+    IReadOnlyList<PackageNode> Packages);

--- a/src/CodeLlmWiki.Wiki/ProjectStructure/ProjectStructureWikiRenderer.cs
+++ b/src/CodeLlmWiki.Wiki/ProjectStructure/ProjectStructureWikiRenderer.cs
@@ -1,4 +1,5 @@
 using System.Text;
+using CodeLlmWiki.Contracts.Identity;
 using CodeLlmWiki.Query.ProjectStructure;
 
 namespace CodeLlmWiki.Wiki.ProjectStructure;
@@ -7,6 +8,8 @@ public sealed class ProjectStructureWikiRenderer : IProjectStructureWikiRenderer
 {
     public IReadOnlyList<WikiPage> Render(ProjectStructureWikiModel model)
     {
+        var packageById = model.Packages.ToDictionary(x => x.Id, x => x);
+
         var pages = new List<WikiPage>
         {
             RenderRepositoryPage(model),
@@ -18,7 +21,11 @@ public sealed class ProjectStructureWikiRenderer : IProjectStructureWikiRenderer
 
         pages.AddRange(model.Projects
             .OrderBy(x => x.Path, StringComparer.Ordinal)
-            .Select(RenderProjectPage));
+            .Select(project => RenderProjectPage(project, packageById)));
+
+        pages.AddRange(model.Packages
+            .OrderBy(x => x.Name, StringComparer.Ordinal)
+            .Select(RenderPackagePage));
 
         return pages;
     }
@@ -31,6 +38,7 @@ public sealed class ProjectStructureWikiRenderer : IProjectStructureWikiRenderer
         sb.AppendLine($"- Path: `{model.Repository.Path}`");
         sb.AppendLine($"- Solutions: {model.Solutions.Count}");
         sb.AppendLine($"- Projects: {model.Projects.Count}");
+        sb.AppendLine($"- Packages: {model.Packages.Count}");
         sb.AppendLine();
         sb.AppendLine("## Solutions");
 
@@ -71,17 +79,54 @@ public sealed class ProjectStructureWikiRenderer : IProjectStructureWikiRenderer
             Markdown: sb.ToString().TrimEnd());
     }
 
-    private static WikiPage RenderProjectPage(ProjectNode project)
+    private static WikiPage RenderProjectPage(ProjectNode project, IReadOnlyDictionary<EntityId, PackageNode> packageById)
     {
         var sb = new StringBuilder();
         sb.AppendLine($"# Project: {project.Name}");
         sb.AppendLine();
         sb.AppendLine($"- Path: `{project.Path}`");
         sb.AppendLine($"- Discovery: `{project.DiscoveryMethod}`");
+        sb.AppendLine();
+        sb.AppendLine("## Packages");
+
+        foreach (var packageId in project.PackageIds)
+        {
+            if (!packageById.TryGetValue(packageId, out var package))
+            {
+                continue;
+            }
+
+            sb.AppendLine($"- [{package.Name}](../packages/{ToSlug(package.Id.Value)}.md)");
+        }
 
         return new WikiPage(
             RelativePath: $"projects/{ToSlug(project.Id.Value)}.md",
             Title: project.Name,
+            Markdown: sb.ToString().TrimEnd());
+    }
+
+    private static WikiPage RenderPackagePage(PackageNode package)
+    {
+        var sb = new StringBuilder();
+        sb.AppendLine($"# Package: {package.Name}");
+        sb.AppendLine();
+        sb.AppendLine("## Declared Versions");
+
+        foreach (var declared in package.DeclaredVersions.OrderBy(x => x, StringComparer.Ordinal))
+        {
+            sb.AppendLine($"- `{declared}`");
+        }
+
+        sb.AppendLine();
+        sb.AppendLine("## Resolved Versions");
+        foreach (var resolved in package.ResolvedVersions.OrderBy(x => x, StringComparer.Ordinal))
+        {
+            sb.AppendLine($"- `{resolved}`");
+        }
+
+        return new WikiPage(
+            RelativePath: $"packages/{ToSlug(package.Id.Value)}.md",
+            Title: package.Name,
             Markdown: sb.ToString().TrimEnd());
     }
 

--- a/tests/CodeLlmWiki.Ingestion.Tests/PackageDependencyVerticalSliceTests.cs
+++ b/tests/CodeLlmWiki.Ingestion.Tests/PackageDependencyVerticalSliceTests.cs
@@ -1,0 +1,152 @@
+using CodeLlmWiki.Contracts.Identity;
+using CodeLlmWiki.Ingestion.ProjectStructure;
+using CodeLlmWiki.Ontology;
+using CodeLlmWiki.Query.ProjectStructure;
+using CodeLlmWiki.Wiki.ProjectStructure;
+
+namespace CodeLlmWiki.Ingestion.Tests;
+
+public sealed class PackageDependencyVerticalSliceTests
+{
+    [Fact]
+    public async Task AnalyzeAsync_DeclaredDependenciesAreRepresentedAndQueryable()
+    {
+        var fixture = await PackageDependencyFixture.CreateAsync();
+        var analyzer = new ProjectStructureAnalyzer(new StableIdGenerator());
+        var analysis = await analyzer.AnalyzeAsync(fixture.RepositoryPath, CancellationToken.None);
+
+        var query = new ProjectStructureQueryService(analysis.Triples);
+        var model = query.GetModel(analysis.RepositoryId);
+
+        Assert.Equal(2, model.Packages.Count);
+
+        var withAssetsProject = model.Projects.Single(x => x.Name == "WithAssets");
+        var withAssetsPackages = withAssetsProject.PackageIds
+            .Select(id => model.Packages.Single(p => p.Id == id).Name)
+            .OrderBy(x => x, StringComparer.Ordinal)
+            .ToArray();
+
+        Assert.Equal(["Newtonsoft.Json"], withAssetsPackages);
+    }
+
+    [Fact]
+    public async Task AnalyzeAsync_ResolvedVersionsAreCapturedWhenAvailable_WithDiagnosticsOtherwise()
+    {
+        var fixture = await PackageDependencyFixture.CreateAsync();
+        var analyzer = new ProjectStructureAnalyzer(new StableIdGenerator());
+        var analysis = await analyzer.AnalyzeAsync(fixture.RepositoryPath, CancellationToken.None);
+
+        var query = new ProjectStructureQueryService(analysis.Triples);
+        var model = query.GetModel(analysis.RepositoryId);
+
+        var newtonsoft = model.Packages.Single(x => x.Name == "Newtonsoft.Json");
+        Assert.Contains("13.0.3", newtonsoft.ResolvedVersions);
+
+        var serilog = model.Packages.Single(x => x.Name == "Serilog");
+        Assert.Empty(serilog.ResolvedVersions);
+
+        Assert.Contains(analysis.Diagnostics, x => x.Code == "package:resolved:not-available");
+    }
+
+    [Fact]
+    public async Task Render_GeneratesPackagePagesAndProjectLinks()
+    {
+        var fixture = await PackageDependencyFixture.CreateAsync();
+        var analyzer = new ProjectStructureAnalyzer(new StableIdGenerator());
+        var analysis = await analyzer.AnalyzeAsync(fixture.RepositoryPath, CancellationToken.None);
+
+        var query = new ProjectStructureQueryService(analysis.Triples);
+        var model = query.GetModel(analysis.RepositoryId);
+
+        var renderer = new ProjectStructureWikiRenderer();
+        var pages = renderer.Render(model);
+
+        Assert.Equal(6, pages.Count);
+        Assert.Equal(2, pages.Count(x => x.RelativePath.StartsWith("packages/", StringComparison.Ordinal)));
+        Assert.Contains(pages, page => page.RelativePath.StartsWith("projects/", StringComparison.Ordinal) && page.Markdown.Contains("packages/", StringComparison.Ordinal));
+    }
+
+    [Fact]
+    public async Task Ontology_ContainsPackagePredicates_AndStillValidates()
+    {
+        var ontologyPath = Path.GetFullPath(Path.Combine(AppContext.BaseDirectory, "..", "..", "..", "..", "..", "ontology", "ontology.v1.yaml"));
+        var loader = new OntologyLoader();
+        var result = await loader.LoadAsync(ontologyPath, CancellationToken.None);
+
+        Assert.True(result.IsValid);
+        Assert.NotNull(result.Definition);
+
+        var predicateIds = result.Definition!.Predicates.Select(x => x.Id).ToHashSet(StringComparer.Ordinal);
+        Assert.Contains("core:referencesPackage", predicateIds);
+        Assert.Contains("core:hasDeclaredVersion", predicateIds);
+        Assert.Contains("core:hasResolvedVersion", predicateIds);
+    }
+
+    private sealed class PackageDependencyFixture
+    {
+        private PackageDependencyFixture(string repositoryPath)
+        {
+            RepositoryPath = repositoryPath;
+        }
+
+        public string RepositoryPath { get; }
+
+        public static async Task<PackageDependencyFixture> CreateAsync()
+        {
+            var root = Path.Combine(Path.GetTempPath(), $"codellmwiki-packages-{Guid.NewGuid():N}", "package-repo");
+            Directory.CreateDirectory(root);
+
+            var solutionPath = Path.Combine(root, "Sample.slnx");
+            var slnx = """
+                       <Solution>
+                         <Project Path="src/WithAssets/WithAssets.csproj" />
+                         <Project Path="src/NoAssets/NoAssets.csproj" />
+                       </Solution>
+                       """;
+            await File.WriteAllTextAsync(solutionPath, slnx);
+
+            var withAssetsDir = Path.Combine(root, "src", "WithAssets");
+            Directory.CreateDirectory(withAssetsDir);
+            var withAssetsCsproj = """
+                                   <Project Sdk="Microsoft.NET.Sdk">
+                                     <PropertyGroup>
+                                       <TargetFramework>net10.0</TargetFramework>
+                                     </PropertyGroup>
+                                     <ItemGroup>
+                                       <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
+                                     </ItemGroup>
+                                   </Project>
+                                   """;
+            await File.WriteAllTextAsync(Path.Combine(withAssetsDir, "WithAssets.csproj"), withAssetsCsproj);
+
+            var withAssetsObj = Path.Combine(withAssetsDir, "obj");
+            Directory.CreateDirectory(withAssetsObj);
+            var assets = """
+                         {
+                           "libraries": {
+                             "Newtonsoft.Json/13.0.3": {
+                               "type": "package"
+                             }
+                           }
+                         }
+                         """;
+            await File.WriteAllTextAsync(Path.Combine(withAssetsObj, "project.assets.json"), assets);
+
+            var noAssetsDir = Path.Combine(root, "src", "NoAssets");
+            Directory.CreateDirectory(noAssetsDir);
+            var noAssetsCsproj = """
+                                 <Project Sdk="Microsoft.NET.Sdk">
+                                   <PropertyGroup>
+                                     <TargetFramework>net10.0</TargetFramework>
+                                   </PropertyGroup>
+                                   <ItemGroup>
+                                     <PackageReference Include="Serilog" Version="3.1.0" />
+                                   </ItemGroup>
+                                 </Project>
+                                 """;
+            await File.WriteAllTextAsync(Path.Combine(noAssetsDir, "NoAssets.csproj"), noAssetsCsproj);
+
+            return new PackageDependencyFixture(root);
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- extends analyzer to ingest NuGet package dependency facts from project files
- captures declared package versions always and resolved versions from `project.assets.json` when available
- emits explicit diagnostics when resolved data is unavailable
- extends query read model with package nodes and project-to-package links
- extends wiki renderer with package pages and package links from project pages
- updates ontology predicate catalog for package relationships and versions

## Validation
- `dotnet build CodeLlmWiki.slnx -v minimal`
- `dotnet test CodeLlmWiki.slnx -v minimal`
- `dotnet run --project src/CodeLlmWiki.Cli -- ingest --path . --allow-partial-success true`

Closes #4
