### PR TITLE
feat(prd-002): complete issue 029 member topology slice

### DIFF
--- a/ontology/ontology.v1.yaml
+++ b/ontology/ontology.v1.yaml
@@ -43,6 +43,7 @@ predicates:
   - id: "core:hasDeclaringType"
   - id: "core:hasDeclaredType"
   - id: "core:hasDeclaredTypeText"
+  - id: "core:constantValue"
   - id: "core:resolutionStatus"
   - id: "core:isPartialType"
   - id: "core:arity"

--- a/plans/002/002-phase-2-dotnet-namespace-type-declaration.issue.029.md
+++ b/plans/002/002-phase-2-dotnet-namespace-type-declaration.issue.029.md
@@ -3,8 +3,8 @@
 > Parent PRD: [PRD 002](./002-phase-2-dotnet-namespace-type-declaration.prd.md)
 
 - Issue: [#29](https://github.com/vbfg1973/code-llm-wiki/issues/29)
-- [ ] Status: open
-- [ ] Completion date: 
+- [x] Status: complete
+- [x] Completion date: 2026-04-18
 
 ## Notes
 
@@ -18,10 +18,10 @@ Add declaration-level member topology for properties, fields, enum members, and 
 
 ## Acceptance criteria
 
-- [ ] Member entities for in-scope declaration members are ingested and linked to declaring types.
-- [ ] Declared member-type relationships are captured for query and rendering.
-- [ ] Enum members and constant values are represented on type pages.
-- [ ] Type pages include deterministic member sections without introducing standalone member pages.
+- [x] Member entities for in-scope declaration members are ingested and linked to declaring types.
+- [x] Declared member-type relationships are captured for query and rendering.
+- [x] Enum members and constant values are represented on type pages.
+- [x] Type pages include deterministic member sections without introducing standalone member pages.
 
 ## Blocked by
 

--- a/plans/002/002-phase-2-dotnet-namespace-type-declaration.plan.md
+++ b/plans/002/002-phase-2-dotnet-namespace-type-declaration.plan.md
@@ -8,7 +8,7 @@
 - [x] Phase 2: Namespace Vertical Slice — completion date: 2026-04-18
 - [x] Phase 3: Internal Type Symbol Vertical Slice — completion date: 2026-04-18
 - [x] Phase 4: Partial, Nested, and Generic Identity Hardening — completion date: 2026-04-18
-- [ ] Phase 5: Member Declaration Topology Vertical Slice — completion date: 
+- [x] Phase 5: Member Declaration Topology Vertical Slice — completion date: 2026-04-18
 - [ ] Phase 6: Type Resolution Fallback and External Stub References — completion date: 
 - [ ] Phase 7: File Backlink and Traceability Vertical Slice — completion date: 
 - [ ] Phase 8: Publication Determinism, Front Matter Validation, and CI Gates — completion date: 

--- a/src/CodeLlmWiki.Contracts/Graph/CorePredicates.cs
+++ b/src/CodeLlmWiki.Contracts/Graph/CorePredicates.cs
@@ -44,6 +44,7 @@ public static class CorePredicates
     public static readonly PredicateId HasDeclaringType = new("core:hasDeclaringType");
     public static readonly PredicateId HasDeclaredType = new("core:hasDeclaredType");
     public static readonly PredicateId HasDeclaredTypeText = new("core:hasDeclaredTypeText");
+    public static readonly PredicateId ConstantValue = new("core:constantValue");
     public static readonly PredicateId ResolutionStatus = new("core:resolutionStatus");
     public static readonly PredicateId IsPartialType = new("core:isPartialType");
     public static readonly PredicateId Arity = new("core:arity");

--- a/src/CodeLlmWiki.Ingestion/ProjectStructure/CSharpDeclarationScanner.cs
+++ b/src/CodeLlmWiki.Ingestion/ProjectStructure/CSharpDeclarationScanner.cs
@@ -145,6 +145,7 @@ internal static class CSharpDeclarationScanner
                     ParseGenericParameters(classDeclaration.TypeParameterList),
                     ParseGenericConstraints(classDeclaration.ConstraintClauses),
                     ParseDirectRelationships(classDeclaration),
+                    ParseDeclaredMembers(classDeclaration.Members, relativePath),
                     relativePath,
                     classDeclaration.Members,
                     importContext,
@@ -163,6 +164,7 @@ internal static class CSharpDeclarationScanner
                     ParseGenericParameters(interfaceDeclaration.TypeParameterList),
                     ParseGenericConstraints(interfaceDeclaration.ConstraintClauses),
                     ParseDirectRelationships(interfaceDeclaration),
+                    ParseDeclaredMembers(interfaceDeclaration.Members, relativePath),
                     relativePath,
                     interfaceDeclaration.Members,
                     importContext,
@@ -181,6 +183,7 @@ internal static class CSharpDeclarationScanner
                     ParseGenericParameters(structDeclaration.TypeParameterList),
                     ParseGenericConstraints(structDeclaration.ConstraintClauses),
                     ParseDirectRelationships(structDeclaration),
+                    ParseDeclaredMembers(structDeclaration.Members, relativePath),
                     relativePath,
                     structDeclaration.Members,
                     importContext,
@@ -199,6 +202,11 @@ internal static class CSharpDeclarationScanner
                     ParseGenericParameters(recordDeclaration.TypeParameterList),
                     ParseGenericConstraints(recordDeclaration.ConstraintClauses),
                     ParseDirectRelationships(recordDeclaration),
+                    ParseDeclaredMembers(recordDeclaration.Members, relativePath)
+                        .Concat(ParseRecordPrimaryMembers(recordDeclaration, relativePath))
+                        .OrderBy(x => x.Kind, StringComparer.Ordinal)
+                        .ThenBy(x => x.Name, StringComparer.Ordinal)
+                        .ToArray(),
                     relativePath,
                     recordDeclaration.Members,
                     importContext,
@@ -217,6 +225,7 @@ internal static class CSharpDeclarationScanner
                     [],
                     [],
                     ([], []),
+                    ParseEnumMembers(enumDeclaration, relativePath),
                     relativePath,
                     members: default,
                     importContext,
@@ -235,6 +244,7 @@ internal static class CSharpDeclarationScanner
                     ParseGenericParameters(delegateDeclaration.TypeParameterList),
                     ParseGenericConstraints(delegateDeclaration.ConstraintClauses),
                     ([], []),
+                    [],
                     relativePath,
                     members: default,
                     importContext,
@@ -255,6 +265,7 @@ internal static class CSharpDeclarationScanner
         IReadOnlyList<string> genericParameters,
         IReadOnlyList<string> genericConstraints,
         (IReadOnlyList<string> Bases, IReadOnlyList<string> Interfaces) relationships,
+        IReadOnlyList<MemberDiscoveryNode> discoveredMembers,
         string relativePath,
         SyntaxList<MemberDeclarationSyntax> members,
         TypeImportContext importContext,
@@ -278,6 +289,7 @@ internal static class CSharpDeclarationScanner
             relationships.Interfaces,
             importContext.Namespaces,
             importContext.Aliases,
+            discoveredMembers,
             relativePath));
 
         if (namespaceName == GlobalNamespaceName)
@@ -385,6 +397,85 @@ internal static class CSharpDeclarationScanner
         }
 
         return "internal";
+    }
+
+    private static IReadOnlyList<MemberDiscoveryNode> ParseDeclaredMembers(
+        SyntaxList<MemberDeclarationSyntax> members,
+        string relativePath)
+    {
+        var discoveredMembers = new List<MemberDiscoveryNode>();
+
+        foreach (var member in members)
+        {
+            switch (member)
+            {
+                case FieldDeclarationSyntax fieldDeclaration:
+                {
+                    var declaredType = NormalizeTypeReference(fieldDeclaration.Declaration.Type.ToString());
+                    var accessibility = ParseAccessibility(fieldDeclaration.Modifiers);
+
+                    foreach (var variable in fieldDeclaration.Declaration.Variables)
+                    {
+                        discoveredMembers.Add(new MemberDiscoveryNode(
+                            "field",
+                            variable.Identifier.ValueText,
+                            accessibility,
+                            declaredType,
+                            variable.Initializer?.Value.ToString(),
+                            relativePath));
+                    }
+
+                    break;
+                }
+                case PropertyDeclarationSyntax propertyDeclaration:
+                    discoveredMembers.Add(new MemberDiscoveryNode(
+                        "property",
+                        propertyDeclaration.Identifier.ValueText,
+                        ParseAccessibility(propertyDeclaration.Modifiers),
+                        NormalizeTypeReference(propertyDeclaration.Type.ToString()),
+                        null,
+                        relativePath));
+                    break;
+            }
+        }
+
+        return discoveredMembers
+            .OrderBy(x => x.Kind, StringComparer.Ordinal)
+            .ThenBy(x => x.Name, StringComparer.Ordinal)
+            .ToArray();
+    }
+
+    private static IReadOnlyList<MemberDiscoveryNode> ParseEnumMembers(EnumDeclarationSyntax enumDeclaration, string relativePath)
+    {
+        return enumDeclaration.Members
+            .Select(member => new MemberDiscoveryNode(
+                "enum-member",
+                member.Identifier.ValueText,
+                "public",
+                null,
+                member.EqualsValue?.Value.ToString(),
+                relativePath))
+            .OrderBy(x => x.Name, StringComparer.Ordinal)
+            .ToArray();
+    }
+
+    private static IReadOnlyList<MemberDiscoveryNode> ParseRecordPrimaryMembers(RecordDeclarationSyntax recordDeclaration, string relativePath)
+    {
+        if (recordDeclaration.ParameterList is null)
+        {
+            return [];
+        }
+
+        return recordDeclaration.ParameterList.Parameters
+            .Select(parameter => new MemberDiscoveryNode(
+                "record-parameter",
+                parameter.Identifier.ValueText,
+                "public",
+                parameter.Type is null ? null : NormalizeTypeReference(parameter.Type.ToString()),
+                null,
+                relativePath))
+            .OrderBy(x => x.Name, StringComparer.Ordinal)
+            .ToArray();
     }
 
     private static bool IsPartial(SyntaxTokenList modifiers)

--- a/src/CodeLlmWiki.Ingestion/ProjectStructure/CSharpDeclarationScanner.cs
+++ b/src/CodeLlmWiki.Ingestion/ProjectStructure/CSharpDeclarationScanner.cs
@@ -447,14 +447,49 @@ internal static class CSharpDeclarationScanner
 
     private static IReadOnlyList<MemberDiscoveryNode> ParseEnumMembers(EnumDeclarationSyntax enumDeclaration, string relativePath)
     {
-        return enumDeclaration.Members
-            .Select(member => new MemberDiscoveryNode(
+        var members = new List<MemberDiscoveryNode>();
+        long? lastIntegralValue = null;
+
+        foreach (var member in enumDeclaration.Members)
+        {
+            string? constantValue;
+
+            if (member.EqualsValue is not null)
+            {
+                var initializerText = member.EqualsValue.Value.ToString().Trim();
+                if (TryParseIntegralConstant(initializerText, out var parsedValue))
+                {
+                    constantValue = parsedValue.ToString();
+                    lastIntegralValue = parsedValue;
+                }
+                else
+                {
+                    constantValue = initializerText;
+                    lastIntegralValue = null;
+                }
+            }
+            else if (lastIntegralValue is null)
+            {
+                constantValue = "0";
+                lastIntegralValue = 0;
+            }
+            else
+            {
+                var nextValue = lastIntegralValue.Value + 1;
+                constantValue = nextValue.ToString();
+                lastIntegralValue = nextValue;
+            }
+
+            members.Add(new MemberDiscoveryNode(
                 "enum-member",
                 member.Identifier.ValueText,
                 "public",
                 null,
-                member.EqualsValue?.Value.ToString(),
-                relativePath))
+                constantValue,
+                relativePath));
+        }
+
+        return members
             .OrderBy(x => x.Name, StringComparer.Ordinal)
             .ToArray();
     }
@@ -538,6 +573,36 @@ internal static class CSharpDeclarationScanner
         }
 
         return value.Trim();
+    }
+
+    private static bool TryParseIntegralConstant(string value, out long parsed)
+    {
+        var normalized = value.Replace("_", string.Empty, StringComparison.Ordinal).Trim();
+
+        if (normalized.StartsWith("0x", StringComparison.OrdinalIgnoreCase))
+        {
+            return long.TryParse(normalized[2..], System.Globalization.NumberStyles.HexNumber, System.Globalization.CultureInfo.InvariantCulture, out parsed);
+        }
+
+        if (normalized.StartsWith("0b", StringComparison.OrdinalIgnoreCase))
+        {
+            try
+            {
+                parsed = Convert.ToInt64(normalized[2..], 2);
+                return true;
+            }
+            catch
+            {
+                parsed = default;
+                return false;
+            }
+        }
+
+        return long.TryParse(
+            normalized,
+            System.Globalization.NumberStyles.Integer,
+            System.Globalization.CultureInfo.InvariantCulture,
+            out parsed);
     }
 
     private static bool LooksLikeInterfaceName(string typeName)

--- a/src/CodeLlmWiki.Ingestion/ProjectStructure/MemberDiscoveryNode.cs
+++ b/src/CodeLlmWiki.Ingestion/ProjectStructure/MemberDiscoveryNode.cs
@@ -1,0 +1,9 @@
+namespace CodeLlmWiki.Ingestion.ProjectStructure;
+
+internal sealed record MemberDiscoveryNode(
+    string Kind,
+    string Name,
+    string Accessibility,
+    string? DeclaredTypeName,
+    string? ConstantValue,
+    string RelativeFilePath);

--- a/src/CodeLlmWiki.Ingestion/ProjectStructure/ProjectStructureAnalyzer.cs
+++ b/src/CodeLlmWiki.Ingestion/ProjectStructure/ProjectStructureAnalyzer.cs
@@ -325,6 +325,7 @@ public sealed class ProjectStructureAnalyzer : IProjectStructureAnalyzer
 
         var typeIdByQualifiedName = new Dictionary<string, EntityId>(StringComparer.Ordinal);
         var declaredTypeNamesBySimpleName = new Dictionary<string, HashSet<string>>(StringComparer.Ordinal);
+        var pendingMemberTypeLinks = new List<PendingMemberTypeLink>();
 
         foreach (var group in typeGroups)
         {
@@ -413,6 +414,83 @@ public sealed class ProjectStructureAnalyzer : IProjectStructureAnalyzer
                     CorePredicates.DeclaresType,
                     new EntityNode(typeId)));
             }
+
+            var memberGroups = group
+                .SelectMany(x => x.Members)
+                .GroupBy(x => $"{x.Kind}:{x.Name}", StringComparer.Ordinal)
+                .OrderBy(x => x.Key, StringComparer.Ordinal)
+                .ToArray();
+
+            foreach (var memberGroup in memberGroups)
+            {
+                var representativeMember = memberGroup
+                    .OrderBy(x => x.RelativeFilePath, StringComparer.Ordinal)
+                    .First();
+
+                var memberNaturalKey = $"{representative.QualifiedName}:{representativeMember.Kind}:{representativeMember.Name}";
+                var memberId = _stableIdGenerator.Create(new EntityKey("member-declaration", memberNaturalKey));
+
+                AddEntityTriples(
+                    triples,
+                    memberId,
+                    "member-declaration",
+                    representativeMember.Name,
+                    $"{representative.QualifiedName}.{representativeMember.Name}");
+
+                triples.Add(new SemanticTriple(
+                    new EntityNode(memberId),
+                    CorePredicates.MemberKind,
+                    new LiteralNode(representativeMember.Kind)));
+
+                triples.Add(new SemanticTriple(
+                    new EntityNode(memberId),
+                    CorePredicates.Accessibility,
+                    new LiteralNode(representativeMember.Accessibility)));
+
+                triples.Add(new SemanticTriple(
+                    new EntityNode(typeId),
+                    CorePredicates.ContainsMember,
+                    new EntityNode(memberId)));
+
+                if (!string.IsNullOrWhiteSpace(representativeMember.DeclaredTypeName))
+                {
+                    triples.Add(new SemanticTriple(
+                        new EntityNode(memberId),
+                        CorePredicates.HasDeclaredTypeText,
+                        new LiteralNode(representativeMember.DeclaredTypeName)));
+
+                    pendingMemberTypeLinks.Add(new PendingMemberTypeLink(
+                        memberId,
+                        representative.NamespaceName,
+                        representativeMember.DeclaredTypeName!,
+                        representative.ImportedNamespaces,
+                        representative.ImportedAliases));
+                }
+
+                if (!string.IsNullOrWhiteSpace(representativeMember.ConstantValue))
+                {
+                    triples.Add(new SemanticTriple(
+                        new EntityNode(memberId),
+                        CorePredicates.ConstantValue,
+                        new LiteralNode(representativeMember.ConstantValue!)));
+                }
+
+                foreach (var relativeFilePath in memberGroup
+                             .Select(x => x.RelativeFilePath)
+                             .Distinct(StringComparer.Ordinal)
+                             .OrderBy(x => x, StringComparer.Ordinal))
+                {
+                    if (!fileIdByRelativePath.TryGetValue(relativeFilePath, out var memberFileId))
+                    {
+                        continue;
+                    }
+
+                    triples.Add(new SemanticTriple(
+                        new EntityNode(memberFileId),
+                        CorePredicates.DeclaresMember,
+                        new EntityNode(memberId)));
+                }
+            }
         }
 
         foreach (var group in typeGroups)
@@ -474,6 +552,26 @@ public sealed class ProjectStructureAnalyzer : IProjectStructureAnalyzer
                     CorePredicates.Implements,
                     new EntityNode(interfaceTypeId)));
             }
+        }
+
+        foreach (var pendingMemberTypeLink in pendingMemberTypeLinks)
+        {
+            var resolvedMemberTypeName = ResolveInternalTypeName(
+                pendingMemberTypeLink.NamespaceName,
+                pendingMemberTypeLink.DeclaredTypeName,
+                pendingMemberTypeLink.ImportedNamespaces,
+                pendingMemberTypeLink.ImportedAliases,
+                typeIdByQualifiedName,
+                declaredTypeNamesBySimpleName);
+            if (resolvedMemberTypeName is null || !typeIdByQualifiedName.TryGetValue(resolvedMemberTypeName, out var resolvedMemberTypeId))
+            {
+                continue;
+            }
+
+            triples.Add(new SemanticTriple(
+                new EntityNode(pendingMemberTypeLink.MemberId),
+                CorePredicates.HasDeclaredType,
+                new EntityNode(resolvedMemberTypeId)));
         }
     }
 
@@ -538,6 +636,13 @@ public sealed class ProjectStructureAnalyzer : IProjectStructureAnalyzer
 
         return null;
     }
+
+    private sealed record PendingMemberTypeLink(
+        EntityId MemberId,
+        string NamespaceName,
+        string DeclaredTypeName,
+        IReadOnlyList<string> ImportedNamespaces,
+        IReadOnlyDictionary<string, string> ImportedAliases);
 
     private static void AddEntityTriples(
         List<SemanticTriple> triples,

--- a/src/CodeLlmWiki.Ingestion/ProjectStructure/TypeDiscoveryNode.cs
+++ b/src/CodeLlmWiki.Ingestion/ProjectStructure/TypeDiscoveryNode.cs
@@ -15,4 +15,5 @@ internal sealed record TypeDiscoveryNode(
     IReadOnlyList<string> DirectInterfaceTypeNames,
     IReadOnlyList<string> ImportedNamespaces,
     IReadOnlyDictionary<string, string> ImportedAliases,
+    IReadOnlyList<MemberDiscoveryNode> Members,
     string RelativeFilePath);

--- a/src/CodeLlmWiki.Query/ProjectStructure/ProjectStructureQueryService.cs
+++ b/src/CodeLlmWiki.Query/ProjectStructure/ProjectStructureQueryService.cs
@@ -361,6 +361,18 @@ public sealed class ProjectStructureQueryService : IProjectStructureQueryService
                     meta.GenericConstraints.Add(value);
                 }
             }
+            else if (triple.Predicate == CorePredicates.MemberKind)
+            {
+                meta.MemberKind = value;
+            }
+            else if (triple.Predicate == CorePredicates.HasDeclaredTypeText)
+            {
+                meta.DeclaredTypeText = value;
+            }
+            else if (triple.Predicate == CorePredicates.ConstantValue)
+            {
+                meta.ConstantValue = value;
+            }
         }
 
         return byId;
@@ -548,6 +560,9 @@ public sealed class ProjectStructureQueryService : IProjectStructureQueryService
         var inheritsEdges = BuildEntityEdges(triples, CorePredicates.Inherits);
         var implementsEdges = BuildEntityEdges(triples, CorePredicates.Implements);
         var declaringTypeEdges = BuildEntityEdges(triples, CorePredicates.HasDeclaringType);
+        var containsMemberEdges = BuildEntityEdges(triples, CorePredicates.ContainsMember);
+        var memberDeclaredTypeEdges = BuildEntityEdges(triples, CorePredicates.HasDeclaredType);
+        var fileDeclaresMember = BuildEntityEdges(triples, CorePredicates.DeclaresMember);
 
         var namespaceIds = metadataById
             .Where(x => x.Value.IsType("namespace"))
@@ -627,6 +642,32 @@ public sealed class ProjectStructureQueryService : IProjectStructureQueryService
                     .OrderBy(id => metadataById.TryGetValue(id, out var meta) ? meta.Path : id.Value, StringComparer.Ordinal)
                     .ToArray());
 
+        var memberIdsByType = containsMemberEdges
+            .GroupBy(x => x.Subject)
+            .ToDictionary(
+                x => x.Key,
+                x => x.Select(v => v.Object)
+                    .Distinct()
+                    .OrderBy(id => metadataById.TryGetValue(id, out var meta) ? meta.Name : id.Value, StringComparer.Ordinal)
+                    .ToArray());
+
+        var declaringTypeByMember = containsMemberEdges
+            .GroupBy(x => x.Object)
+            .ToDictionary(x => x.Key, x => x.First().Subject);
+
+        var declarationFilesByMember = fileDeclaresMember
+            .GroupBy(x => x.Object)
+            .ToDictionary(
+                x => x.Key,
+                x => x.Select(v => v.Subject)
+                    .Distinct()
+                    .OrderBy(id => metadataById.TryGetValue(id, out var meta) ? meta.Path : id.Value, StringComparer.Ordinal)
+                    .ToArray());
+
+        var declaredTypeByMember = memberDeclaredTypeEdges
+            .GroupBy(x => x.Subject)
+            .ToDictionary(x => x.Key, x => x.First().Object);
+
         var directBasesByType = inheritsEdges
             .GroupBy(x => x.Subject)
             .ToDictionary(
@@ -699,6 +740,8 @@ public sealed class ProjectStructureQueryService : IProjectStructureQueryService
                 directBaseIds ??= [];
                 directInterfacesByType.TryGetValue(typeId, out var directInterfaceIds);
                 directInterfaceIds ??= [];
+                memberIdsByType.TryGetValue(typeId, out var memberIds);
+                memberIds ??= [];
 
                 return new TypeDeclarationNode(
                     typeId,
@@ -724,7 +767,7 @@ public sealed class ProjectStructureQueryService : IProjectStructureQueryService
                             metadataById.TryGetValue(id, out var targetMeta) ? targetMeta.Name : id.Value,
                             DeclarationResolutionStatus.Resolved))
                         .ToArray(),
-                    [],
+                    memberIds,
                     declarationFileIds);
             })
             .OrderBy(
@@ -736,7 +779,62 @@ public sealed class ProjectStructureQueryService : IProjectStructureQueryService
                 StringComparer.Ordinal)
             .ToArray();
 
-        return new DeclarationCatalog(namespaces, types, []);
+        var memberIds = containsMemberEdges
+            .Select(x => x.Object)
+            .Concat(metadataById.Where(x => x.Value.IsType("member-declaration")).Select(x => x.Key))
+            .Distinct()
+            .OrderBy(id => metadataById.TryGetValue(id, out var meta) ? meta.Path : id.Value, StringComparer.Ordinal)
+            .ToArray();
+
+        var members = memberIds
+            .Select(memberId =>
+            {
+                var meta = metadataById.TryGetValue(memberId, out var memberMeta)
+                    ? memberMeta
+                    : new EntityMetadata(memberId);
+
+                declaringTypeByMember.TryGetValue(memberId, out var declaringTypeId);
+                declarationFilesByMember.TryGetValue(memberId, out var declarationFileIds);
+                declarationFileIds ??= [];
+
+                declaredTypeByMember.TryGetValue(memberId, out var declaredTypeId);
+
+                var declaredType = declaredTypeId == default
+                    ? (!string.IsNullOrWhiteSpace(meta.DeclaredTypeText)
+                        ? new TypeReferenceNode(
+                            null,
+                            meta.DeclaredTypeText,
+                            DeclarationResolutionStatus.SourceTextFallback)
+                        : null)
+                    : new TypeReferenceNode(
+                        declaredTypeId,
+                        metadataById.TryGetValue(declaredTypeId, out var declaredTypeMeta)
+                            ? declaredTypeMeta.Name
+                            : declaredTypeId.Value,
+                        DeclarationResolutionStatus.Resolved);
+
+                return new MemberDeclarationNode(
+                    memberId,
+                    ParseMemberKind(meta.MemberKind),
+                    meta.Name,
+                    meta.Name,
+                    declaringTypeId == default ? default : declaringTypeId,
+                    ParseAccessibility(meta.Accessibility),
+                    declaredType,
+                    string.IsNullOrWhiteSpace(meta.ConstantValue) ? null : meta.ConstantValue,
+                    declarationFileIds);
+            })
+            .Where(x => x.DeclaringTypeId != default)
+            .OrderBy(
+                x => DeclarationOrderingRules.GetDeterministicSortKey(
+                    x.Kind.ToString(),
+                    x.Name,
+                    x.DeclaredType?.DisplayText ?? string.Empty,
+                    x.Id.Value),
+                StringComparer.Ordinal)
+            .ToArray();
+
+        return new DeclarationCatalog(namespaces, types, members);
     }
 
     private static DeclarationAccessibility ParseAccessibility(string accessibility)
@@ -764,6 +862,18 @@ public sealed class ProjectStructureQueryService : IProjectStructureQueryService
             "enum" => TypeDeclarationKind.Enum,
             "delegate" => TypeDeclarationKind.Delegate,
             _ => TypeDeclarationKind.Unknown,
+        };
+    }
+
+    private static MemberDeclarationKind ParseMemberKind(string kind)
+    {
+        return kind.ToLowerInvariant() switch
+        {
+            "field" => MemberDeclarationKind.Field,
+            "property" => MemberDeclarationKind.Property,
+            "enum-member" => MemberDeclarationKind.EnumMember,
+            "record-parameter" => MemberDeclarationKind.RecordParameter,
+            _ => MemberDeclarationKind.Unknown,
         };
     }
 
@@ -818,6 +928,9 @@ public sealed class ProjectStructureQueryService : IProjectStructureQueryService
             IsPartialType = false;
             GenericParameters = new HashSet<string>(StringComparer.Ordinal);
             GenericConstraints = new HashSet<string>(StringComparer.Ordinal);
+            MemberKind = string.Empty;
+            DeclaredTypeText = string.Empty;
+            ConstantValue = string.Empty;
         }
 
         public EntityId Id { get; }
@@ -875,6 +988,12 @@ public sealed class ProjectStructureQueryService : IProjectStructureQueryService
         public HashSet<string> GenericParameters { get; }
 
         public HashSet<string> GenericConstraints { get; }
+
+        public string MemberKind { get; set; }
+
+        public string DeclaredTypeText { get; set; }
+
+        public string ConstantValue { get; set; }
 
         public bool IsType(string entityType) => EntityType.Equals(entityType, StringComparison.OrdinalIgnoreCase);
     }

--- a/src/CodeLlmWiki.Wiki/ProjectStructure/ProjectStructureWikiRenderer.cs
+++ b/src/CodeLlmWiki.Wiki/ProjectStructure/ProjectStructureWikiRenderer.cs
@@ -72,6 +72,7 @@ public sealed class ProjectStructureWikiRenderer : IProjectStructureWikiRenderer
         var projectById = model.Projects.ToDictionary(x => x.Id, x => x);
         var namespaceById = model.Declarations.Namespaces.ToDictionary(x => x.Id, x => x);
         var typeById = model.Declarations.Types.ToDictionary(x => x.Id, x => x);
+        var memberById = model.Declarations.Members.ToDictionary(x => x.Id, x => x);
         var fileById = model.Files.ToDictionary(x => x.Id, x => x);
 
         var pages = new List<WikiPage>
@@ -83,7 +84,7 @@ public sealed class ProjectStructureWikiRenderer : IProjectStructureWikiRenderer
         pages.AddRange(orderedProjects.Select(project => RenderProjectPage(model.Repository.Id.Value, project, packageById, resolver)));
         pages.AddRange(orderedPackages.Select(package => RenderPackagePage(model.Repository.Id.Value, package, resolver)));
         pages.AddRange(orderedNamespaces.Select(namespaceDeclaration => RenderNamespacePage(model.Repository.Id.Value, namespaceDeclaration, namespaceById, typeById, resolver)));
-        pages.AddRange(orderedTypes.Select(typeDeclaration => RenderTypePage(model.Repository.Id.Value, typeDeclaration, namespaceById, typeById, fileById, resolver)));
+        pages.AddRange(orderedTypes.Select(typeDeclaration => RenderTypePage(model.Repository.Id.Value, typeDeclaration, namespaceById, typeById, memberById, fileById, resolver)));
         pages.AddRange(orderedFiles.Select(file => RenderFilePage(model.Repository, file, resolver, maxMergeEntriesPerFile)));
 
         pages.Add(RenderIndexPage(model, resolver, indexPath));
@@ -361,6 +362,7 @@ public sealed class ProjectStructureWikiRenderer : IProjectStructureWikiRenderer
         TypeDeclarationNode typeDeclaration,
         IReadOnlyDictionary<EntityId, NamespaceDeclarationNode> namespaceById,
         IReadOnlyDictionary<EntityId, TypeDeclarationNode> typeById,
+        IReadOnlyDictionary<EntityId, MemberDeclarationNode> memberById,
         IReadOnlyDictionary<EntityId, FileNode> fileById,
         WikiPathResolver resolver)
     {
@@ -416,6 +418,13 @@ public sealed class ProjectStructureWikiRenderer : IProjectStructureWikiRenderer
                 sb.AppendLine($"- {directInterface.DisplayText}");
             }
         }
+
+        sb.AppendLine();
+        sb.AppendLine("## Members");
+        AppendMemberSection(sb, "Properties", typeDeclaration, memberById, MemberDeclarationKind.Property);
+        AppendMemberSection(sb, "Fields", typeDeclaration, memberById, MemberDeclarationKind.Field);
+        AppendMemberSection(sb, "Record Parameters", typeDeclaration, memberById, MemberDeclarationKind.RecordParameter);
+        AppendMemberSection(sb, "Enum Members", typeDeclaration, memberById, MemberDeclarationKind.EnumMember);
 
         if (typeDeclaration.GenericParameters.Count > 0 || typeDeclaration.GenericConstraints.Count > 0)
         {
@@ -479,6 +488,48 @@ public sealed class ProjectStructureWikiRenderer : IProjectStructureWikiRenderer
             RelativePath: resolver.GetPath(typeDeclaration.Id),
             Title: typeDeclaration.Name,
             Markdown: WithFrontMatter(frontMatter, sb.ToString().TrimEnd()));
+    }
+
+    private static void AppendMemberSection(
+        StringBuilder sb,
+        string sectionName,
+        TypeDeclarationNode typeDeclaration,
+        IReadOnlyDictionary<EntityId, MemberDeclarationNode> memberById,
+        MemberDeclarationKind expectedKind)
+    {
+        var members = typeDeclaration.MemberIds
+            .Where(memberById.ContainsKey)
+            .Select(id => memberById[id])
+            .Where(member => member.Kind == expectedKind)
+            .OrderBy(member => member.Name, StringComparer.Ordinal)
+            .ThenBy(member => member.Id.Value, StringComparer.Ordinal)
+            .ToArray();
+
+        sb.AppendLine($"### {sectionName}");
+        if (members.Length == 0)
+        {
+            sb.AppendLine("- none");
+            return;
+        }
+
+        foreach (var member in members)
+        {
+            var declaredType = member.DeclaredType?.DisplayText;
+            if (expectedKind == MemberDeclarationKind.EnumMember)
+            {
+                var constant = string.IsNullOrWhiteSpace(member.ConstantValue) ? "-" : member.ConstantValue;
+                sb.AppendLine($"- {member.Name} = {constant}");
+                continue;
+            }
+
+            if (string.IsNullOrWhiteSpace(declaredType))
+            {
+                sb.AppendLine($"- {member.Name}");
+                continue;
+            }
+
+            sb.AppendLine($"- {member.Name}: {declaredType}");
+        }
     }
 
     private static WikiPage RenderFilePage(

--- a/tests/CodeLlmWiki.Ingestion.Tests/MemberTopologyVerticalSliceTests.cs
+++ b/tests/CodeLlmWiki.Ingestion.Tests/MemberTopologyVerticalSliceTests.cs
@@ -123,8 +123,8 @@ public sealed class MemberTopologyVerticalSliceTests
 
                 public enum Status
                 {
-                    Unknown = 0,
-                    Ready = 1
+                    Unknown,
+                    Ready
                 }
                 """);
 

--- a/tests/CodeLlmWiki.Ingestion.Tests/MemberTopologyVerticalSliceTests.cs
+++ b/tests/CodeLlmWiki.Ingestion.Tests/MemberTopologyVerticalSliceTests.cs
@@ -1,0 +1,166 @@
+using System.Diagnostics;
+using CodeLlmWiki.Contracts.Identity;
+using CodeLlmWiki.Ingestion.ProjectStructure;
+using CodeLlmWiki.Query.ProjectStructure;
+using CodeLlmWiki.Wiki.ProjectStructure;
+
+namespace CodeLlmWiki.Ingestion.Tests;
+
+public sealed class MemberTopologyVerticalSliceTests
+{
+    [Fact]
+    public async Task Query_IngestsMemberEntities_ForSupportedKinds()
+    {
+        var fixture = await MemberFixture.CreateAsync();
+        var analyzer = new ProjectStructureAnalyzer(new StableIdGenerator());
+        var analysis = await analyzer.AnalyzeAsync(fixture.RepositoryPath, CancellationToken.None);
+        var model = new ProjectStructureQueryService(analysis.Triples).GetModel(analysis.RepositoryId);
+
+        Assert.Contains(model.Declarations.Members, x => x.Kind == MemberDeclarationKind.Property && x.Name == "Name");
+        Assert.Contains(model.Declarations.Members, x => x.Kind == MemberDeclarationKind.Field && x.Name == "_count");
+        Assert.Contains(model.Declarations.Members, x => x.Kind == MemberDeclarationKind.EnumMember && x.Name == "Ready");
+        Assert.Contains(model.Declarations.Members, x => x.Kind == MemberDeclarationKind.RecordParameter && x.Name == "Id");
+    }
+
+    [Fact]
+    public async Task Query_CapturesDeclaredMemberTypeRelationships()
+    {
+        var fixture = await MemberFixture.CreateAsync();
+        var analyzer = new ProjectStructureAnalyzer(new StableIdGenerator());
+        var analysis = await analyzer.AnalyzeAsync(fixture.RepositoryPath, CancellationToken.None);
+        var model = new ProjectStructureQueryService(analysis.Triples).GetModel(analysis.RepositoryId);
+
+        var helperType = model.Declarations.Types.Single(x => x.Name == "Helper");
+        var helperProperty = model.Declarations.Members.Single(x => x.Name == "Helper" && x.Kind == MemberDeclarationKind.Property);
+
+        Assert.NotNull(helperProperty.DeclaredType);
+        Assert.Equal(helperType.Id, helperProperty.DeclaredType!.TypeId);
+        Assert.Equal(DeclarationResolutionStatus.Resolved, helperProperty.DeclaredType.ResolutionStatus);
+    }
+
+    [Fact]
+    public async Task Render_TypePages_ContainDeterministicMemberSections_AndNoStandaloneMemberPages()
+    {
+        var fixture = await MemberFixture.CreateAsync();
+        var analyzer = new ProjectStructureAnalyzer(new StableIdGenerator());
+        var analysis = await analyzer.AnalyzeAsync(fixture.RepositoryPath, CancellationToken.None);
+        var model = new ProjectStructureQueryService(analysis.Triples).GetModel(analysis.RepositoryId);
+        var pages = new ProjectStructureWikiRenderer().Render(model);
+
+        Assert.DoesNotContain(pages, x => x.RelativePath.StartsWith("members/", StringComparison.Ordinal));
+
+        var workerPage = pages.Single(x => x.RelativePath == "types/Acme/Members/Worker.md");
+        Assert.Contains("## Members", workerPage.Markdown, StringComparison.Ordinal);
+        Assert.Contains("### Properties", workerPage.Markdown, StringComparison.Ordinal);
+        Assert.Contains("### Fields", workerPage.Markdown, StringComparison.Ordinal);
+        Assert.Contains("Name", workerPage.Markdown, StringComparison.Ordinal);
+        Assert.Contains("_count", workerPage.Markdown, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public async Task Render_EnumMembers_IncludeConstantValues()
+    {
+        var fixture = await MemberFixture.CreateAsync();
+        var analyzer = new ProjectStructureAnalyzer(new StableIdGenerator());
+        var analysis = await analyzer.AnalyzeAsync(fixture.RepositoryPath, CancellationToken.None);
+        var model = new ProjectStructureQueryService(analysis.Triples).GetModel(analysis.RepositoryId);
+        var pages = new ProjectStructureWikiRenderer().Render(model);
+
+        var enumPage = pages.Single(x => x.RelativePath == "types/Acme/Members/Status.md");
+        Assert.Contains("### Enum Members", enumPage.Markdown, StringComparison.Ordinal);
+        Assert.Contains("Unknown = 0", enumPage.Markdown, StringComparison.Ordinal);
+        Assert.Contains("Ready = 1", enumPage.Markdown, StringComparison.Ordinal);
+    }
+
+    private sealed class MemberFixture
+    {
+        private MemberFixture(string repositoryPath)
+        {
+            RepositoryPath = repositoryPath;
+        }
+
+        public string RepositoryPath { get; }
+
+        public static async Task<MemberFixture> CreateAsync()
+        {
+            var root = Path.Combine(Path.GetTempPath(), $"codellmwiki-members-{Guid.NewGuid():N}", "member-repo");
+            Directory.CreateDirectory(root);
+
+            await File.WriteAllTextAsync(Path.Combine(root, "Sample.slnx"),
+                """
+                <Solution>
+                  <Project Path="src/App/App.csproj" />
+                </Solution>
+                """);
+
+            var appDir = Path.Combine(root, "src", "App");
+            Directory.CreateDirectory(appDir);
+            await File.WriteAllTextAsync(Path.Combine(appDir, "App.csproj"),
+                """
+                <Project Sdk="Microsoft.NET.Sdk">
+                  <PropertyGroup>
+                    <TargetFramework>net10.0</TargetFramework>
+                  </PropertyGroup>
+                </Project>
+                """);
+
+            await File.WriteAllTextAsync(Path.Combine(appDir, "Members.cs"),
+                """
+                namespace Acme.Members;
+
+                public class Helper
+                {
+                }
+
+                public record Job(Guid Id, Helper Helper);
+
+                public class Worker
+                {
+                    public string Name { get; set; } = string.Empty;
+                    private readonly int _count = 3;
+                    public Helper Helper { get; set; } = new();
+                }
+
+                public enum Status
+                {
+                    Unknown = 0,
+                    Ready = 1
+                }
+                """);
+
+            RunGit(root, "init", "-b", "main");
+            RunGit(root, "config", "user.email", "test@example.com");
+            RunGit(root, "config", "user.name", "Test User");
+            RunGit(root, "add", ".");
+            RunGit(root, "commit", "-m", "initial");
+
+            return new MemberFixture(root);
+        }
+    }
+
+    private static void RunGit(string workingDirectory, params string[] args)
+    {
+        var startInfo = new ProcessStartInfo
+        {
+            FileName = "git",
+            WorkingDirectory = workingDirectory,
+            RedirectStandardOutput = true,
+            RedirectStandardError = true,
+        };
+
+        foreach (var arg in args)
+        {
+            startInfo.ArgumentList.Add(arg);
+        }
+
+        using var process = Process.Start(startInfo)!;
+        process.WaitForExit();
+
+        if (process.ExitCode != 0)
+        {
+            var stdOut = process.StandardOutput.ReadToEnd();
+            var stdErr = process.StandardError.ReadToEnd();
+            throw new InvalidOperationException($"git {string.Join(' ', args)} failed: {stdOut}\n{stdErr}");
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- adds member declaration ingestion for properties, fields, enum members, and record declaration parameters
- models members as graph entities linked to declaring types and file declaration origins
- captures member declared-type relationships (resolved internal links + source text fallback)
- captures enum member constant values and renders them on parent type pages
- adds deterministic member sections on type pages without introducing member page families
- updates ontology/contracts and marks local issue/plan checklists complete

## Validation
- `dotnet test tests/CodeLlmWiki.Ingestion.Tests/CodeLlmWiki.Ingestion.Tests.csproj --filter "FullyQualifiedName~MemberTopologyVerticalSliceTests"`
- `dotnet test`

Closes #29
