### PR TITLE
Phase 4: File Inventory and Classification Vertical Slice (#5)

### DIFF
--- a/ontology/ontology.v1.yaml
+++ b/ontology/ontology.v1.yaml
@@ -9,3 +9,5 @@ predicates:
   - id: "core:referencesPackage"
   - id: "core:hasDeclaredVersion"
   - id: "core:hasResolvedVersion"
+  - id: "core:fileKind"
+  - id: "core:isSolutionMember"

--- a/src/CodeLlmWiki.Contracts/Graph/CorePredicates.cs
+++ b/src/CodeLlmWiki.Contracts/Graph/CorePredicates.cs
@@ -10,4 +10,6 @@ public static class CorePredicates
     public static readonly PredicateId DiscoveryMethod = new("core:discoveryMethod");
     public static readonly PredicateId HasDeclaredVersion = new("core:hasDeclaredVersion");
     public static readonly PredicateId HasResolvedVersion = new("core:hasResolvedVersion");
+    public static readonly PredicateId FileKind = new("core:fileKind");
+    public static readonly PredicateId IsSolutionMember = new("core:isSolutionMember");
 }

--- a/src/CodeLlmWiki.Ingestion/ProjectStructure/ProjectStructureAnalyzer.cs
+++ b/src/CodeLlmWiki.Ingestion/ProjectStructure/ProjectStructureAnalyzer.cs
@@ -1,5 +1,6 @@
 using System.Xml.Linq;
 using System.Text.Json;
+using System.Diagnostics;
 using CodeLlmWiki.Contracts.Graph;
 using CodeLlmWiki.Contracts.Identity;
 using Microsoft.Build.Construction;
@@ -108,6 +109,27 @@ public sealed class ProjectStructureAnalyzer : IProjectStructureAnalyzer
                     triples.Add(new SemanticTriple(new EntityNode(solutionId), CorePredicates.Contains, new EntityNode(projectId)));
                 }
             }
+        }
+
+        var solutionMemberPaths = BuildSolutionMemberPathSet(fullRepositoryPath, solutionProjectMap);
+        var gitTrackedFiles = DiscoverGitTrackedHeadFiles(fullRepositoryPath, diagnostics);
+
+        foreach (var relativeFilePath in gitTrackedFiles.OrderBy(x => x, StringComparer.Ordinal))
+        {
+            var fileId = _stableIdGenerator.Create(new EntityKey("file", relativeFilePath));
+            AddEntityTriples(
+                triples,
+                fileId,
+                "file",
+                Path.GetFileName(relativeFilePath),
+                relativeFilePath);
+
+            triples.Add(new SemanticTriple(new EntityNode(fileId), CorePredicates.FileKind, new LiteralNode(ClassifyFile(relativeFilePath))));
+            triples.Add(new SemanticTriple(
+                new EntityNode(fileId),
+                CorePredicates.IsSolutionMember,
+                new LiteralNode(IsSolutionMember(relativeFilePath, solutionMemberPaths).ToString().ToLowerInvariant())));
+            triples.Add(new SemanticTriple(new EntityNode(repositoryId), CorePredicates.Contains, new EntityNode(fileId)));
         }
 
         return Task.FromResult(new ProjectStructureAnalysisResult(repositoryId, triples, diagnostics));
@@ -330,7 +352,142 @@ public sealed class ProjectStructureAnalyzer : IProjectStructureAnalyzer
         return relative;
     }
 
+    private static HashSet<string> BuildSolutionMemberPathSet(
+        string repositoryRoot,
+        Dictionary<string, HashSet<string>> solutionProjectMap)
+    {
+        var members = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+
+        foreach (var pair in solutionProjectMap)
+        {
+            var relativeSolutionPath = ToRelativePath(repositoryRoot, pair.Key);
+            if (!relativeSolutionPath.StartsWith("../", StringComparison.Ordinal))
+            {
+                members.Add(relativeSolutionPath);
+            }
+
+            foreach (var projectPath in pair.Value)
+            {
+                var relativeProjectPath = ToRelativePath(repositoryRoot, projectPath);
+                if (relativeProjectPath.StartsWith("../", StringComparison.Ordinal))
+                {
+                    continue;
+                }
+
+                members.Add(relativeProjectPath);
+
+                var directory = Path.GetDirectoryName(relativeProjectPath)?.Replace('\\', '/');
+                if (!string.IsNullOrWhiteSpace(directory))
+                {
+                    members.Add($"{directory.TrimEnd('/')}/");
+                }
+            }
+        }
+
+        return members;
+    }
+
+    private static HashSet<string> DiscoverGitTrackedHeadFiles(string repositoryRoot, List<IngestionDiagnostic> diagnostics)
+    {
+        var filesFromHead = RunGitWithNulDelimitedOutput(repositoryRoot, "ls-tree", "-r", "--name-only", "-z", "HEAD");
+        if (filesFromHead.ExitCode == 0 && filesFromHead.Entries.Count > 0)
+        {
+            return filesFromHead.Entries;
+        }
+
+        diagnostics.Add(new IngestionDiagnostic(
+            "file:head:not-available",
+            "HEAD file listing unavailable, falling back to git index listing."));
+
+        var filesFromIndex = RunGitWithNulDelimitedOutput(repositoryRoot, "ls-files", "-z");
+        if (filesFromIndex.ExitCode == 0)
+        {
+            return filesFromIndex.Entries;
+        }
+
+        diagnostics.Add(new IngestionDiagnostic(
+            "file:git:failed",
+            $"Failed to list git-tracked files: {filesFromIndex.Error}"));
+
+        return new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+    }
+
+    private static GitCommandResult RunGitWithNulDelimitedOutput(string repositoryRoot, params string[] args)
+    {
+        var startInfo = new ProcessStartInfo
+        {
+            FileName = "git",
+            WorkingDirectory = repositoryRoot,
+            RedirectStandardOutput = true,
+            RedirectStandardError = true,
+        };
+
+        foreach (var arg in args)
+        {
+            startInfo.ArgumentList.Add(arg);
+        }
+
+        using var process = Process.Start(startInfo)!;
+        using var outputStream = new MemoryStream();
+        process.StandardOutput.BaseStream.CopyTo(outputStream);
+        var error = process.StandardError.ReadToEnd();
+        process.WaitForExit();
+
+        var entries = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+        var bytes = outputStream.ToArray();
+        var start = 0;
+        for (var i = 0; i < bytes.Length; i++)
+        {
+            if (bytes[i] != 0)
+            {
+                continue;
+            }
+
+            if (i > start)
+            {
+                var value = System.Text.Encoding.UTF8.GetString(bytes, start, i - start).Replace('\\', '/');
+                if (!string.IsNullOrWhiteSpace(value))
+                {
+                    entries.Add(value);
+                }
+            }
+
+            start = i + 1;
+        }
+
+        return new GitCommandResult(process.ExitCode, entries, error);
+    }
+
+    private static string ClassifyFile(string relativePath)
+    {
+        var extension = Path.GetExtension(relativePath).ToLowerInvariant();
+        return extension switch
+        {
+            ".cs" => "dotnet-source",
+            ".sln" or ".slnx" => "solution",
+            ".csproj" => "project",
+            ".props" or ".targets" => "msbuild",
+            ".md" => "documentation",
+            ".json" or ".yaml" or ".yml" => "configuration",
+            _ => "other",
+        };
+    }
+
+    private static bool IsSolutionMember(string relativeFilePath, HashSet<string> solutionMemberPaths)
+    {
+        if (solutionMemberPaths.Contains(relativeFilePath))
+        {
+            return true;
+        }
+
+        return solutionMemberPaths.Any(entry =>
+            entry.EndsWith("/", StringComparison.Ordinal) &&
+            relativeFilePath.StartsWith(entry, StringComparison.OrdinalIgnoreCase));
+    }
+
     private sealed record ProjectDiscoveryResult(string Name, string Method, IReadOnlyList<PackageReferenceInfo> DeclaredPackages);
 
     private sealed record PackageReferenceInfo(string PackageId, string? DeclaredVersion);
+
+    private sealed record GitCommandResult(int ExitCode, HashSet<string> Entries, string Error);
 }

--- a/src/CodeLlmWiki.Query/ProjectStructure/FileNode.cs
+++ b/src/CodeLlmWiki.Query/ProjectStructure/FileNode.cs
@@ -1,0 +1,10 @@
+using CodeLlmWiki.Contracts.Identity;
+
+namespace CodeLlmWiki.Query.ProjectStructure;
+
+public sealed record FileNode(
+    EntityId Id,
+    string Name,
+    string Path,
+    string Classification,
+    bool IsSolutionMember);

--- a/src/CodeLlmWiki.Query/ProjectStructure/ProjectStructureQueryService.cs
+++ b/src/CodeLlmWiki.Query/ProjectStructure/ProjectStructureQueryService.cs
@@ -96,8 +96,29 @@ public sealed class ProjectStructureQueryService : IProjectStructureQueryService
             })
             .ToArray();
 
+        var fileIds = contains
+            .Where(x => x.Subject == repositoryId)
+            .Select(x => x.Object)
+            .Where(id => metadataById.TryGetValue(id, out var meta) && meta.IsType("file"))
+            .Distinct()
+            .OrderBy(id => metadataById[id].Path, StringComparer.Ordinal)
+            .ToArray();
+
+        var files = fileIds
+            .Select(fileId =>
+            {
+                var meta = metadataById[fileId];
+                return new FileNode(
+                    fileId,
+                    meta.Name,
+                    meta.Path,
+                    meta.FileKind,
+                    meta.IsSolutionMember);
+            })
+            .ToArray();
+
         var repository = new RepositoryNode(repositoryId, repoMeta.Name, repoMeta.Path);
-        return new ProjectStructureWikiModel(repository, solutions, projects, packages);
+        return new ProjectStructureWikiModel(repository, solutions, projects, packages, files);
     }
 
     private static Dictionary<EntityId, EntityMetadata> BuildEntityMetadata(IReadOnlyList<SemanticTriple> triples)
@@ -139,6 +160,14 @@ public sealed class ProjectStructureQueryService : IProjectStructureQueryService
             else if (triple.Predicate == CorePredicates.DiscoveryMethod)
             {
                 meta.DiscoveryMethod = value;
+            }
+            else if (triple.Predicate == CorePredicates.FileKind)
+            {
+                meta.FileKind = value;
+            }
+            else if (triple.Predicate == CorePredicates.IsSolutionMember)
+            {
+                meta.IsSolutionMember = bool.TryParse(value, out var parsed) && parsed;
             }
         }
 
@@ -217,6 +246,8 @@ public sealed class ProjectStructureQueryService : IProjectStructureQueryService
             Name = id.Value;
             Path = id.Value;
             DiscoveryMethod = string.Empty;
+            FileKind = string.Empty;
+            IsSolutionMember = false;
             EntityType = string.Empty;
         }
 
@@ -229,6 +260,10 @@ public sealed class ProjectStructureQueryService : IProjectStructureQueryService
         public string Path { get; set; }
 
         public string DiscoveryMethod { get; set; }
+
+        public string FileKind { get; set; }
+
+        public bool IsSolutionMember { get; set; }
 
         public bool IsType(string entityType) => EntityType.Equals(entityType, StringComparison.OrdinalIgnoreCase);
     }

--- a/src/CodeLlmWiki.Query/ProjectStructure/ProjectStructureWikiModel.cs
+++ b/src/CodeLlmWiki.Query/ProjectStructure/ProjectStructureWikiModel.cs
@@ -4,4 +4,5 @@ public sealed record ProjectStructureWikiModel(
     RepositoryNode Repository,
     IReadOnlyList<SolutionNode> Solutions,
     IReadOnlyList<ProjectNode> Projects,
-    IReadOnlyList<PackageNode> Packages);
+    IReadOnlyList<PackageNode> Packages,
+    IReadOnlyList<FileNode> Files);

--- a/src/CodeLlmWiki.Wiki/ProjectStructure/ProjectStructureWikiRenderer.cs
+++ b/src/CodeLlmWiki.Wiki/ProjectStructure/ProjectStructureWikiRenderer.cs
@@ -27,6 +27,10 @@ public sealed class ProjectStructureWikiRenderer : IProjectStructureWikiRenderer
             .OrderBy(x => x.Name, StringComparer.Ordinal)
             .Select(RenderPackagePage));
 
+        pages.AddRange(model.Files
+            .OrderBy(x => x.Path, StringComparer.Ordinal)
+            .Select(file => RenderFilePage(model.Repository.Id.Value, file)));
+
         return pages;
     }
 
@@ -39,6 +43,7 @@ public sealed class ProjectStructureWikiRenderer : IProjectStructureWikiRenderer
         sb.AppendLine($"- Solutions: {model.Solutions.Count}");
         sb.AppendLine($"- Projects: {model.Projects.Count}");
         sb.AppendLine($"- Packages: {model.Packages.Count}");
+        sb.AppendLine($"- Files: {model.Files.Count}");
         sb.AppendLine();
         sb.AppendLine("## Solutions");
 
@@ -50,7 +55,7 @@ public sealed class ProjectStructureWikiRenderer : IProjectStructureWikiRenderer
         return new WikiPage(
             RelativePath: $"repositories/{ToSlug(model.Repository.Id.Value)}.md",
             Title: model.Repository.Name,
-            Markdown: sb.ToString().TrimEnd());
+            Markdown: WithFrontMatter(model.Repository.Id.Value, "repository", model.Repository.Id.Value, sb.ToString().TrimEnd()));
     }
 
     private static WikiPage RenderSolutionPage(SolutionNode solution, IReadOnlyList<ProjectNode> projects)
@@ -76,7 +81,7 @@ public sealed class ProjectStructureWikiRenderer : IProjectStructureWikiRenderer
         return new WikiPage(
             RelativePath: $"solutions/{ToSlug(solution.Id.Value)}.md",
             Title: solution.Name,
-            Markdown: sb.ToString().TrimEnd());
+            Markdown: WithFrontMatter(solution.Id.Value, "solution", string.Empty, sb.ToString().TrimEnd()));
     }
 
     private static WikiPage RenderProjectPage(ProjectNode project, IReadOnlyDictionary<EntityId, PackageNode> packageById)
@@ -102,7 +107,7 @@ public sealed class ProjectStructureWikiRenderer : IProjectStructureWikiRenderer
         return new WikiPage(
             RelativePath: $"projects/{ToSlug(project.Id.Value)}.md",
             Title: project.Name,
-            Markdown: sb.ToString().TrimEnd());
+            Markdown: WithFrontMatter(project.Id.Value, "project", string.Empty, sb.ToString().TrimEnd()));
     }
 
     private static WikiPage RenderPackagePage(PackageNode package)
@@ -127,11 +132,44 @@ public sealed class ProjectStructureWikiRenderer : IProjectStructureWikiRenderer
         return new WikiPage(
             RelativePath: $"packages/{ToSlug(package.Id.Value)}.md",
             Title: package.Name,
-            Markdown: sb.ToString().TrimEnd());
+            Markdown: WithFrontMatter(package.Id.Value, "package", string.Empty, sb.ToString().TrimEnd()));
+    }
+
+    private static WikiPage RenderFilePage(string repositoryId, FileNode file)
+    {
+        var sb = new StringBuilder();
+        sb.AppendLine($"# File: {file.Name}");
+        sb.AppendLine();
+        sb.AppendLine($"- Path: `{file.Path}`");
+        sb.AppendLine($"- classification: {file.Classification}");
+        sb.AppendLine($"- is_solution_member: {file.IsSolutionMember.ToString().ToLowerInvariant()}");
+
+        return new WikiPage(
+            RelativePath: $"files/{ToSlug(file.Id.Value)}.md",
+            Title: file.Name,
+            Markdown: WithFrontMatter(file.Id.Value, "file", repositoryId, sb.ToString().TrimEnd()));
     }
 
     private static string ToSlug(string value)
     {
         return value.Replace(':', '-').Replace('/', '-');
+    }
+
+    private static string WithFrontMatter(string entityId, string entityType, string repositoryId, string body)
+    {
+        var sb = new StringBuilder();
+        sb.AppendLine("---");
+        sb.AppendLine($"entity_id: {entityId}");
+        sb.AppendLine($"entity_type: {entityType}");
+
+        if (!string.IsNullOrWhiteSpace(repositoryId))
+        {
+            sb.AppendLine($"repository_id: {repositoryId}");
+        }
+
+        sb.AppendLine("---");
+        sb.AppendLine();
+        sb.Append(body);
+        return sb.ToString();
     }
 }

--- a/tests/CodeLlmWiki.Ingestion.Tests/FileInventoryVerticalSliceTests.cs
+++ b/tests/CodeLlmWiki.Ingestion.Tests/FileInventoryVerticalSliceTests.cs
@@ -1,0 +1,143 @@
+using System.Diagnostics;
+using CodeLlmWiki.Contracts.Identity;
+using CodeLlmWiki.Ingestion.ProjectStructure;
+using CodeLlmWiki.Query.ProjectStructure;
+using CodeLlmWiki.Wiki.ProjectStructure;
+
+namespace CodeLlmWiki.Ingestion.Tests;
+
+public sealed class FileInventoryVerticalSliceTests
+{
+    [Fact]
+    public async Task AnalyzeAsync_RepresentsAllGitTrackedHeadFilesInGraph()
+    {
+        var fixture = await FileInventoryFixture.CreateAsync();
+        var analyzer = new ProjectStructureAnalyzer(new StableIdGenerator());
+        var analysis = await analyzer.AnalyzeAsync(fixture.RepositoryPath, CancellationToken.None);
+
+        var query = new ProjectStructureQueryService(analysis.Triples);
+        var model = query.GetModel(analysis.RepositoryId);
+
+        Assert.Equal(5, model.Files.Count);
+        Assert.Contains(model.Files, x => x.Path == "Sample.slnx");
+        Assert.Contains(model.Files, x => x.Path == "src/App/App.csproj");
+        Assert.Contains(model.Files, x => x.Path == "src/App/Program.cs");
+        Assert.Contains(model.Files, x => x.Path == "README.md");
+        Assert.Contains(model.Files, x => x.Path == "appsettings.json");
+    }
+
+    [Fact]
+    public async Task AnalyzeAsync_FileClassificationFactsAreQueryable()
+    {
+        var fixture = await FileInventoryFixture.CreateAsync();
+        var analyzer = new ProjectStructureAnalyzer(new StableIdGenerator());
+        var analysis = await analyzer.AnalyzeAsync(fixture.RepositoryPath, CancellationToken.None);
+        var query = new ProjectStructureQueryService(analysis.Triples);
+        var model = query.GetModel(analysis.RepositoryId);
+
+        var source = model.Files.Single(x => x.Path == "src/App/Program.cs");
+        Assert.Equal("dotnet-source", source.Classification);
+        Assert.True(source.IsSolutionMember);
+
+        var readme = model.Files.Single(x => x.Path == "README.md");
+        Assert.Equal("documentation", readme.Classification);
+        Assert.False(readme.IsSolutionMember);
+    }
+
+    [Fact]
+    public async Task Render_FilePagesAreMetadataOnlyWithMinimalFrontMatter()
+    {
+        var fixture = await FileInventoryFixture.CreateAsync();
+        var analyzer = new ProjectStructureAnalyzer(new StableIdGenerator());
+        var analysis = await analyzer.AnalyzeAsync(fixture.RepositoryPath, CancellationToken.None);
+        var query = new ProjectStructureQueryService(analysis.Triples);
+        var model = query.GetModel(analysis.RepositoryId);
+
+        var renderer = new ProjectStructureWikiRenderer();
+        var pages = renderer.Render(model);
+
+        var filePages = pages
+            .Where(x => x.RelativePath.StartsWith("files/", StringComparison.Ordinal))
+            .ToArray();
+
+        Assert.Equal(5, filePages.Length);
+
+        var programPage = filePages.Single(x => x.Markdown.Contains("src/App/Program.cs", StringComparison.Ordinal));
+        Assert.StartsWith("---", programPage.Markdown, StringComparison.Ordinal);
+        Assert.Contains("entity_type: file", programPage.Markdown, StringComparison.Ordinal);
+        Assert.Contains("classification: dotnet-source", programPage.Markdown, StringComparison.Ordinal);
+        Assert.DoesNotContain("HELLO FROM SOURCE", programPage.Markdown, StringComparison.Ordinal);
+    }
+
+    private sealed class FileInventoryFixture
+    {
+        private FileInventoryFixture(string repositoryPath)
+        {
+            RepositoryPath = repositoryPath;
+        }
+
+        public string RepositoryPath { get; }
+
+        public static async Task<FileInventoryFixture> CreateAsync()
+        {
+            var root = Path.Combine(Path.GetTempPath(), $"codellmwiki-files-{Guid.NewGuid():N}", "file-repo");
+            Directory.CreateDirectory(root);
+
+            await File.WriteAllTextAsync(Path.Combine(root, "Sample.slnx"),
+                """
+                <Solution>
+                  <Project Path="src/App/App.csproj" />
+                </Solution>
+                """);
+
+            var appDir = Path.Combine(root, "src", "App");
+            Directory.CreateDirectory(appDir);
+            await File.WriteAllTextAsync(Path.Combine(appDir, "App.csproj"),
+                """
+                <Project Sdk="Microsoft.NET.Sdk">
+                  <PropertyGroup>
+                    <TargetFramework>net10.0</TargetFramework>
+                  </PropertyGroup>
+                </Project>
+                """);
+
+            await File.WriteAllTextAsync(Path.Combine(appDir, "Program.cs"), "Console.WriteLine(\"HELLO FROM SOURCE\");");
+            await File.WriteAllTextAsync(Path.Combine(root, "README.md"), "# sample");
+            await File.WriteAllTextAsync(Path.Combine(root, "appsettings.json"), "{ \"Name\": \"Sample\" }");
+
+            RunGit(root, "init", "-b", "main");
+            RunGit(root, "config", "user.email", "test@example.com");
+            RunGit(root, "config", "user.name", "Test User");
+            RunGit(root, "add", ".");
+            RunGit(root, "commit", "-m", "initial");
+
+            return new FileInventoryFixture(root);
+        }
+
+        private static void RunGit(string workingDirectory, params string[] args)
+        {
+            var startInfo = new ProcessStartInfo
+            {
+                FileName = "git",
+                WorkingDirectory = workingDirectory,
+                RedirectStandardOutput = true,
+                RedirectStandardError = true,
+            };
+
+            foreach (var arg in args)
+            {
+                startInfo.ArgumentList.Add(arg);
+            }
+
+            using var process = Process.Start(startInfo)!;
+            process.WaitForExit();
+
+            if (process.ExitCode != 0)
+            {
+                var stdOut = process.StandardOutput.ReadToEnd();
+                var stdErr = process.StandardError.ReadToEnd();
+                throw new InvalidOperationException($"git {string.Join(' ', args)} failed: {stdOut}\n{stdErr}");
+            }
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- ingests all git-tracked `HEAD` files into semantic triples
- adds file classification and solution-membership facts (`core:fileKind`, `core:isSolutionMember`)
- extends query model with file nodes and queryable file metadata
- extends wiki rendering with metadata-first file pages (no source excerpts)
- adds minimal front matter on generated pages while keeping richer detail in body sections

## Validation
- `dotnet build CodeLlmWiki.slnx -v minimal`
- `dotnet test CodeLlmWiki.slnx -v minimal`
- `dotnet run --project src/CodeLlmWiki.Cli -- ingest --path . --allow-partial-success true`

Closes #5
