### PR TITLE
feat(prd-002): complete issue 030 resolution fallback and stubs

### DIFF
--- a/plans/002/002-phase-2-dotnet-namespace-type-declaration.issue.030.md
+++ b/plans/002/002-phase-2-dotnet-namespace-type-declaration.issue.030.md
@@ -3,8 +3,8 @@
 > Parent PRD: [PRD 002](./002-phase-2-dotnet-namespace-type-declaration.prd.md)
 
 - Issue: [#30](https://github.com/vbfg1973/code-llm-wiki/issues/30)
-- [ ] Status: open
-- [ ] Completion date: 
+- [x] Status: complete
+- [x] Completion date: 2026-04-18
 
 ## Notes
 
@@ -18,10 +18,10 @@ Implement robust type-resolution behavior for member declared types and declarat
 
 ## Acceptance criteria
 
-- [ ] Declared type links use resolved symbol identity when available.
-- [ ] Unresolved declared types retain source-text fallback with explicit resolution status.
-- [ ] External referenced types are captured and rendered as dependency stubs without external-type pages.
-- [ ] Partial semantic failure still produces usable output with explicit diagnostics/provenance indicators.
+- [x] Declared type links use resolved symbol identity when available.
+- [x] Unresolved declared types retain source-text fallback with explicit resolution status.
+- [x] External referenced types are captured and rendered as dependency stubs without external-type pages.
+- [x] Partial semantic failure still produces usable output with explicit diagnostics/provenance indicators.
 
 ## Blocked by
 

--- a/plans/002/002-phase-2-dotnet-namespace-type-declaration.plan.md
+++ b/plans/002/002-phase-2-dotnet-namespace-type-declaration.plan.md
@@ -9,7 +9,7 @@
 - [x] Phase 3: Internal Type Symbol Vertical Slice — completion date: 2026-04-18
 - [x] Phase 4: Partial, Nested, and Generic Identity Hardening — completion date: 2026-04-18
 - [x] Phase 5: Member Declaration Topology Vertical Slice — completion date: 2026-04-18
-- [ ] Phase 6: Type Resolution Fallback and External Stub References — completion date: 
+- [x] Phase 6: Type Resolution Fallback and External Stub References — completion date: 2026-04-18
 - [ ] Phase 7: File Backlink and Traceability Vertical Slice — completion date: 
 - [ ] Phase 8: Publication Determinism, Front Matter Validation, and CI Gates — completion date: 
 

--- a/src/CodeLlmWiki.Ingestion/ProjectStructure/ProjectStructureAnalyzer.cs
+++ b/src/CodeLlmWiki.Ingestion/ProjectStructure/ProjectStructureAnalyzer.cs
@@ -327,6 +327,7 @@ public sealed class ProjectStructureAnalyzer : IProjectStructureAnalyzer
         var declaredTypeNamesBySimpleName = new Dictionary<string, HashSet<string>>(StringComparer.Ordinal);
         var pendingMemberTypeLinks = new List<PendingMemberTypeLink>();
         var externalStubIdByReference = new Dictionary<string, EntityId>(StringComparer.Ordinal);
+        var unresolvedReferenceIdByText = new Dictionary<string, EntityId>(StringComparer.Ordinal);
 
         foreach (var group in typeGroups)
         {
@@ -532,10 +533,10 @@ public sealed class ProjectStructureAnalyzer : IProjectStructureAnalyzer
                     }
                     else
                     {
+                        baseTypeId = GetOrCreateUnresolvedReferenceId(normalizedBaseType, unresolvedReferenceIdByText, triples);
                         diagnostics.Add(new IngestionDiagnostic(
                             "type:resolution:fallback",
                             $"Unresolved base type '{baseType}' for '{representative.QualifiedName}'."));
-                        continue;
                     }
                 }
 
@@ -563,10 +564,10 @@ public sealed class ProjectStructureAnalyzer : IProjectStructureAnalyzer
                     }
                     else
                     {
+                        interfaceTypeId = GetOrCreateUnresolvedReferenceId(normalizedInterfaceType, unresolvedReferenceIdByText, triples);
                         diagnostics.Add(new IngestionDiagnostic(
                             "type:resolution:fallback",
                             $"Unresolved interface type '{interfaceType}' for '{representative.QualifiedName}'."));
-                        continue;
                     }
                 }
 
@@ -682,6 +683,29 @@ public sealed class ProjectStructureAnalyzer : IProjectStructureAnalyzer
             $"external/{referenceName}");
 
         return stubId;
+    }
+
+    private EntityId GetOrCreateUnresolvedReferenceId(
+        string referenceName,
+        Dictionary<string, EntityId> unresolvedReferenceIdByText,
+        List<SemanticTriple> triples)
+    {
+        if (unresolvedReferenceIdByText.TryGetValue(referenceName, out var existing))
+        {
+            return existing;
+        }
+
+        var unresolvedId = _stableIdGenerator.Create(new EntityKey("unresolved-type-reference", referenceName));
+        unresolvedReferenceIdByText[referenceName] = unresolvedId;
+
+        AddEntityTriples(
+            triples,
+            unresolvedId,
+            "unresolved-type-reference",
+            referenceName,
+            $"unresolved/{referenceName}");
+
+        return unresolvedId;
     }
 
     private static bool IsExternalStubCandidate(string normalizedReferenceName)

--- a/src/CodeLlmWiki.Ingestion/ProjectStructure/ProjectStructureAnalyzer.cs
+++ b/src/CodeLlmWiki.Ingestion/ProjectStructure/ProjectStructureAnalyzer.cs
@@ -326,6 +326,7 @@ public sealed class ProjectStructureAnalyzer : IProjectStructureAnalyzer
         var typeIdByQualifiedName = new Dictionary<string, EntityId>(StringComparer.Ordinal);
         var declaredTypeNamesBySimpleName = new Dictionary<string, HashSet<string>>(StringComparer.Ordinal);
         var pendingMemberTypeLinks = new List<PendingMemberTypeLink>();
+        var externalStubIdByReference = new Dictionary<string, EntityId>(StringComparer.Ordinal);
 
         foreach (var group in typeGroups)
         {
@@ -524,7 +525,18 @@ public sealed class ProjectStructureAnalyzer : IProjectStructureAnalyzer
                     declaredTypeNamesBySimpleName);
                 if (resolvedBaseQualifiedName is null || !typeIdByQualifiedName.TryGetValue(resolvedBaseQualifiedName, out var baseTypeId))
                 {
-                    continue;
+                    var normalizedBaseType = NormalizeTypeReferenceName(baseType);
+                    if (IsExternalStubCandidate(normalizedBaseType))
+                    {
+                        baseTypeId = GetOrCreateExternalStubId(normalizedBaseType, externalStubIdByReference, triples);
+                    }
+                    else
+                    {
+                        diagnostics.Add(new IngestionDiagnostic(
+                            "type:resolution:fallback",
+                            $"Unresolved base type '{baseType}' for '{representative.QualifiedName}'."));
+                        continue;
+                    }
                 }
 
                 triples.Add(new SemanticTriple(
@@ -544,7 +556,18 @@ public sealed class ProjectStructureAnalyzer : IProjectStructureAnalyzer
                     declaredTypeNamesBySimpleName);
                 if (resolvedInterfaceQualifiedName is null || !typeIdByQualifiedName.TryGetValue(resolvedInterfaceQualifiedName, out var interfaceTypeId))
                 {
-                    continue;
+                    var normalizedInterfaceType = NormalizeTypeReferenceName(interfaceType);
+                    if (IsExternalStubCandidate(normalizedInterfaceType))
+                    {
+                        interfaceTypeId = GetOrCreateExternalStubId(normalizedInterfaceType, externalStubIdByReference, triples);
+                    }
+                    else
+                    {
+                        diagnostics.Add(new IngestionDiagnostic(
+                            "type:resolution:fallback",
+                            $"Unresolved interface type '{interfaceType}' for '{representative.QualifiedName}'."));
+                        continue;
+                    }
                 }
 
                 triples.Add(new SemanticTriple(
@@ -565,7 +588,18 @@ public sealed class ProjectStructureAnalyzer : IProjectStructureAnalyzer
                 declaredTypeNamesBySimpleName);
             if (resolvedMemberTypeName is null || !typeIdByQualifiedName.TryGetValue(resolvedMemberTypeName, out var resolvedMemberTypeId))
             {
-                continue;
+                var normalizedMemberType = NormalizeTypeReferenceName(pendingMemberTypeLink.DeclaredTypeName);
+                if (IsExternalStubCandidate(normalizedMemberType))
+                {
+                    resolvedMemberTypeId = GetOrCreateExternalStubId(normalizedMemberType, externalStubIdByReference, triples);
+                }
+                else
+                {
+                    diagnostics.Add(new IngestionDiagnostic(
+                        "type:resolution:fallback",
+                        $"Unresolved declared member type '{pendingMemberTypeLink.DeclaredTypeName}' for member '{pendingMemberTypeLink.MemberId.Value}'."));
+                    continue;
+                }
             }
 
             triples.Add(new SemanticTriple(
@@ -588,17 +622,7 @@ public sealed class ProjectStructureAnalyzer : IProjectStructureAnalyzer
             return null;
         }
 
-        var normalized = referenceName.Trim();
-        if (normalized.StartsWith("global::", StringComparison.Ordinal))
-        {
-            normalized = normalized[8..];
-        }
-
-        var genericIndex = normalized.IndexOf('<');
-        if (genericIndex >= 0)
-        {
-            normalized = normalized[..genericIndex];
-        }
+        var normalized = NormalizeTypeReferenceName(referenceName);
 
         var aliasSplit = normalized.Split('.', 2, StringSplitOptions.TrimEntries);
         if (aliasSplit.Length == 2 && importedAliases.TryGetValue(aliasSplit[0], out var aliasTarget))
@@ -635,6 +659,56 @@ public sealed class ProjectStructureAnalyzer : IProjectStructureAnalyzer
         }
 
         return null;
+    }
+
+    private EntityId GetOrCreateExternalStubId(
+        string referenceName,
+        Dictionary<string, EntityId> externalStubIdByReference,
+        List<SemanticTriple> triples)
+    {
+        if (externalStubIdByReference.TryGetValue(referenceName, out var existing))
+        {
+            return existing;
+        }
+
+        var stubId = _stableIdGenerator.Create(new EntityKey("external-type-stub", referenceName));
+        externalStubIdByReference[referenceName] = stubId;
+
+        AddEntityTriples(
+            triples,
+            stubId,
+            "external-type-stub",
+            referenceName,
+            $"external/{referenceName}");
+
+        return stubId;
+    }
+
+    private static bool IsExternalStubCandidate(string normalizedReferenceName)
+    {
+        if (string.IsNullOrWhiteSpace(normalizedReferenceName))
+        {
+            return false;
+        }
+
+        return normalizedReferenceName.All(c => char.IsLetterOrDigit(c) || c is '_' or '.');
+    }
+
+    private static string NormalizeTypeReferenceName(string referenceName)
+    {
+        var normalized = referenceName.Trim();
+        if (normalized.StartsWith("global::", StringComparison.Ordinal))
+        {
+            normalized = normalized[8..];
+        }
+
+        var genericIndex = normalized.IndexOf('<');
+        if (genericIndex >= 0)
+        {
+            normalized = normalized[..genericIndex];
+        }
+
+        return normalized.Trim();
     }
 
     private sealed record PendingMemberTypeLink(

--- a/src/CodeLlmWiki.Query/ProjectStructure/DeclarationResolutionStatus.cs
+++ b/src/CodeLlmWiki.Query/ProjectStructure/DeclarationResolutionStatus.cs
@@ -4,6 +4,7 @@ public enum DeclarationResolutionStatus
 {
     Unknown = 0,
     Resolved,
+    ExternalStub,
     SourceTextFallback,
     Unresolved,
 }

--- a/src/CodeLlmWiki.Query/ProjectStructure/ProjectStructureQueryService.cs
+++ b/src/CodeLlmWiki.Query/ProjectStructure/ProjectStructureQueryService.cs
@@ -760,12 +760,12 @@ public sealed class ProjectStructureQueryService : IProjectStructureQueryService
                     directBaseIds.Select(id => new TypeReferenceNode(
                             id,
                             metadataById.TryGetValue(id, out var targetMeta) ? targetMeta.Name : id.Value,
-                            DeclarationResolutionStatus.Resolved))
+                            GetReferenceResolutionStatus(id, metadataById)))
                         .ToArray(),
                     directInterfaceIds.Select(id => new TypeReferenceNode(
                             id,
                             metadataById.TryGetValue(id, out var targetMeta) ? targetMeta.Name : id.Value,
-                            DeclarationResolutionStatus.Resolved))
+                            GetReferenceResolutionStatus(id, metadataById)))
                         .ToArray(),
                     memberIds,
                     declarationFileIds);
@@ -811,7 +811,7 @@ public sealed class ProjectStructureQueryService : IProjectStructureQueryService
                         metadataById.TryGetValue(declaredTypeId, out var declaredTypeMeta)
                             ? declaredTypeMeta.Name
                             : declaredTypeId.Value,
-                        DeclarationResolutionStatus.Resolved);
+                        GetReferenceResolutionStatus(declaredTypeId, metadataById));
 
                 return new MemberDeclarationNode(
                     memberId,
@@ -875,6 +875,28 @@ public sealed class ProjectStructureQueryService : IProjectStructureQueryService
             "record-parameter" => MemberDeclarationKind.RecordParameter,
             _ => MemberDeclarationKind.Unknown,
         };
+    }
+
+    private static DeclarationResolutionStatus GetReferenceResolutionStatus(
+        EntityId targetId,
+        IReadOnlyDictionary<EntityId, EntityMetadata> metadataById)
+    {
+        if (!metadataById.TryGetValue(targetId, out var targetMeta))
+        {
+            return DeclarationResolutionStatus.Unresolved;
+        }
+
+        if (targetMeta.IsType("type-declaration"))
+        {
+            return DeclarationResolutionStatus.Resolved;
+        }
+
+        if (targetMeta.IsType("external-type-stub"))
+        {
+            return DeclarationResolutionStatus.ExternalStub;
+        }
+
+        return DeclarationResolutionStatus.Unresolved;
     }
 
     private static IReadOnlyList<EntityEdge> BuildEntityEdges(

--- a/src/CodeLlmWiki.Query/ProjectStructure/ProjectStructureQueryService.cs
+++ b/src/CodeLlmWiki.Query/ProjectStructure/ProjectStructureQueryService.cs
@@ -896,6 +896,11 @@ public sealed class ProjectStructureQueryService : IProjectStructureQueryService
             return DeclarationResolutionStatus.ExternalStub;
         }
 
+        if (targetMeta.IsType("unresolved-type-reference"))
+        {
+            return DeclarationResolutionStatus.SourceTextFallback;
+        }
+
         return DeclarationResolutionStatus.Unresolved;
     }
 

--- a/src/CodeLlmWiki.Wiki/ProjectStructure/ProjectStructureWikiRenderer.cs
+++ b/src/CodeLlmWiki.Wiki/ProjectStructure/ProjectStructureWikiRenderer.cs
@@ -401,7 +401,7 @@ public sealed class ProjectStructureWikiRenderer : IProjectStructureWikiRenderer
             }
             else
             {
-                sb.AppendLine($"- {directBaseType.DisplayText}");
+                sb.AppendLine($"- {FormatTypeReference(directBaseType)}");
             }
         }
 
@@ -415,7 +415,7 @@ public sealed class ProjectStructureWikiRenderer : IProjectStructureWikiRenderer
             }
             else
             {
-                sb.AppendLine($"- {directInterface.DisplayText}");
+                sb.AppendLine($"- {FormatTypeReference(directInterface)}");
             }
         }
 
@@ -528,8 +528,19 @@ public sealed class ProjectStructureWikiRenderer : IProjectStructureWikiRenderer
                 continue;
             }
 
-            sb.AppendLine($"- {member.Name}: {declaredType}");
+            sb.AppendLine($"- {member.Name}: {FormatTypeReference(member.DeclaredType!)}");
         }
+    }
+
+    private static string FormatTypeReference(TypeReferenceNode reference)
+    {
+        return reference.ResolutionStatus switch
+        {
+            DeclarationResolutionStatus.ExternalStub => $"{reference.DisplayText} (external)",
+            DeclarationResolutionStatus.SourceTextFallback => $"{reference.DisplayText} (unresolved)",
+            DeclarationResolutionStatus.Unresolved => $"{reference.DisplayText} (unresolved)",
+            _ => reference.DisplayText,
+        };
     }
 
     private static WikiPage RenderFilePage(

--- a/src/CodeLlmWiki.Wiki/ProjectStructure/ProjectStructureWikiRenderer.cs
+++ b/src/CodeLlmWiki.Wiki/ProjectStructure/ProjectStructureWikiRenderer.cs
@@ -537,7 +537,7 @@ public sealed class ProjectStructureWikiRenderer : IProjectStructureWikiRenderer
         return reference.ResolutionStatus switch
         {
             DeclarationResolutionStatus.ExternalStub => $"{reference.DisplayText} (external)",
-            DeclarationResolutionStatus.SourceTextFallback => $"{reference.DisplayText} (unresolved)",
+            DeclarationResolutionStatus.SourceTextFallback => $"{reference.DisplayText} (source text fallback)",
             DeclarationResolutionStatus.Unresolved => $"{reference.DisplayText} (unresolved)",
             _ => reference.DisplayText,
         };

--- a/tests/CodeLlmWiki.Ingestion.Tests/TypeResolutionFallbackTests.cs
+++ b/tests/CodeLlmWiki.Ingestion.Tests/TypeResolutionFallbackTests.cs
@@ -1,0 +1,170 @@
+using System.Diagnostics;
+using CodeLlmWiki.Contracts.Identity;
+using CodeLlmWiki.Ingestion.ProjectStructure;
+using CodeLlmWiki.Query.ProjectStructure;
+using CodeLlmWiki.Wiki.ProjectStructure;
+
+namespace CodeLlmWiki.Ingestion.Tests;
+
+public sealed class TypeResolutionFallbackTests
+{
+    [Fact]
+    public async Task Query_UsesResolvedIdentityLinks_WhenAvailable()
+    {
+        var fixture = await ResolutionFixture.CreateAsync();
+        var analyzer = new ProjectStructureAnalyzer(new StableIdGenerator());
+        var analysis = await analyzer.AnalyzeAsync(fixture.RepositoryPath, CancellationToken.None);
+        var model = new ProjectStructureQueryService(analysis.Triples).GetModel(analysis.RepositoryId);
+
+        var internalDependency = model.Declarations.Types.Single(x => x.Name == "InternalDependency");
+        var internalMember = model.Declarations.Members.Single(x => x.Name == "Internal" && x.Kind == MemberDeclarationKind.Property);
+
+        Assert.NotNull(internalMember.DeclaredType);
+        Assert.Equal(internalDependency.Id, internalMember.DeclaredType!.TypeId);
+        Assert.Equal(DeclarationResolutionStatus.Resolved, internalMember.DeclaredType.ResolutionStatus);
+    }
+
+    [Fact]
+    public async Task Query_UnresolvedDeclaredTypes_KeepSourceFallbackWithExplicitStatus()
+    {
+        var fixture = await ResolutionFixture.CreateAsync();
+        var analyzer = new ProjectStructureAnalyzer(new StableIdGenerator());
+        var analysis = await analyzer.AnalyzeAsync(fixture.RepositoryPath, CancellationToken.None);
+        var model = new ProjectStructureQueryService(analysis.Triples).GetModel(analysis.RepositoryId);
+
+        var coordinates = model.Declarations.Members.Single(x => x.Name == "Coordinates" && x.Kind == MemberDeclarationKind.Property);
+
+        Assert.NotNull(coordinates.DeclaredType);
+        Assert.Null(coordinates.DeclaredType!.TypeId);
+        Assert.Equal(DeclarationResolutionStatus.SourceTextFallback, coordinates.DeclaredType.ResolutionStatus);
+        Assert.Contains("(int X, int Y)", coordinates.DeclaredType.DisplayText, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public async Task Query_ExternalReferences_AreCapturedAsStubsWithoutStandalonePages()
+    {
+        var fixture = await ResolutionFixture.CreateAsync();
+        var analyzer = new ProjectStructureAnalyzer(new StableIdGenerator());
+        var analysis = await analyzer.AnalyzeAsync(fixture.RepositoryPath, CancellationToken.None);
+        var model = new ProjectStructureQueryService(analysis.Triples).GetModel(analysis.RepositoryId);
+        var pages = new ProjectStructureWikiRenderer().Render(model);
+
+        var client = model.Declarations.Members.Single(x => x.Name == "Client" && x.Kind == MemberDeclarationKind.Property);
+        Assert.NotNull(client.DeclaredType);
+        Assert.Equal(DeclarationResolutionStatus.ExternalStub, client.DeclaredType!.ResolutionStatus);
+        Assert.Equal("System.Net.Http.HttpClient", client.DeclaredType.DisplayText);
+
+        var workerContract = model.Declarations.Types.Single(x => x.Name == "IWorkerContract");
+        Assert.Contains(workerContract.DirectBaseTypes, x => x.DisplayText == "IDisposable" && x.ResolutionStatus == DeclarationResolutionStatus.ExternalStub);
+
+        Assert.DoesNotContain(model.Declarations.Types, x => x.Name == "IDisposable" || x.Name == "HttpClient");
+        Assert.DoesNotContain(pages, x => x.RelativePath.Contains("HttpClient", StringComparison.Ordinal));
+        Assert.DoesNotContain(pages, x => x.RelativePath.Contains("IDisposable", StringComparison.Ordinal));
+    }
+
+    [Fact]
+    public async Task AnalyzeAsync_PartialResolutionFailure_StillProducesUsableOutput_WithDiagnostics()
+    {
+        var fixture = await ResolutionFixture.CreateAsync();
+        var analyzer = new ProjectStructureAnalyzer(new StableIdGenerator());
+        var analysis = await analyzer.AnalyzeAsync(fixture.RepositoryPath, CancellationToken.None);
+        var model = new ProjectStructureQueryService(analysis.Triples).GetModel(analysis.RepositoryId);
+        var pages = new ProjectStructureWikiRenderer().Render(model);
+
+        Assert.Contains(analysis.Diagnostics, x => x.Code == "type:resolution:fallback");
+        Assert.NotEmpty(model.Declarations.Types);
+        Assert.NotEmpty(pages);
+    }
+
+    private sealed class ResolutionFixture
+    {
+        private ResolutionFixture(string repositoryPath)
+        {
+            RepositoryPath = repositoryPath;
+        }
+
+        public string RepositoryPath { get; }
+
+        public static async Task<ResolutionFixture> CreateAsync()
+        {
+            var root = Path.Combine(Path.GetTempPath(), $"codellmwiki-resolution-{Guid.NewGuid():N}", "resolution-repo");
+            Directory.CreateDirectory(root);
+
+            await File.WriteAllTextAsync(Path.Combine(root, "Sample.slnx"),
+                """
+                <Solution>
+                  <Project Path="src/App/App.csproj" />
+                </Solution>
+                """);
+
+            var appDir = Path.Combine(root, "src", "App");
+            Directory.CreateDirectory(appDir);
+            await File.WriteAllTextAsync(Path.Combine(appDir, "App.csproj"),
+                """
+                <Project Sdk="Microsoft.NET.Sdk">
+                  <PropertyGroup>
+                    <TargetFramework>net10.0</TargetFramework>
+                  </PropertyGroup>
+                </Project>
+                """);
+
+            await File.WriteAllTextAsync(Path.Combine(appDir, "Resolution.cs"),
+                """
+                namespace Acme.Resolution;
+
+                public class InternalDependency
+                {
+                }
+
+                public interface IWorkerContract : IDisposable
+                {
+                }
+
+                public class Worker : IWorkerContract
+                {
+                    public InternalDependency Internal { get; set; } = new();
+                    public System.Net.Http.HttpClient Client { get; set; } = new();
+                    public (int X, int Y) Coordinates { get; set; }
+
+                    public void Dispose()
+                    {
+                    }
+                }
+                """);
+
+            RunGit(root, "init", "-b", "main");
+            RunGit(root, "config", "user.email", "test@example.com");
+            RunGit(root, "config", "user.name", "Test User");
+            RunGit(root, "add", ".");
+            RunGit(root, "commit", "-m", "initial");
+
+            return new ResolutionFixture(root);
+        }
+    }
+
+    private static void RunGit(string workingDirectory, params string[] args)
+    {
+        var startInfo = new ProcessStartInfo
+        {
+            FileName = "git",
+            WorkingDirectory = workingDirectory,
+            RedirectStandardOutput = true,
+            RedirectStandardError = true,
+        };
+
+        foreach (var arg in args)
+        {
+            startInfo.ArgumentList.Add(arg);
+        }
+
+        using var process = Process.Start(startInfo)!;
+        process.WaitForExit();
+
+        if (process.ExitCode != 0)
+        {
+            var stdOut = process.StandardOutput.ReadToEnd();
+            var stdErr = process.StandardError.ReadToEnd();
+            throw new InvalidOperationException($"git {string.Join(' ', args)} failed: {stdOut}\n{stdErr}");
+        }
+    }
+}

--- a/tests/CodeLlmWiki.Ingestion.Tests/TypeResolutionFallbackTests.cs
+++ b/tests/CodeLlmWiki.Ingestion.Tests/TypeResolutionFallbackTests.cs
@@ -76,6 +76,25 @@ public sealed class TypeResolutionFallbackTests
         Assert.NotEmpty(pages);
     }
 
+    [Fact]
+    public async Task Query_UnresolvedBaseTypes_AreRetainedWithFallbackStatus()
+    {
+        var fixture = await ResolutionFixture.CreateAsync();
+        var analyzer = new ProjectStructureAnalyzer(new StableIdGenerator());
+        var analysis = await analyzer.AnalyzeAsync(fixture.RepositoryPath, CancellationToken.None);
+        var model = new ProjectStructureQueryService(analysis.Triples).GetModel(analysis.RepositoryId);
+        var pages = new ProjectStructureWikiRenderer().Render(model);
+
+        var brokenWorker = model.Declarations.Types.Single(x => x.Name == "BrokenWorker");
+        var unresolvedBase = Assert.Single(brokenWorker.DirectBaseTypes);
+
+        Assert.Equal("Missing[]", unresolvedBase.DisplayText);
+        Assert.Equal(DeclarationResolutionStatus.SourceTextFallback, unresolvedBase.ResolutionStatus);
+
+        var brokenWorkerPage = pages.Single(x => x.RelativePath == "types/Acme/Resolution/BrokenWorker.md");
+        Assert.Contains("Missing[] (source text fallback)", brokenWorkerPage.Markdown, StringComparison.Ordinal);
+    }
+
     private sealed class ResolutionFixture
     {
         private ResolutionFixture(string repositoryPath)
@@ -129,6 +148,10 @@ public sealed class TypeResolutionFallbackTests
                     public void Dispose()
                     {
                     }
+                }
+
+                public class BrokenWorker : Missing[]
+                {
                 }
                 """);
 


### PR DESCRIPTION
## Summary
- hardens type/member reference resolution to prefer internal symbol links when resolvable
- preserves unresolved declared-type source text with explicit fallback status
- captures unresolved external references as `external-type-stub` dependencies (no standalone external pages)
- surfaces external/unresolved markers in rendered type/member relationship sections
- emits resolution fallback diagnostics while preserving usable output
- adds dedicated fallback/external-stub vertical-slice tests and marks local plan/issue checklists complete

## Validation
- `dotnet test tests/CodeLlmWiki.Ingestion.Tests/CodeLlmWiki.Ingestion.Tests.csproj --filter "FullyQualifiedName~TypeResolutionFallbackTests"`
- `dotnet test`

Closes #30
