### PR TITLE
Phase 6: Deterministic Wiki + GraphML Publication (#7)

### DIFF
--- a/src/CodeLlmWiki.Cli/CliApplication.cs
+++ b/src/CodeLlmWiki.Cli/CliApplication.cs
@@ -1,6 +1,7 @@
 using System.Text.Json;
 using CodeLlmWiki.Cli.Commands;
 using CodeLlmWiki.Cli.Config;
+using CodeLlmWiki.Cli.Features.Ingest;
 using CodeLlmWiki.Ingestion;
 using CommandLine;
 
@@ -9,11 +10,17 @@ namespace CodeLlmWiki.Cli;
 public sealed class CliApplication
 {
     private const string DefaultOntologyPath = "ontology/ontology.v1.yaml";
-    private readonly IIngestionRunner _runner;
+    private const string DefaultOutputRoot = "artifacts";
 
-    public CliApplication(IIngestionRunner runner)
+    private readonly IIngestionRunner _runner;
+    private readonly IIngestionArtifactPublisher _artifactPublisher;
+
+    public CliApplication(
+        IIngestionRunner runner,
+        IIngestionArtifactPublisher? artifactPublisher = null)
     {
         _runner = runner;
+        _artifactPublisher = artifactPublisher ?? NoOpIngestionArtifactPublisher.Instance;
     }
 
     public Task<int> RunAsync(string[] args, CancellationToken cancellationToken)
@@ -42,13 +49,33 @@ public sealed class CliApplication
             ?? config.OntologyPath
             ?? DefaultOntologyPath;
 
+        var outputRoot = options.OutputRoot
+            ?? config.OutputRoot
+            ?? DefaultOutputRoot;
+
         var request = new IngestionRunRequest(
             RepositoryPath: options.RepositoryPath,
             ConfigPath: options.ConfigPath,
             OntologyPath: ontologyPath,
             AllowPartialSuccess: allowPartial);
 
+        var startedAtUtc = DateTimeOffset.UtcNow;
         var result = await _runner.RunAsync(request, cancellationToken);
+        var completedAtUtc = DateTimeOffset.UtcNow;
+
+        var publication = await _artifactPublisher.PublishAsync(
+            new IngestionArtifactPublishRequest(
+                RepositoryPath: options.RepositoryPath,
+                OutputRootPath: outputRoot,
+                StartedAtUtc: startedAtUtc,
+                CompletedAtUtc: completedAtUtc,
+                RunResult: result),
+            cancellationToken);
+
+        if (!publication.Succeeded)
+        {
+            return 1;
+        }
 
         return result.ExitCode;
     }

--- a/src/CodeLlmWiki.Cli/CodeLlmWiki.Cli.csproj
+++ b/src/CodeLlmWiki.Cli/CodeLlmWiki.Cli.csproj
@@ -2,6 +2,8 @@
 
   <ItemGroup>
     <ProjectReference Include="..\CodeLlmWiki.Ingestion\CodeLlmWiki.Ingestion.csproj" />
+    <ProjectReference Include="..\CodeLlmWiki.Query\CodeLlmWiki.Query.csproj" />
+    <ProjectReference Include="..\CodeLlmWiki.Wiki\CodeLlmWiki.Wiki.csproj" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/CodeLlmWiki.Cli/Commands/IngestOptions.cs
+++ b/src/CodeLlmWiki.Cli/Commands/IngestOptions.cs
@@ -14,6 +14,9 @@ public sealed class IngestOptions
     [Option('o', "ontology", Required = false, HelpText = "Path to ontology yaml file.")]
     public string? OntologyPath { get; init; }
 
+    [Option('r', "output-root", Required = false, HelpText = "Directory for run-scoped generated artifacts.")]
+    public string? OutputRoot { get; init; }
+
     [Option('a', "allow-partial-success", Required = false, HelpText = "Overrides partial-success exit policy.")]
     public string? AllowPartialSuccess { get; init; }
 }

--- a/src/CodeLlmWiki.Cli/Config/IngestionCliConfig.cs
+++ b/src/CodeLlmWiki.Cli/Config/IngestionCliConfig.cs
@@ -1,6 +1,9 @@
 namespace CodeLlmWiki.Cli.Config;
 
-public sealed record IngestionCliConfig(string? OntologyPath, bool? AllowPartialSuccess)
+public sealed record IngestionCliConfig(
+    string? OntologyPath,
+    bool? AllowPartialSuccess,
+    string? OutputRoot)
 {
-    public static readonly IngestionCliConfig Empty = new(null, null);
+    public static readonly IngestionCliConfig Empty = new(null, null, null);
 }

--- a/src/CodeLlmWiki.Cli/Features/Ingest/GraphMlSerializer.cs
+++ b/src/CodeLlmWiki.Cli/Features/Ingest/GraphMlSerializer.cs
@@ -1,0 +1,142 @@
+using System.Security.Cryptography;
+using System.Text;
+using System.Xml.Linq;
+using CodeLlmWiki.Contracts.Graph;
+
+namespace CodeLlmWiki.Cli.Features.Ingest;
+
+public static class GraphMlSerializer
+{
+    public static GraphMlSerializationResult Serialize(IReadOnlyList<SemanticTriple> triples)
+    {
+        var nodes = BuildNodes(triples);
+        var nodeIdByKey = nodes
+            .OrderBy(x => x.Key, StringComparer.Ordinal)
+            .Select((node, index) => new { node.Key, NodeId = $"n{index + 1:D6}" })
+            .ToDictionary(x => x.Key, x => x.NodeId, StringComparer.Ordinal);
+
+        var edgeRecords = triples
+            .Select((triple, index) => new
+            {
+                Index = index,
+                SubjectKey = ToNodeKey(triple.Subject),
+                Predicate = triple.Predicate.Value,
+                ObjectKey = ToNodeKey(triple.Object),
+            })
+            .OrderBy(x => x.SubjectKey, StringComparer.Ordinal)
+            .ThenBy(x => x.Predicate, StringComparer.Ordinal)
+            .ThenBy(x => x.ObjectKey, StringComparer.Ordinal)
+            .ThenBy(x => x.Index)
+            .ToArray();
+
+        XNamespace ns = "http://graphml.graphdrawing.org/xmlns";
+
+        var graphElement = new XElement(ns + "graph", new XAttribute("edgedefault", "directed"));
+
+        foreach (var node in nodes.OrderBy(x => x.Key, StringComparer.Ordinal))
+        {
+            graphElement.Add(new XElement(
+                ns + "node",
+                new XAttribute("id", nodeIdByKey[node.Key]),
+                new XElement(ns + "data", new XAttribute("key", "d0"), node.Kind),
+                new XElement(ns + "data", new XAttribute("key", "d1"), node.Label)));
+        }
+
+        foreach (var edge in edgeRecords.Select((value, index) => new { value, index }))
+        {
+            graphElement.Add(new XElement(
+                ns + "edge",
+                new XAttribute("id", $"e{edge.index + 1:D6}"),
+                new XAttribute("source", nodeIdByKey[edge.value.SubjectKey]),
+                new XAttribute("target", nodeIdByKey[edge.value.ObjectKey]),
+                new XElement(ns + "data", new XAttribute("key", "d2"), edge.value.Predicate)));
+        }
+
+        var document = new XDocument(
+            new XElement(
+                ns + "graphml",
+                new XElement(
+                    ns + "key",
+                    new XAttribute("id", "d0"),
+                    new XAttribute("for", "node"),
+                    new XAttribute("attr.name", "kind"),
+                    new XAttribute("attr.type", "string")),
+                new XElement(
+                    ns + "key",
+                    new XAttribute("id", "d1"),
+                    new XAttribute("for", "node"),
+                    new XAttribute("attr.name", "label"),
+                    new XAttribute("attr.type", "string")),
+                new XElement(
+                    ns + "key",
+                    new XAttribute("id", "d2"),
+                    new XAttribute("for", "edge"),
+                    new XAttribute("attr.name", "predicate"),
+                    new XAttribute("attr.type", "string")),
+                graphElement));
+
+        return new GraphMlSerializationResult(
+            document.ToString(SaveOptions.DisableFormatting),
+            nodes.Count,
+            edgeRecords.Length);
+    }
+
+    private static IReadOnlyList<GraphMlNode> BuildNodes(IReadOnlyList<SemanticTriple> triples)
+    {
+        var byKey = new Dictionary<string, GraphMlNode>(StringComparer.Ordinal);
+
+        foreach (var triple in triples)
+        {
+            var subjectNode = ToNode(triple.Subject);
+            if (!byKey.ContainsKey(subjectNode.Key))
+            {
+                byKey[subjectNode.Key] = subjectNode;
+            }
+
+            var objectNode = ToNode(triple.Object);
+            if (!byKey.ContainsKey(objectNode.Key))
+            {
+                byKey[objectNode.Key] = objectNode;
+            }
+        }
+
+        return byKey.Values.ToArray();
+    }
+
+    private static GraphMlNode ToNode(GraphNode node)
+    {
+        return node switch
+        {
+            EntityNode entity => new GraphMlNode(
+                Key: ToNodeKey(node),
+                Kind: "entity",
+                Label: entity.Id.Value),
+            LiteralNode literal => new GraphMlNode(
+                Key: ToNodeKey(node),
+                Kind: "literal",
+                Label: literal.Value?.ToString() ?? string.Empty),
+            _ => new GraphMlNode(
+                Key: ToNodeKey(node),
+                Kind: "unknown",
+                Label: node.ToString() ?? string.Empty),
+        };
+    }
+
+    private static string ToNodeKey(GraphNode node)
+    {
+        return node switch
+        {
+            EntityNode entity => $"entity:{entity.Id.Value}",
+            LiteralNode literal => "literal:" + Convert.ToHexString(
+                SHA256.HashData(Encoding.UTF8.GetBytes(literal.Value?.ToString() ?? string.Empty))),
+            _ => $"unknown:{node}",
+        };
+    }
+
+    private sealed record GraphMlNode(string Key, string Kind, string Label);
+}
+
+public sealed record GraphMlSerializationResult(
+    string GraphMl,
+    int NodeCount,
+    int EdgeCount);

--- a/src/CodeLlmWiki.Cli/Features/Ingest/IIngestionArtifactPublisher.cs
+++ b/src/CodeLlmWiki.Cli/Features/Ingest/IIngestionArtifactPublisher.cs
@@ -1,0 +1,8 @@
+using CodeLlmWiki.Ingestion;
+
+namespace CodeLlmWiki.Cli.Features.Ingest;
+
+public interface IIngestionArtifactPublisher
+{
+    Task<IngestionArtifactPublishResult> PublishAsync(IngestionArtifactPublishRequest request, CancellationToken cancellationToken);
+}

--- a/src/CodeLlmWiki.Cli/Features/Ingest/IngestionArtifactPublishRequest.cs
+++ b/src/CodeLlmWiki.Cli/Features/Ingest/IngestionArtifactPublishRequest.cs
@@ -1,0 +1,10 @@
+using CodeLlmWiki.Ingestion;
+
+namespace CodeLlmWiki.Cli.Features.Ingest;
+
+public sealed record IngestionArtifactPublishRequest(
+    string RepositoryPath,
+    string OutputRootPath,
+    DateTimeOffset StartedAtUtc,
+    DateTimeOffset CompletedAtUtc,
+    IngestionRunResult RunResult);

--- a/src/CodeLlmWiki.Cli/Features/Ingest/IngestionArtifactPublishResult.cs
+++ b/src/CodeLlmWiki.Cli/Features/Ingest/IngestionArtifactPublishResult.cs
@@ -1,0 +1,11 @@
+namespace CodeLlmWiki.Cli.Features.Ingest;
+
+public sealed record IngestionArtifactPublishResult(
+    bool Succeeded,
+    bool LatestPromoted,
+    string RunId,
+    string RunDirectory,
+    string ManifestPath,
+    string? WikiDirectory,
+    string? GraphMlPath,
+    string? FailureReason);

--- a/src/CodeLlmWiki.Cli/Features/Ingest/IngestionArtifactPublisher.cs
+++ b/src/CodeLlmWiki.Cli/Features/Ingest/IngestionArtifactPublisher.cs
@@ -50,16 +50,13 @@ public sealed class IngestionArtifactPublisher : IIngestionArtifactPublisher
                 WriteWikiPages(wikiDirectory, pages);
             }
 
-            if (request.RunResult.Triples.Count > 0)
-            {
-                var graph = GraphMlSerializer.Serialize(request.RunResult.Triples);
-                graphNodeCount = graph.NodeCount;
-                graphEdgeCount = graph.EdgeCount;
+            var graph = GraphMlSerializer.Serialize(request.RunResult.Triples);
+            graphNodeCount = graph.NodeCount;
+            graphEdgeCount = graph.EdgeCount;
 
-                graphMlPath = Path.Combine(runDirectory, "graph", "graph.graphml");
-                Directory.CreateDirectory(Path.GetDirectoryName(graphMlPath)!);
-                await File.WriteAllTextAsync(graphMlPath, graph.GraphMl, cancellationToken);
-            }
+            graphMlPath = Path.Combine(runDirectory, "graph", "graph.graphml");
+            Directory.CreateDirectory(Path.GetDirectoryName(graphMlPath)!);
+            await File.WriteAllTextAsync(graphMlPath, graph.GraphMl, cancellationToken);
 
             var shouldPromoteLatest = request.RunResult.Status != IngestionRunStatus.Failed;
             var manifest = BuildManifest(

--- a/src/CodeLlmWiki.Cli/Features/Ingest/IngestionArtifactPublisher.cs
+++ b/src/CodeLlmWiki.Cli/Features/Ingest/IngestionArtifactPublisher.cs
@@ -1,0 +1,285 @@
+using System.Text.Json;
+using System.Text.Json.Serialization;
+using CodeLlmWiki.Contracts.Graph;
+using CodeLlmWiki.Contracts.Identity;
+using CodeLlmWiki.Ingestion;
+using CodeLlmWiki.Query.ProjectStructure;
+using CodeLlmWiki.Wiki.ProjectStructure;
+
+namespace CodeLlmWiki.Cli.Features.Ingest;
+
+public sealed class IngestionArtifactPublisher : IIngestionArtifactPublisher
+{
+    private static readonly JsonSerializerOptions JsonOptions = new()
+    {
+        WriteIndented = true,
+        DefaultIgnoreCondition = JsonIgnoreCondition.WhenWritingNull,
+    };
+
+    public async Task<IngestionArtifactPublishResult> PublishAsync(
+        IngestionArtifactPublishRequest request,
+        CancellationToken cancellationToken)
+    {
+        var runId = request.CompletedAtUtc.UtcDateTime.ToString("yyyyMMddTHHmmssfffZ");
+        var outputRoot = Path.GetFullPath(request.OutputRootPath);
+        var runsRoot = Path.Combine(outputRoot, "runs");
+        var runDirectory = Path.Combine(runsRoot, runId);
+        var manifestPath = Path.Combine(runDirectory, "manifest.json");
+
+        Directory.CreateDirectory(runDirectory);
+
+        string? wikiDirectory = null;
+        string? graphMlPath = null;
+        var wikiPageCount = 0;
+        var graphNodeCount = 0;
+        var graphEdgeCount = 0;
+
+        try
+        {
+            if (request.RunResult.RepositoryId != default && request.RunResult.Triples.Count > 0)
+            {
+                var query = new ProjectStructureQueryService(request.RunResult.Triples);
+                var model = query.GetModel(request.RunResult.RepositoryId);
+                var renderer = new ProjectStructureWikiRenderer();
+                var pages = renderer.Render(model)
+                    .OrderBy(x => x.RelativePath, StringComparer.Ordinal)
+                    .ToArray();
+
+                wikiPageCount = pages.Length;
+                wikiDirectory = Path.Combine(runDirectory, "wiki");
+                WriteWikiPages(wikiDirectory, pages);
+            }
+
+            if (request.RunResult.Triples.Count > 0)
+            {
+                var graph = GraphMlSerializer.Serialize(request.RunResult.Triples);
+                graphNodeCount = graph.NodeCount;
+                graphEdgeCount = graph.EdgeCount;
+
+                graphMlPath = Path.Combine(runDirectory, "graph", "graph.graphml");
+                Directory.CreateDirectory(Path.GetDirectoryName(graphMlPath)!);
+                await File.WriteAllTextAsync(graphMlPath, graph.GraphMl, cancellationToken);
+            }
+
+            var shouldPromoteLatest = request.RunResult.Status != IngestionRunStatus.Failed;
+            var manifest = BuildManifest(
+                request,
+                runId,
+                latestPromoted: false,
+                wikiPageCount,
+                graphNodeCount,
+                graphEdgeCount,
+                wikiDirectory,
+                graphMlPath);
+
+            await WriteManifestAsync(manifestPath, manifest, cancellationToken);
+
+            var latestPromoted = false;
+            if (shouldPromoteLatest)
+            {
+                PromoteLatest(outputRoot, runDirectory);
+                latestPromoted = true;
+
+                manifest = manifest with { LatestPromoted = true };
+                await WriteManifestAsync(manifestPath, manifest, cancellationToken);
+                var latestManifestPath = Path.Combine(outputRoot, "latest", "manifest.json");
+                await WriteManifestAsync(latestManifestPath, manifest, cancellationToken);
+            }
+
+            return new IngestionArtifactPublishResult(
+                Succeeded: true,
+                LatestPromoted: latestPromoted,
+                RunId: runId,
+                RunDirectory: runDirectory,
+                ManifestPath: manifestPath,
+                WikiDirectory: wikiDirectory,
+                GraphMlPath: graphMlPath,
+                FailureReason: null);
+        }
+        catch (Exception ex)
+        {
+            return new IngestionArtifactPublishResult(
+                Succeeded: false,
+                LatestPromoted: false,
+                RunId: runId,
+                RunDirectory: runDirectory,
+                ManifestPath: manifestPath,
+                WikiDirectory: wikiDirectory,
+                GraphMlPath: graphMlPath,
+                FailureReason: ex.Message);
+        }
+    }
+
+    private static RunManifest BuildManifest(
+        IngestionArtifactPublishRequest request,
+        string runId,
+        bool latestPromoted,
+        int wikiPageCount,
+        int graphNodeCount,
+        int graphEdgeCount,
+        string? wikiDirectory,
+        string? graphMlPath)
+    {
+        var duration = request.CompletedAtUtc - request.StartedAtUtc;
+
+        var diagnosticsSummary = request.RunResult.Diagnostics
+            .GroupBy(x => x.Code, StringComparer.Ordinal)
+            .OrderBy(x => x.Key, StringComparer.Ordinal)
+            .Select(x => new DiagnosticSummary(x.Key, x.Count()))
+            .ToArray();
+
+        var headBranch = GetRepositoryBranch(request.RunResult.Triples, request.RunResult.RepositoryId, CorePredicates.HeadBranch);
+        var mainlineBranch = GetRepositoryBranch(request.RunResult.Triples, request.RunResult.RepositoryId, CorePredicates.MainlineBranch);
+
+        return new RunManifest(
+            RunId: runId,
+            Status: request.RunResult.Status.ToString(),
+            ExitCode: request.RunResult.ExitCode,
+            StartedAtUtc: request.StartedAtUtc,
+            CompletedAtUtc: request.CompletedAtUtc,
+            DurationMs: Math.Max(0, (long)duration.TotalMilliseconds),
+            RepositoryPath: Path.GetFullPath(request.RepositoryPath),
+            HeadBranch: headBranch,
+            MainlineBranch: mainlineBranch,
+            TripleCount: request.RunResult.Triples.Count,
+            DiagnosticCount: request.RunResult.Diagnostics.Count,
+            WikiPageCount: wikiPageCount,
+            GraphMlNodeCount: graphNodeCount,
+            GraphMlEdgeCount: graphEdgeCount,
+            DiagnosticsSummary: diagnosticsSummary,
+            Artifacts: new ArtifactReferences(
+                Wiki: wikiDirectory is null ? null : "wiki",
+                GraphMl: graphMlPath is null ? null : "graph/graph.graphml",
+                Manifest: "manifest.json"),
+            LatestPromoted: latestPromoted);
+    }
+
+    private static string GetRepositoryBranch(
+        IReadOnlyList<SemanticTriple> triples,
+        EntityId repositoryId,
+        PredicateId predicate)
+    {
+        var value = triples
+            .Where(x => x.Predicate == predicate)
+            .Where(x => x.Subject is EntityNode entity && entity.Id == repositoryId)
+            .Select(x => x.Object as LiteralNode)
+            .Where(x => x is not null)
+            .Select(x => x!.Value?.ToString())
+            .FirstOrDefault();
+
+        return string.IsNullOrWhiteSpace(value) ? "unknown" : value;
+    }
+
+    private static async Task WriteManifestAsync(
+        string manifestPath,
+        RunManifest manifest,
+        CancellationToken cancellationToken)
+    {
+        Directory.CreateDirectory(Path.GetDirectoryName(manifestPath)!);
+        var json = JsonSerializer.Serialize(manifest, JsonOptions);
+        await File.WriteAllTextAsync(manifestPath, json + Environment.NewLine, cancellationToken);
+    }
+
+    private static void WriteWikiPages(string wikiRoot, IReadOnlyList<WikiPage> pages)
+    {
+        Directory.CreateDirectory(wikiRoot);
+
+        foreach (var page in pages)
+        {
+            var fullPath = Path.Combine(wikiRoot, page.RelativePath.Replace('/', Path.DirectorySeparatorChar));
+            var parent = Path.GetDirectoryName(fullPath);
+            if (!string.IsNullOrWhiteSpace(parent))
+            {
+                Directory.CreateDirectory(parent);
+            }
+
+            File.WriteAllText(fullPath, page.Markdown + Environment.NewLine);
+        }
+    }
+
+    private static void PromoteLatest(string outputRoot, string runDirectory)
+    {
+        var latestPath = Path.Combine(outputRoot, "latest");
+        var stagingPath = Path.Combine(outputRoot, $".latest-staging-{Guid.NewGuid():N}");
+        var backupPath = Path.Combine(outputRoot, $".latest-backup-{Guid.NewGuid():N}");
+
+        CopyDirectory(runDirectory, stagingPath);
+
+        var hadLatest = Directory.Exists(latestPath);
+
+        if (hadLatest)
+        {
+            Directory.Move(latestPath, backupPath);
+        }
+
+        try
+        {
+            Directory.Move(stagingPath, latestPath);
+            if (hadLatest && Directory.Exists(backupPath))
+            {
+                Directory.Delete(backupPath, recursive: true);
+            }
+        }
+        catch
+        {
+            if (Directory.Exists(stagingPath))
+            {
+                Directory.Delete(stagingPath, recursive: true);
+            }
+
+            if (hadLatest && Directory.Exists(backupPath) && !Directory.Exists(latestPath))
+            {
+                Directory.Move(backupPath, latestPath);
+            }
+
+            throw;
+        }
+    }
+
+    private static void CopyDirectory(string source, string destination)
+    {
+        Directory.CreateDirectory(destination);
+
+        foreach (var directory in Directory.GetDirectories(source, "*", SearchOption.AllDirectories))
+        {
+            var relative = Path.GetRelativePath(source, directory);
+            Directory.CreateDirectory(Path.Combine(destination, relative));
+        }
+
+        foreach (var file in Directory.GetFiles(source, "*", SearchOption.AllDirectories))
+        {
+            var relative = Path.GetRelativePath(source, file);
+            var targetFile = Path.Combine(destination, relative);
+            var targetDirectory = Path.GetDirectoryName(targetFile);
+            if (!string.IsNullOrWhiteSpace(targetDirectory))
+            {
+                Directory.CreateDirectory(targetDirectory);
+            }
+
+            File.Copy(file, targetFile, overwrite: true);
+        }
+    }
+
+    private sealed record RunManifest(
+        string RunId,
+        string Status,
+        int ExitCode,
+        DateTimeOffset StartedAtUtc,
+        DateTimeOffset CompletedAtUtc,
+        long DurationMs,
+        string RepositoryPath,
+        string HeadBranch,
+        string MainlineBranch,
+        int TripleCount,
+        int DiagnosticCount,
+        int WikiPageCount,
+        int GraphMlNodeCount,
+        int GraphMlEdgeCount,
+        IReadOnlyList<DiagnosticSummary> DiagnosticsSummary,
+        ArtifactReferences Artifacts,
+        bool LatestPromoted);
+
+    private sealed record ArtifactReferences(string? Wiki, string? GraphMl, string Manifest);
+
+    private sealed record DiagnosticSummary(string Code, int Count);
+}

--- a/src/CodeLlmWiki.Cli/Features/Ingest/NoOpIngestionArtifactPublisher.cs
+++ b/src/CodeLlmWiki.Cli/Features/Ingest/NoOpIngestionArtifactPublisher.cs
@@ -1,0 +1,23 @@
+namespace CodeLlmWiki.Cli.Features.Ingest;
+
+public sealed class NoOpIngestionArtifactPublisher : IIngestionArtifactPublisher
+{
+    public static readonly NoOpIngestionArtifactPublisher Instance = new();
+
+    private NoOpIngestionArtifactPublisher()
+    {
+    }
+
+    public Task<IngestionArtifactPublishResult> PublishAsync(IngestionArtifactPublishRequest request, CancellationToken cancellationToken)
+    {
+        return Task.FromResult(new IngestionArtifactPublishResult(
+            Succeeded: true,
+            LatestPromoted: false,
+            RunId: string.Empty,
+            RunDirectory: string.Empty,
+            ManifestPath: string.Empty,
+            WikiDirectory: null,
+            GraphMlPath: null,
+            FailureReason: null));
+    }
+}

--- a/src/CodeLlmWiki.Cli/Program.cs
+++ b/src/CodeLlmWiki.Cli/Program.cs
@@ -1,4 +1,5 @@
 using CodeLlmWiki.Cli;
+using CodeLlmWiki.Cli.Features.Ingest;
 using CodeLlmWiki.Contracts.Identity;
 using CodeLlmWiki.Ingestion;
 using CodeLlmWiki.Ingestion.ProjectStructure;
@@ -7,7 +8,8 @@ using CodeLlmWiki.Ontology;
 var analyzer = new ProjectStructureAnalyzer(new StableIdGenerator());
 var pipeline = new ProjectStructureIngestionPipeline(analyzer);
 var runner = new IngestionRunner(new OntologyLoader(), pipeline);
-var app = new CliApplication(runner);
+var artifactPublisher = new IngestionArtifactPublisher();
+var app = new CliApplication(runner, artifactPublisher);
 var exitCode = await app.RunAsync(args, CancellationToken.None);
 
 Environment.Exit(exitCode);

--- a/src/CodeLlmWiki.Ingestion/IngestionRunResult.cs
+++ b/src/CodeLlmWiki.Ingestion/IngestionRunResult.cs
@@ -1,4 +1,5 @@
 using CodeLlmWiki.Contracts.Graph;
+using CodeLlmWiki.Contracts.Identity;
 
 namespace CodeLlmWiki.Ingestion;
 
@@ -6,4 +7,5 @@ public sealed record IngestionRunResult(
     IngestionRunStatus Status,
     int ExitCode,
     IReadOnlyList<IngestionDiagnostic> Diagnostics,
+    EntityId RepositoryId,
     IReadOnlyList<SemanticTriple> Triples);

--- a/src/CodeLlmWiki.Ingestion/IngestionRunner.cs
+++ b/src/CodeLlmWiki.Ingestion/IngestionRunner.cs
@@ -25,7 +25,7 @@ public sealed class IngestionRunner : IIngestionRunner
         if (!ontology.IsValid || ontology.Definition is null)
         {
             var errors = ontology.Issues.Select(x => new IngestionDiagnostic(x.Code, x.Message)).ToArray();
-            return new IngestionRunResult(IngestionRunStatus.Failed, 1, errors, []);
+            return new IngestionRunResult(IngestionRunStatus.Failed, 1, errors, default, []);
         }
 
         var fullRepositoryPath = Path.GetFullPath(request.RepositoryPath);
@@ -47,6 +47,6 @@ public sealed class IngestionRunner : IIngestionRunner
             _ => 1,
         };
 
-        return new IngestionRunResult(status, exitCode, diagnostics, pipelineResult.Triples);
+        return new IngestionRunResult(status, exitCode, diagnostics, repositoryId, pipelineResult.Triples);
     }
 }

--- a/tests/CodeLlmWiki.Cli.Tests/CliApplicationTests.cs
+++ b/tests/CodeLlmWiki.Cli.Tests/CliApplicationTests.cs
@@ -1,4 +1,6 @@
 using CodeLlmWiki.Cli;
+using CodeLlmWiki.Cli.Features.Ingest;
+using CodeLlmWiki.Contracts.Identity;
 using CodeLlmWiki.Ingestion;
 
 namespace CodeLlmWiki.Cli.Tests;
@@ -42,6 +44,7 @@ public sealed class CliApplicationTests
                 IngestionRunStatus.SucceededWithDiagnostics,
                 2,
                 [new IngestionDiagnostic("warn:0001", "warning")],
+                new StableIdGenerator().Create(new EntityKey("repository", ".")),
                 []),
         };
 
@@ -52,6 +55,35 @@ public sealed class CliApplicationTests
 
         Assert.Equal(2, first);
         Assert.Equal(2, second);
+    }
+
+    [Fact]
+    public async Task RunAsync_PassesOutputRootOptionOverrideToPublisher()
+    {
+        var configPath = WriteTempFile(
+            """
+            {
+              "ontologyPath": "./ontology/ontology.v1.yaml",
+              "outputRoot": "./from-config"
+            }
+            """);
+
+        var runner = new CapturingRunner();
+        var publisher = new CapturingPublisher();
+        var app = new CliApplication(runner, publisher);
+
+        var exitCode = await app.RunAsync(
+            [
+                "ingest",
+                "--path", ".",
+                "--config", configPath,
+                "--output-root", "./from-option",
+            ],
+            CancellationToken.None);
+
+        Assert.Equal(0, exitCode);
+        Assert.NotNull(publisher.LastRequest);
+        Assert.Equal("./from-option", publisher.LastRequest!.OutputRootPath);
     }
 
     private static string WriteTempFile(string content)
@@ -69,12 +101,32 @@ public sealed class CliApplicationTests
             IngestionRunStatus.Succeeded,
             0,
             [],
+            new StableIdGenerator().Create(new EntityKey("repository", ".")),
             []);
 
         public Task<IngestionRunResult> RunAsync(IngestionRunRequest request, CancellationToken cancellationToken)
         {
             LastRequest = request;
             return Task.FromResult(NextResult);
+        }
+    }
+
+    private sealed class CapturingPublisher : IIngestionArtifactPublisher
+    {
+        public IngestionArtifactPublishRequest? LastRequest { get; private set; }
+
+        public Task<IngestionArtifactPublishResult> PublishAsync(IngestionArtifactPublishRequest request, CancellationToken cancellationToken)
+        {
+            LastRequest = request;
+            return Task.FromResult(new IngestionArtifactPublishResult(
+                Succeeded: true,
+                LatestPromoted: false,
+                RunId: "run",
+                RunDirectory: "run",
+                ManifestPath: "manifest",
+                WikiDirectory: null,
+                GraphMlPath: null,
+                FailureReason: null));
         }
     }
 }

--- a/tests/CodeLlmWiki.Cli.Tests/IngestionArtifactPublisherTests.cs
+++ b/tests/CodeLlmWiki.Cli.Tests/IngestionArtifactPublisherTests.cs
@@ -113,6 +113,7 @@ public sealed class IngestionArtifactPublisherTests
         Assert.False(result.LatestPromoted);
         Assert.True(File.Exists(markerPath));
         Assert.True(File.Exists(result.ManifestPath));
+        Assert.True(File.Exists(Path.Combine(result.RunDirectory, "graph", "graph.graphml")));
     }
 
     private static int CountOccurrences(string value, string token)

--- a/tests/CodeLlmWiki.Cli.Tests/IngestionArtifactPublisherTests.cs
+++ b/tests/CodeLlmWiki.Cli.Tests/IngestionArtifactPublisherTests.cs
@@ -1,0 +1,238 @@
+using System.Diagnostics;
+using System.Text.Json;
+using CodeLlmWiki.Cli.Features.Ingest;
+using CodeLlmWiki.Contracts.Identity;
+using CodeLlmWiki.Ingestion;
+using CodeLlmWiki.Ingestion.ProjectStructure;
+
+namespace CodeLlmWiki.Cli.Tests;
+
+public sealed class IngestionArtifactPublisherTests
+{
+    [Fact]
+    public async Task PublishAsync_EmitsDeterministicWikiAndGraphMl_RunManifest_AndPromotesLatestOnSuccess()
+    {
+        var fixture = await PublisherFixture.CreateAsync();
+        var analyzer = new ProjectStructureAnalyzer(new StableIdGenerator());
+        var analysis = await analyzer.AnalyzeAsync(fixture.RepositoryPath, CancellationToken.None);
+
+        var runResult = new IngestionRunResult(
+            Status: IngestionRunStatus.SucceededWithDiagnostics,
+            ExitCode: 0,
+            Diagnostics: analysis.Diagnostics,
+            RepositoryId: analysis.RepositoryId,
+            Triples: analysis.Triples);
+
+        var outputRoot = Path.Combine(Path.GetTempPath(), $"codellmwiki-artifacts-{Guid.NewGuid():N}");
+        Directory.CreateDirectory(Path.Combine(outputRoot, "latest"));
+        await File.WriteAllTextAsync(Path.Combine(outputRoot, "latest", "stale.txt"), "stale");
+
+        var publisher = new IngestionArtifactPublisher();
+
+        var first = await publisher.PublishAsync(
+            new IngestionArtifactPublishRequest(
+                RepositoryPath: fixture.RepositoryPath,
+                OutputRootPath: outputRoot,
+                StartedAtUtc: new DateTimeOffset(2026, 1, 1, 0, 0, 0, TimeSpan.Zero),
+                CompletedAtUtc: new DateTimeOffset(2026, 1, 1, 0, 1, 0, TimeSpan.Zero),
+                RunResult: runResult),
+            CancellationToken.None);
+
+        var second = await publisher.PublishAsync(
+            new IngestionArtifactPublishRequest(
+                RepositoryPath: fixture.RepositoryPath,
+                OutputRootPath: outputRoot,
+                StartedAtUtc: new DateTimeOffset(2026, 1, 1, 0, 2, 0, TimeSpan.Zero),
+                CompletedAtUtc: new DateTimeOffset(2026, 1, 1, 0, 3, 0, TimeSpan.Zero),
+                RunResult: runResult),
+            CancellationToken.None);
+
+        Assert.True(first.Succeeded);
+        Assert.True(first.LatestPromoted);
+        Assert.True(second.Succeeded);
+        Assert.True(second.LatestPromoted);
+        Assert.False(File.Exists(Path.Combine(outputRoot, "latest", "stale.txt")));
+
+        Assert.Contains(Directory.GetFiles(Path.Combine(first.RunDirectory, "wiki", "repositories"), "*.md"), _ => true);
+        Assert.Contains(Directory.GetFiles(Path.Combine(first.RunDirectory, "wiki", "solutions"), "*.md"), _ => true);
+        Assert.Contains(Directory.GetFiles(Path.Combine(first.RunDirectory, "wiki", "projects"), "*.md"), _ => true);
+        Assert.Contains(Directory.GetFiles(Path.Combine(first.RunDirectory, "wiki", "packages"), "*.md"), _ => true);
+        Assert.Contains(Directory.GetFiles(Path.Combine(first.RunDirectory, "wiki", "files"), "*.md"), _ => true);
+
+        var graphMl = await File.ReadAllTextAsync(Path.Combine(first.RunDirectory, "graph", "graph.graphml"));
+        Assert.Contains("<graphml", graphMl, StringComparison.Ordinal);
+        var edgeCount = CountOccurrences(graphMl, "<edge ");
+        Assert.Equal(runResult.Triples.Count, edgeCount);
+
+        var firstWikiSnapshot = ReadDirectorySnapshot(Path.Combine(first.RunDirectory, "wiki"));
+        var secondWikiSnapshot = ReadDirectorySnapshot(Path.Combine(second.RunDirectory, "wiki"));
+        Assert.Equal(firstWikiSnapshot, secondWikiSnapshot);
+
+        var firstGraph = await File.ReadAllTextAsync(Path.Combine(first.RunDirectory, "graph", "graph.graphml"));
+        var secondGraph = await File.ReadAllTextAsync(Path.Combine(second.RunDirectory, "graph", "graph.graphml"));
+        Assert.Equal(firstGraph, secondGraph);
+
+        var latestManifestPath = Path.Combine(outputRoot, "latest", "manifest.json");
+        var latestManifest = JsonDocument.Parse(await File.ReadAllTextAsync(latestManifestPath));
+        Assert.Equal(second.RunId, latestManifest.RootElement.GetProperty("RunId").GetString());
+        Assert.True(latestManifest.RootElement.GetProperty("LatestPromoted").GetBoolean());
+        Assert.Equal(runResult.Triples.Count, latestManifest.RootElement.GetProperty("TripleCount").GetInt32());
+        Assert.True(latestManifest.RootElement.GetProperty("DurationMs").GetInt64() > 0);
+        Assert.True(latestManifest.RootElement.GetProperty("DiagnosticsSummary").GetArrayLength() >= 0);
+        Assert.Equal("wiki", latestManifest.RootElement.GetProperty("Artifacts").GetProperty("Wiki").GetString());
+        Assert.Equal("graph/graph.graphml", latestManifest.RootElement.GetProperty("Artifacts").GetProperty("GraphMl").GetString());
+    }
+
+    [Fact]
+    public async Task PublishAsync_DoesNotPromoteLatest_WhenRunFailed()
+    {
+        var outputRoot = Path.Combine(Path.GetTempPath(), $"codellmwiki-artifacts-failed-{Guid.NewGuid():N}");
+        var latestDirectory = Path.Combine(outputRoot, "latest");
+        Directory.CreateDirectory(latestDirectory);
+        var markerPath = Path.Combine(latestDirectory, "marker.txt");
+        await File.WriteAllTextAsync(markerPath, "preserve");
+
+        var runResult = new IngestionRunResult(
+            Status: IngestionRunStatus.Failed,
+            ExitCode: 1,
+            Diagnostics: [new IngestionDiagnostic("ontology:invalid", "invalid")],
+            RepositoryId: default,
+            Triples: []);
+
+        var publisher = new IngestionArtifactPublisher();
+        var result = await publisher.PublishAsync(
+            new IngestionArtifactPublishRequest(
+                RepositoryPath: ".",
+                OutputRootPath: outputRoot,
+                StartedAtUtc: new DateTimeOffset(2026, 1, 1, 0, 0, 0, TimeSpan.Zero),
+                CompletedAtUtc: new DateTimeOffset(2026, 1, 1, 0, 0, 5, TimeSpan.Zero),
+                RunResult: runResult),
+            CancellationToken.None);
+
+        Assert.True(result.Succeeded);
+        Assert.False(result.LatestPromoted);
+        Assert.True(File.Exists(markerPath));
+        Assert.True(File.Exists(result.ManifestPath));
+    }
+
+    private static int CountOccurrences(string value, string token)
+    {
+        var count = 0;
+        var index = 0;
+
+        while (index >= 0)
+        {
+            index = value.IndexOf(token, index, StringComparison.Ordinal);
+            if (index < 0)
+            {
+                break;
+            }
+
+            count++;
+            index += token.Length;
+        }
+
+        return count;
+    }
+
+    private static IReadOnlyList<string> ReadDirectorySnapshot(string root)
+    {
+        return Directory
+            .EnumerateFiles(root, "*", SearchOption.AllDirectories)
+            .OrderBy(x => x, StringComparer.Ordinal)
+            .Select(path =>
+            {
+                var relative = Path.GetRelativePath(root, path).Replace('\\', '/');
+                var content = File.ReadAllText(path);
+                return $"{relative}\n{content}";
+            })
+            .ToArray();
+    }
+
+    private sealed class PublisherFixture
+    {
+        private PublisherFixture(string repositoryPath)
+        {
+            RepositoryPath = repositoryPath;
+        }
+
+        public string RepositoryPath { get; }
+
+        public static async Task<PublisherFixture> CreateAsync()
+        {
+            var root = Path.Combine(Path.GetTempPath(), $"codellmwiki-publisher-{Guid.NewGuid():N}", "fixture-repo");
+            Directory.CreateDirectory(root);
+
+            await File.WriteAllTextAsync(Path.Combine(root, "Sample.slnx"),
+                """
+                <Solution>
+                  <Project Path="src/App/App.csproj" />
+                </Solution>
+                """);
+
+            var appDir = Path.Combine(root, "src", "App");
+            Directory.CreateDirectory(appDir);
+            await File.WriteAllTextAsync(Path.Combine(appDir, "App.csproj"),
+                """
+                <Project Sdk="Microsoft.NET.Sdk">
+                  <PropertyGroup>
+                    <TargetFramework>net10.0</TargetFramework>
+                  </PropertyGroup>
+                  <ItemGroup>
+                    <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
+                  </ItemGroup>
+                </Project>
+                """);
+
+            var objDir = Path.Combine(appDir, "obj");
+            Directory.CreateDirectory(objDir);
+            await File.WriteAllTextAsync(Path.Combine(objDir, "project.assets.json"),
+                """
+                {
+                  "libraries": {
+                    "Newtonsoft.Json/13.0.3": {
+                      "type": "package"
+                    }
+                  }
+                }
+                """);
+
+            await File.WriteAllTextAsync(Path.Combine(appDir, "Program.cs"), "Console.WriteLine(\"artifact\");\n");
+            await File.WriteAllTextAsync(Path.Combine(root, "README.md"), "# fixture\n");
+
+            RunGit(root, "init", "-b", "main");
+            RunGit(root, "config", "user.name", "Test User");
+            RunGit(root, "config", "user.email", "test@example.com");
+            RunGit(root, "add", ".");
+            RunGit(root, "commit", "-m", "initial");
+
+            return new PublisherFixture(root);
+        }
+
+        private static void RunGit(string workingDirectory, params string[] args)
+        {
+            var startInfo = new ProcessStartInfo
+            {
+                FileName = "git",
+                WorkingDirectory = workingDirectory,
+                RedirectStandardOutput = true,
+                RedirectStandardError = true,
+            };
+
+            foreach (var arg in args)
+            {
+                startInfo.ArgumentList.Add(arg);
+            }
+
+            using var process = Process.Start(startInfo)!;
+            var stdOut = process.StandardOutput.ReadToEnd();
+            var stdErr = process.StandardError.ReadToEnd();
+            process.WaitForExit();
+
+            if (process.ExitCode != 0)
+            {
+                throw new InvalidOperationException($"git {string.Join(' ', args)} failed: {stdOut}\n{stdErr}");
+            }
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- add run-scoped artifact publication under `output-root/runs/{run_id}` with deterministic wiki regeneration from query interfaces
- add GraphML serialization from semantic triples and emit per-run graph artifact
- add machine-readable run manifest with timings, counts, diagnostics summary, branch context, and artifact references
- add success-gated `latest` promotion using staging + move semantics; do not promote `latest` for failed runs
- wire CLI ingest flow to publish artifacts after ingestion, with config/CLI support for `--output-root`

## Validation
- dotnet build CodeLlmWiki.slnx -v minimal
- dotnet test CodeLlmWiki.slnx -v minimal
- dotnet run --project src/CodeLlmWiki.Cli -- ingest --path . --output-root /tmp/codellmwiki-phase6-check --allow-partial-success true

Closes #7
