### PR TITLE
PRD 003 / Issue 045: calls, external usage, extension methods

### DIFF
--- a/ontology/ontology.v1.yaml
+++ b/ontology/ontology.v1.yaml
@@ -70,3 +70,4 @@ predicates:
   - id: "core:isExtensionMethod"
   - id: "core:extendsType"
   - id: "core:externalAssemblyName"
+  - id: "core:resolutionReason"

--- a/ontology/ontology.v1.yaml
+++ b/ontology/ontology.v1.yaml
@@ -69,3 +69,4 @@ predicates:
   - id: "core:writesField"
   - id: "core:isExtensionMethod"
   - id: "core:extendsType"
+  - id: "core:externalAssemblyName"

--- a/plans/003/003-phase-3-dotnet-method-extraction-and-relations.issue.045.md
+++ b/plans/003/003-phase-3-dotnet-method-extraction-and-relations.issue.045.md
@@ -3,8 +3,8 @@
 > Parent PRD: [PRD 003](./003-phase-3-dotnet-method-extraction-and-relations.prd.md)
 
 - Issue: [#45](https://github.com/vbfg1973/code-llm-wiki/issues/45)
-- [ ] Status: open
-- [ ] Completion date:
+- [x] Status: completed
+- [x] Completion date: 2026-04-18
 
 ## Notes
 
@@ -18,10 +18,10 @@ Deliver method call relationship extraction for internal callers, including inte
 
 ## Acceptance criteria
 
-- [ ] `calls` edges are created for internal method callers with semantically resolved targets where possible.
-- [ ] External invocation usage is represented at external type and external assembly granularity (no deep external method pages).
-- [ ] Extension methods are captured, flagged, resolved from extension-call syntax, and linked to extended internal types.
-- [ ] Method pages render deterministic `Calls`/`Called By` sections and degradation diagnostics/provenance when semantic binding fails.
+- [x] `calls` edges are created for internal method callers with semantically resolved targets where possible.
+- [x] External invocation usage is represented at external type and external assembly granularity (no deep external method pages).
+- [x] Extension methods are captured, flagged, resolved from extension-call syntax, and linked to extended internal types.
+- [x] Method pages render deterministic `Calls`/`Called By` sections and degradation diagnostics/provenance when semantic binding fails.
 
 ## Blocked by
 

--- a/plans/003/003-phase-3-dotnet-method-extraction-and-relations.plan.md
+++ b/plans/003/003-phase-3-dotnet-method-extraction-and-relations.plan.md
@@ -7,7 +7,7 @@
 - [x] Phase 1: Method Contracts and Ontology Expansion — completion date: 2026-04-18
 - [x] Phase 2: Method Declaration and Method Page Vertical Slice — completion date: 2026-04-18
 - [x] Phase 3: Implements and Overrides Relationship Vertical Slice — completion date: 2026-04-18
-- [ ] Phase 4: Calls, External Usage, and Extension Method Vertical Slice — completion date:
+- [x] Phase 4: Calls, External Usage, and Extension Method Vertical Slice — completion date: 2026-04-18
 - [ ] Phase 5: Read-Write Data-Flow and Type Count Scalars Vertical Slice — completion date:
 - [ ] Phase 6: Publication Determinism, Validation, and CI Gates — completion date:
 

--- a/src/CodeLlmWiki.Contracts/Graph/CorePredicates.cs
+++ b/src/CodeLlmWiki.Contracts/Graph/CorePredicates.cs
@@ -71,4 +71,5 @@ public static class CorePredicates
     public static readonly PredicateId IsExtensionMethod = new("core:isExtensionMethod");
     public static readonly PredicateId ExtendsType = new("core:extendsType");
     public static readonly PredicateId ExternalAssemblyName = new("core:externalAssemblyName");
+    public static readonly PredicateId ResolutionReason = new("core:resolutionReason");
 }

--- a/src/CodeLlmWiki.Contracts/Graph/CorePredicates.cs
+++ b/src/CodeLlmWiki.Contracts/Graph/CorePredicates.cs
@@ -70,4 +70,5 @@ public static class CorePredicates
     public static readonly PredicateId WritesField = new("core:writesField");
     public static readonly PredicateId IsExtensionMethod = new("core:isExtensionMethod");
     public static readonly PredicateId ExtendsType = new("core:extendsType");
+    public static readonly PredicateId ExternalAssemblyName = new("core:externalAssemblyName");
 }

--- a/src/CodeLlmWiki.Ingestion/ProjectStructure/CSharpDeclarationScanner.cs
+++ b/src/CodeLlmWiki.Ingestion/ProjectStructure/CSharpDeclarationScanner.cs
@@ -515,6 +515,15 @@ internal static class CSharpDeclarationScanner
                     var canonicalName = string.IsNullOrWhiteSpace(explicitInterface)
                         ? methodName
                         : $"{explicitInterface}.{methodName}";
+                    var isExtensionMethod =
+                        methodDeclaration.Modifiers.Any(x => x.IsKind(Microsoft.CodeAnalysis.CSharp.SyntaxKind.StaticKeyword))
+                        && methodDeclaration.ParameterList.Parameters.Count > 0
+                        && methodDeclaration.ParameterList.Parameters[0].Modifiers.Any(x => x.IsKind(Microsoft.CodeAnalysis.CSharp.SyntaxKind.ThisKeyword));
+                    var extendedTypeName = isExtensionMethod
+                        ? methodDeclaration.ParameterList.Parameters[0].Type is null
+                            ? null
+                            : NormalizeMethodTypeReference(methodDeclaration.ParameterList.Parameters[0].Type!.ToString())
+                        : null;
 
                     discoveredMethods.Add(new MethodDiscoveryNode(
                         Kind: "method",
@@ -522,6 +531,8 @@ internal static class CSharpDeclarationScanner
                         CanonicalName: canonicalName,
                         Accessibility: ParseAccessibility(methodDeclaration.Modifiers),
                         IsOverride: methodDeclaration.Modifiers.Any(x => x.IsKind(Microsoft.CodeAnalysis.CSharp.SyntaxKind.OverrideKeyword)),
+                        IsExtensionMethod: isExtensionMethod,
+                        ExtendedTypeName: extendedTypeName,
                         Arity: methodDeclaration.TypeParameterList?.Parameters.Count ?? 0,
                         ReturnTypeName: NormalizeMethodTypeReference(methodDeclaration.ReturnType.ToString()),
                         Parameters: ParseMethodParameters(methodDeclaration.ParameterList.Parameters),
@@ -539,6 +550,8 @@ internal static class CSharpDeclarationScanner
                         CanonicalName: ".ctor",
                         Accessibility: ParseAccessibility(constructorDeclaration.Modifiers),
                         IsOverride: false,
+                        IsExtensionMethod: false,
+                        ExtendedTypeName: null,
                         Arity: 0,
                         ReturnTypeName: null,
                         Parameters: ParseMethodParameters(constructorDeclaration.ParameterList.Parameters),

--- a/src/CodeLlmWiki.Ingestion/ProjectStructure/MethodDiscoveryNode.cs
+++ b/src/CodeLlmWiki.Ingestion/ProjectStructure/MethodDiscoveryNode.cs
@@ -6,6 +6,8 @@ internal sealed record MethodDiscoveryNode(
     string CanonicalName,
     string Accessibility,
     bool IsOverride,
+    bool IsExtensionMethod,
+    string? ExtendedTypeName,
     int Arity,
     string? ReturnTypeName,
     IReadOnlyList<MethodParameterDiscoveryNode> Parameters,

--- a/src/CodeLlmWiki.Ingestion/ProjectStructure/ProjectStructureAnalyzer.cs
+++ b/src/CodeLlmWiki.Ingestion/ProjectStructure/ProjectStructureAnalyzer.cs
@@ -1219,7 +1219,11 @@ public sealed class ProjectStructureAnalyzer : IProjectStructureAnalyzer
                     unresolvedTarget = invocation.ToString().Trim();
                 }
 
-                var unresolvedTargetId = GetOrCreateUnresolvedCallTargetId(unresolvedTarget, unresolvedCallTargetIdByText, triples);
+                var unresolvedTargetId = GetOrCreateUnresolvedCallTargetId(
+                    unresolvedTarget,
+                    "symbol-unresolved",
+                    unresolvedCallTargetIdByText,
+                    triples);
                 triples.Add(new SemanticTriple(
                     new EntityNode(sourceMethodId),
                     CorePredicates.Calls,
@@ -1233,6 +1237,21 @@ public sealed class ProjectStructureAnalyzer : IProjectStructureAnalyzer
             var targetSymbol = calledSymbol.ReducedFrom ?? calledSymbol;
             if (targetSymbol.ContainingType is null)
             {
+                var unresolvedTarget = invocation.Expression.ToString().Trim();
+                if (string.IsNullOrWhiteSpace(unresolvedTarget))
+                {
+                    unresolvedTarget = invocation.ToString().Trim();
+                }
+
+                var unresolvedTargetId = GetOrCreateUnresolvedCallTargetId(
+                    unresolvedTarget,
+                    "missing-containing-type",
+                    unresolvedCallTargetIdByText,
+                    triples);
+                triples.Add(new SemanticTriple(
+                    new EntityNode(sourceMethodId),
+                    CorePredicates.Calls,
+                    new EntityNode(unresolvedTargetId)));
                 diagnostics.Add(new IngestionDiagnostic(
                     "method:call:resolution:failed",
                     $"Invocation target has no containing type for '{targetSymbol.Name}' in method '{sourceMethodId.Value}'."));
@@ -1240,18 +1259,40 @@ public sealed class ProjectStructureAnalyzer : IProjectStructureAnalyzer
             }
 
             var targetTypeQualifiedName = GetTypeQualifiedName(targetSymbol.ContainingType);
-            if (typeIdByQualifiedName.TryGetValue(targetTypeQualifiedName, out var targetTypeId) &&
-                methodCandidatesByTypeId.TryGetValue(targetTypeId, out var targetCandidates))
+            if (typeIdByQualifiedName.TryGetValue(targetTypeQualifiedName, out var targetTypeId))
             {
-                var targetMethodId = ResolveTargetMethodId(targetSymbol, targetCandidates);
-                if (targetMethodId is not null)
+                if (methodCandidatesByTypeId.TryGetValue(targetTypeId, out var targetCandidates))
                 {
-                    triples.Add(new SemanticTriple(
-                        new EntityNode(sourceMethodId),
-                        CorePredicates.Calls,
-                        new EntityNode(targetMethodId.Value)));
-                    continue;
+                    var targetMethodId = ResolveTargetMethodId(targetSymbol, targetCandidates);
+                    if (targetMethodId is not null)
+                    {
+                        triples.Add(new SemanticTriple(
+                            new EntityNode(sourceMethodId),
+                            CorePredicates.Calls,
+                            new EntityNode(targetMethodId.Value)));
+                        continue;
+                    }
                 }
+
+                var unresolvedTarget = invocation.Expression.ToString().Trim();
+                if (string.IsNullOrWhiteSpace(unresolvedTarget))
+                {
+                    unresolvedTarget = invocation.ToString().Trim();
+                }
+
+                var unresolvedTargetId = GetOrCreateUnresolvedCallTargetId(
+                    unresolvedTarget,
+                    "internal-target-unmatched",
+                    unresolvedCallTargetIdByText,
+                    triples);
+                triples.Add(new SemanticTriple(
+                    new EntityNode(sourceMethodId),
+                    CorePredicates.Calls,
+                    new EntityNode(unresolvedTargetId)));
+                diagnostics.Add(new IngestionDiagnostic(
+                    "method:call:internal-target-unmatched",
+                    $"Invocation '{invocation}' resolved to internal type '{targetTypeQualifiedName}' but no unique method declaration could be matched in method '{sourceMethodId.Value}'."));
+                continue;
             }
 
             var externalTypeName = targetSymbol.ContainingType.ToDisplayString(SymbolDisplayFormat.CSharpErrorMessageFormat);
@@ -1366,22 +1407,29 @@ public sealed class ProjectStructureAnalyzer : IProjectStructureAnalyzer
 
     private EntityId GetOrCreateUnresolvedCallTargetId(
         string targetText,
+        string resolutionReason,
         Dictionary<string, EntityId> unresolvedCallTargetIdByText,
         List<SemanticTriple> triples)
     {
-        if (unresolvedCallTargetIdByText.TryGetValue(targetText, out var existing))
+        var key = $"{resolutionReason}|{targetText}";
+        if (unresolvedCallTargetIdByText.TryGetValue(key, out var existing))
         {
             return existing;
         }
 
-        var unresolvedId = _stableIdGenerator.Create(new EntityKey("unresolved-call-target", targetText));
-        unresolvedCallTargetIdByText[targetText] = unresolvedId;
+        var unresolvedNaturalKey = $"{resolutionReason}:{targetText}";
+        var unresolvedId = _stableIdGenerator.Create(new EntityKey("unresolved-call-target", unresolvedNaturalKey));
+        unresolvedCallTargetIdByText[key] = unresolvedId;
         AddEntityTriples(
             triples,
             unresolvedId,
             "unresolved-call-target",
             targetText,
             $"unresolved-call/{targetText}");
+        triples.Add(new SemanticTriple(
+            new EntityNode(unresolvedId),
+            CorePredicates.ResolutionReason,
+            new LiteralNode(resolutionReason)));
 
         return unresolvedId;
     }

--- a/src/CodeLlmWiki.Ingestion/ProjectStructure/ProjectStructureAnalyzer.cs
+++ b/src/CodeLlmWiki.Ingestion/ProjectStructure/ProjectStructureAnalyzer.cs
@@ -5,6 +5,9 @@ using System.Globalization;
 using CodeLlmWiki.Contracts.Graph;
 using CodeLlmWiki.Contracts.Identity;
 using CodeLlmWiki.Query.ProjectStructure;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
 using Microsoft.Build.Construction;
 using Microsoft.Build.Evaluation;
 
@@ -348,9 +351,12 @@ public sealed class ProjectStructureAnalyzer : IProjectStructureAnalyzer
         var directInterfaceTypeIdsByTypeId = new Dictionary<EntityId, List<EntityId>>();
         var pendingMemberTypeLinks = new List<PendingMemberTypeLink>();
         var pendingMethodReturnTypeLinks = new List<PendingMethodReturnTypeLink>();
+        var pendingMethodExtendedTypeLinks = new List<PendingMethodExtendedTypeLink>();
         var pendingMethodParameterTypeLinks = new List<PendingMethodParameterTypeLink>();
+        var methodIdByDeclarationLocation = new Dictionary<MethodDeclarationLocationKey, EntityId>();
         var externalStubIdByReference = new Dictionary<string, EntityId>(StringComparer.Ordinal);
         var unresolvedReferenceIdByText = new Dictionary<string, EntityId>(StringComparer.Ordinal);
+        var unresolvedCallTargetIdByText = new Dictionary<string, EntityId>(StringComparer.Ordinal);
         var projectAssemblyContexts = BuildProjectAssemblyContexts(repositoryRoot, projectAssemblyNameByPath);
 
         foreach (var group in typeGroups)
@@ -607,6 +613,24 @@ public sealed class ProjectStructureAnalyzer : IProjectStructureAnalyzer
                     CorePredicates.ContainsMethod,
                     new EntityNode(methodId)));
 
+                if (representativeMethod.IsExtensionMethod)
+                {
+                    triples.Add(new SemanticTriple(
+                        new EntityNode(methodId),
+                        CorePredicates.IsExtensionMethod,
+                        new LiteralNode("true")));
+
+                    if (!string.IsNullOrWhiteSpace(representativeMethod.ExtendedTypeName))
+                    {
+                        pendingMethodExtendedTypeLinks.Add(new PendingMethodExtendedTypeLink(
+                            methodId,
+                            representative.NamespaceName,
+                            representativeMethod.ExtendedTypeName!,
+                            representative.ImportedNamespaces,
+                            representative.ImportedAliases));
+                    }
+                }
+
                 if (!methodCandidatesByTypeId.TryGetValue(typeId, out var methodCandidates))
                 {
                     methodCandidates = new List<MethodRelationshipCandidate>();
@@ -659,6 +683,7 @@ public sealed class ProjectStructureAnalyzer : IProjectStructureAnalyzer
                              .ThenBy(x => x.Line)
                              .ThenBy(x => x.Column))
                 {
+                    methodIdByDeclarationLocation[new MethodDeclarationLocationKey(location.RelativeFilePath, location.Line, location.Column)] = methodId;
                     triples.Add(new SemanticTriple(
                         new EntityNode(methodId),
                         CorePredicates.DeclarationSourceLocation,
@@ -922,6 +947,17 @@ public sealed class ProjectStructureAnalyzer : IProjectStructureAnalyzer
             }
         }
 
+        CaptureMethodCalls(
+            repositoryRoot,
+            sourceFiles,
+            typeIdByQualifiedName,
+            methodCandidatesByTypeId,
+            methodIdByDeclarationLocation,
+            externalStubIdByReference,
+            unresolvedCallTargetIdByText,
+            triples,
+            diagnostics);
+
         foreach (var pendingMemberTypeLink in pendingMemberTypeLinks)
         {
             var resolvedMemberTypeName = ResolveInternalTypeName(
@@ -985,6 +1021,38 @@ public sealed class ProjectStructureAnalyzer : IProjectStructureAnalyzer
                 new EntityNode(resolvedReturnTypeId)));
         }
 
+        foreach (var pendingExtendedTypeLink in pendingMethodExtendedTypeLinks)
+        {
+            var resolvedExtendedTypeName = ResolveInternalTypeName(
+                pendingExtendedTypeLink.NamespaceName,
+                pendingExtendedTypeLink.ExtendedTypeName,
+                pendingExtendedTypeLink.ImportedNamespaces,
+                pendingExtendedTypeLink.ImportedAliases,
+                typeIdByQualifiedName,
+                declaredTypeNamesBySimpleName);
+
+            if (resolvedExtendedTypeName is null || !typeIdByQualifiedName.TryGetValue(resolvedExtendedTypeName, out var resolvedExtendedTypeId))
+            {
+                var normalizedExtendedType = NormalizeTypeReferenceName(pendingExtendedTypeLink.ExtendedTypeName);
+                if (IsExternalStubCandidate(normalizedExtendedType))
+                {
+                    resolvedExtendedTypeId = GetOrCreateExternalStubId(normalizedExtendedType, externalStubIdByReference, triples);
+                }
+                else
+                {
+                    diagnostics.Add(new IngestionDiagnostic(
+                        "type:resolution:fallback",
+                        $"Unresolved extension target type '{pendingExtendedTypeLink.ExtendedTypeName}' for method '{pendingExtendedTypeLink.MethodId.Value}'."));
+                    continue;
+                }
+            }
+
+            triples.Add(new SemanticTriple(
+                new EntityNode(pendingExtendedTypeLink.MethodId),
+                CorePredicates.ExtendsType,
+                new EntityNode(resolvedExtendedTypeId)));
+        }
+
         foreach (var pendingParameterTypeLink in pendingMethodParameterTypeLinks)
         {
             var resolvedParameterTypeName = ResolveInternalTypeName(
@@ -1016,6 +1084,306 @@ public sealed class ProjectStructureAnalyzer : IProjectStructureAnalyzer
                 CorePredicates.HasDeclaredType,
                 new EntityNode(resolvedParameterTypeId)));
         }
+    }
+
+    private void CaptureMethodCalls(
+        string repositoryRoot,
+        IReadOnlyList<string> sourceFiles,
+        IReadOnlyDictionary<string, EntityId> typeIdByQualifiedName,
+        IReadOnlyDictionary<EntityId, List<MethodRelationshipCandidate>> methodCandidatesByTypeId,
+        IReadOnlyDictionary<MethodDeclarationLocationKey, EntityId> methodIdByDeclarationLocation,
+        Dictionary<string, EntityId> externalStubIdByReference,
+        Dictionary<string, EntityId> unresolvedCallTargetIdByText,
+        List<SemanticTriple> triples,
+        List<IngestionDiagnostic> diagnostics)
+    {
+        if (sourceFiles.Count == 0 || methodIdByDeclarationLocation.Count == 0)
+        {
+            return;
+        }
+
+        var syntaxTrees = new List<SyntaxTree>(sourceFiles.Count);
+        foreach (var relativePath in sourceFiles.OrderBy(x => x, StringComparer.Ordinal))
+        {
+            var fullPath = Path.Combine(repositoryRoot, relativePath.Replace('/', Path.DirectorySeparatorChar));
+            if (!File.Exists(fullPath))
+            {
+                continue;
+            }
+
+            var sourceText = File.ReadAllText(fullPath);
+            var syntaxTree = CSharpSyntaxTree.ParseText(sourceText, path: relativePath);
+            syntaxTrees.Add(syntaxTree);
+        }
+
+        if (syntaxTrees.Count == 0)
+        {
+            return;
+        }
+
+        var references = BuildCompilationReferences(diagnostics);
+        var compilation = CSharpCompilation.Create(
+            assemblyName: "CodeLlmWiki.CallGraph",
+            syntaxTrees: syntaxTrees,
+            references: references,
+            options: new CSharpCompilationOptions(OutputKind.DynamicallyLinkedLibrary));
+
+        foreach (var syntaxTree in syntaxTrees)
+        {
+            var semanticModel = compilation.GetSemanticModel(syntaxTree, ignoreAccessibility: true);
+            var root = syntaxTree.GetRoot() as CompilationUnitSyntax;
+            if (root is null)
+            {
+                continue;
+            }
+
+            foreach (var methodDeclaration in root.DescendantNodes().OfType<MethodDeclarationSyntax>())
+            {
+                if (methodDeclaration.Body is null && methodDeclaration.ExpressionBody is null)
+                {
+                    continue;
+                }
+
+                var sourceMethodId = ResolveSourceMethodId(methodDeclaration.Identifier.GetLocation(), methodIdByDeclarationLocation);
+                if (sourceMethodId == default)
+                {
+                    continue;
+                }
+
+                AddCallEdgesForInvocations(
+                    methodDeclaration,
+                    sourceMethodId,
+                    semanticModel,
+                    typeIdByQualifiedName,
+                    methodCandidatesByTypeId,
+                    externalStubIdByReference,
+                    unresolvedCallTargetIdByText,
+                    triples,
+                    diagnostics);
+            }
+
+            foreach (var constructorDeclaration in root.DescendantNodes().OfType<ConstructorDeclarationSyntax>())
+            {
+                if (constructorDeclaration.Body is null && constructorDeclaration.ExpressionBody is null)
+                {
+                    continue;
+                }
+
+                var sourceMethodId = ResolveSourceMethodId(constructorDeclaration.Identifier.GetLocation(), methodIdByDeclarationLocation);
+                if (sourceMethodId == default)
+                {
+                    continue;
+                }
+
+                AddCallEdgesForInvocations(
+                    constructorDeclaration,
+                    sourceMethodId,
+                    semanticModel,
+                    typeIdByQualifiedName,
+                    methodCandidatesByTypeId,
+                    externalStubIdByReference,
+                    unresolvedCallTargetIdByText,
+                    triples,
+                    diagnostics);
+            }
+        }
+    }
+
+    private void AddCallEdgesForInvocations(
+        MemberDeclarationSyntax declaration,
+        EntityId sourceMethodId,
+        SemanticModel semanticModel,
+        IReadOnlyDictionary<string, EntityId> typeIdByQualifiedName,
+        IReadOnlyDictionary<EntityId, List<MethodRelationshipCandidate>> methodCandidatesByTypeId,
+        Dictionary<string, EntityId> externalStubIdByReference,
+        Dictionary<string, EntityId> unresolvedCallTargetIdByText,
+        List<SemanticTriple> triples,
+        List<IngestionDiagnostic> diagnostics)
+    {
+        var invocations = declaration
+            .DescendantNodes()
+            .OfType<InvocationExpressionSyntax>()
+            .ToArray();
+
+        foreach (var invocation in invocations)
+        {
+            var symbolInfo = semanticModel.GetSymbolInfo(invocation);
+            var calledSymbol = symbolInfo.Symbol as IMethodSymbol
+                               ?? symbolInfo.CandidateSymbols.OfType<IMethodSymbol>().FirstOrDefault();
+
+            if (calledSymbol is null)
+            {
+                var unresolvedTarget = invocation.Expression.ToString().Trim();
+                if (string.IsNullOrWhiteSpace(unresolvedTarget))
+                {
+                    unresolvedTarget = invocation.ToString().Trim();
+                }
+
+                var unresolvedTargetId = GetOrCreateUnresolvedCallTargetId(unresolvedTarget, unresolvedCallTargetIdByText, triples);
+                triples.Add(new SemanticTriple(
+                    new EntityNode(sourceMethodId),
+                    CorePredicates.Calls,
+                    new EntityNode(unresolvedTargetId)));
+                diagnostics.Add(new IngestionDiagnostic(
+                    "method:call:resolution:failed",
+                    $"Failed to resolve invocation '{invocation}' in method '{sourceMethodId.Value}'."));
+                continue;
+            }
+
+            var targetSymbol = calledSymbol.ReducedFrom ?? calledSymbol;
+            if (targetSymbol.ContainingType is null)
+            {
+                diagnostics.Add(new IngestionDiagnostic(
+                    "method:call:resolution:failed",
+                    $"Invocation target has no containing type for '{targetSymbol.Name}' in method '{sourceMethodId.Value}'."));
+                continue;
+            }
+
+            var targetTypeQualifiedName = GetTypeQualifiedName(targetSymbol.ContainingType);
+            if (typeIdByQualifiedName.TryGetValue(targetTypeQualifiedName, out var targetTypeId) &&
+                methodCandidatesByTypeId.TryGetValue(targetTypeId, out var targetCandidates))
+            {
+                var targetMethodId = ResolveTargetMethodId(targetSymbol, targetCandidates);
+                if (targetMethodId is not null)
+                {
+                    triples.Add(new SemanticTriple(
+                        new EntityNode(sourceMethodId),
+                        CorePredicates.Calls,
+                        new EntityNode(targetMethodId.Value)));
+                    continue;
+                }
+            }
+
+            var externalTypeName = targetSymbol.ContainingType.ToDisplayString(SymbolDisplayFormat.CSharpErrorMessageFormat);
+            var externalTypeId = GetOrCreateExternalStubId(externalTypeName, externalStubIdByReference, triples);
+            if (!string.IsNullOrWhiteSpace(targetSymbol.ContainingAssembly?.Name))
+            {
+                triples.Add(new SemanticTriple(
+                    new EntityNode(externalTypeId),
+                    CorePredicates.ExternalAssemblyName,
+                    new LiteralNode(targetSymbol.ContainingAssembly!.Name)));
+            }
+
+            triples.Add(new SemanticTriple(
+                new EntityNode(sourceMethodId),
+                CorePredicates.Calls,
+                new EntityNode(externalTypeId)));
+        }
+    }
+
+    private static IReadOnlyList<MetadataReference> BuildCompilationReferences(List<IngestionDiagnostic> diagnostics)
+    {
+        var tpa = AppContext.GetData("TRUSTED_PLATFORM_ASSEMBLIES") as string;
+        if (string.IsNullOrWhiteSpace(tpa))
+        {
+            diagnostics.Add(new IngestionDiagnostic(
+                "method:call:references:missing",
+                "Trusted platform assemblies were unavailable; semantic call resolution may be degraded."));
+            return [];
+        }
+
+        return tpa
+            .Split(Path.PathSeparator, StringSplitOptions.RemoveEmptyEntries)
+            .Where(File.Exists)
+            .Select(path => MetadataReference.CreateFromFile(path))
+            .ToArray();
+    }
+
+    private static EntityId ResolveSourceMethodId(
+        Location declarationLocation,
+        IReadOnlyDictionary<MethodDeclarationLocationKey, EntityId> methodIdByDeclarationLocation)
+    {
+        var lineSpan = declarationLocation.GetLineSpan();
+        var key = new MethodDeclarationLocationKey(
+            declarationLocation.SourceTree?.FilePath ?? string.Empty,
+            lineSpan.StartLinePosition.Line + 1,
+            lineSpan.StartLinePosition.Character + 1);
+
+        return methodIdByDeclarationLocation.TryGetValue(key, out var methodId)
+            ? methodId
+            : default;
+    }
+
+    private static EntityId? ResolveTargetMethodId(
+        IMethodSymbol targetSymbol,
+        IReadOnlyList<MethodRelationshipCandidate> candidates)
+    {
+        var targetName = targetSymbol.MethodKind == MethodKind.Constructor
+            ? ".ctor"
+            : targetSymbol.Name;
+        var arity = targetSymbol.Arity;
+        var parameterCount = targetSymbol.Parameters.Length;
+
+        var nameAndShapeMatches = candidates
+            .Where(x =>
+                string.Equals(x.Kind, "method", StringComparison.Ordinal)
+                && ExtractMethodNameForRelationship(x.CanonicalName).Equals(targetName, StringComparison.Ordinal)
+                && x.Arity == arity
+                && x.ParameterTypeSignatures.Count == parameterCount)
+            .ToArray();
+
+        if (nameAndShapeMatches.Length == 1)
+        {
+            return nameAndShapeMatches[0].MethodId;
+        }
+
+        if (nameAndShapeMatches.Length == 0)
+        {
+            return null;
+        }
+
+        var symbolParameterSignatures = targetSymbol.Parameters
+            .Select(x => NormalizeMethodIdentityTypeSignature(x.Type.ToDisplayString(SymbolDisplayFormat.MinimallyQualifiedFormat)))
+            .ToArray();
+
+        var exactMatches = nameAndShapeMatches
+            .Where(candidate => candidate.ParameterTypeSignatures.SequenceEqual(symbolParameterSignatures, StringComparer.Ordinal))
+            .ToArray();
+
+        return exactMatches.Length == 1
+            ? exactMatches[0].MethodId
+            : null;
+    }
+
+    private static string GetTypeQualifiedName(ITypeSymbol typeSymbol)
+    {
+        var segments = new Stack<string>();
+        var currentType = typeSymbol;
+        while (currentType is not null)
+        {
+            segments.Push(currentType.MetadataName);
+            currentType = currentType.ContainingType;
+        }
+
+        var namespaceName = typeSymbol.ContainingNamespace?.ToDisplayString();
+        if (!string.IsNullOrWhiteSpace(namespaceName) && !typeSymbol.ContainingNamespace!.IsGlobalNamespace)
+        {
+            segments.Push(namespaceName);
+        }
+
+        return string.Join(".", segments);
+    }
+
+    private EntityId GetOrCreateUnresolvedCallTargetId(
+        string targetText,
+        Dictionary<string, EntityId> unresolvedCallTargetIdByText,
+        List<SemanticTriple> triples)
+    {
+        if (unresolvedCallTargetIdByText.TryGetValue(targetText, out var existing))
+        {
+            return existing;
+        }
+
+        var unresolvedId = _stableIdGenerator.Create(new EntityKey("unresolved-call-target", targetText));
+        unresolvedCallTargetIdByText[targetText] = unresolvedId;
+        AddEntityTriples(
+            triples,
+            unresolvedId,
+            "unresolved-call-target",
+            targetText,
+            $"unresolved-call/{targetText}");
+
+        return unresolvedId;
     }
 
     private static string FormatDeclarationSourceLocation(DeclarationSourceLocation location)
@@ -1378,12 +1746,21 @@ public sealed class ProjectStructureAnalyzer : IProjectStructureAnalyzer
         IReadOnlyList<string> ImportedNamespaces,
         IReadOnlyDictionary<string, string> ImportedAliases);
 
+    private sealed record PendingMethodExtendedTypeLink(
+        EntityId MethodId,
+        string NamespaceName,
+        string ExtendedTypeName,
+        IReadOnlyList<string> ImportedNamespaces,
+        IReadOnlyDictionary<string, string> ImportedAliases);
+
     private sealed record PendingMethodParameterTypeLink(
         EntityId ParameterId,
         string NamespaceName,
         string DeclaredTypeName,
         IReadOnlyList<string> ImportedNamespaces,
         IReadOnlyDictionary<string, string> ImportedAliases);
+
+    private sealed record MethodDeclarationLocationKey(string RelativeFilePath, int Line, int Column);
 
     private sealed record ProjectAssemblyContext(string RelativeDirectory, string AssemblyName);
 

--- a/src/CodeLlmWiki.Query/ProjectStructure/MethodRelationNode.cs
+++ b/src/CodeLlmWiki.Query/ProjectStructure/MethodRelationNode.cs
@@ -9,4 +9,5 @@ public sealed record MethodRelationNode(
     EntityId? TargetMemberId,
     TypeReferenceNode? ExternalTargetType,
     string? ExternalAssemblyName,
-    DeclarationResolutionStatus ResolutionStatus);
+    DeclarationResolutionStatus ResolutionStatus,
+    string? ResolutionReason = null);

--- a/src/CodeLlmWiki.Query/ProjectStructure/ProjectStructureQueryService.cs
+++ b/src/CodeLlmWiki.Query/ProjectStructure/ProjectStructureQueryService.cs
@@ -397,6 +397,10 @@ public sealed class ProjectStructureQueryService : IProjectStructureQueryService
             {
                 meta.ExternalAssemblyName = value;
             }
+            else if (triple.Predicate == CorePredicates.ResolutionReason)
+            {
+                meta.ResolutionReason = value;
+            }
         }
 
         return byId;
@@ -1117,7 +1121,8 @@ public sealed class ProjectStructureQueryService : IProjectStructureQueryService
                         null,
                         null,
                         null,
-                        resolutionStatus);
+                        resolutionStatus,
+                        null);
                 }
 
                 return new MethodRelationNode(
@@ -1132,7 +1137,10 @@ public sealed class ProjectStructureQueryService : IProjectStructureQueryService
                     metadataById.TryGetValue(x.Object, out var callTargetMeta) && !string.IsNullOrWhiteSpace(callTargetMeta.ExternalAssemblyName)
                         ? callTargetMeta.ExternalAssemblyName
                         : null,
-                    resolutionStatus);
+                    resolutionStatus,
+                    metadataById.TryGetValue(x.Object, out var unresolvedTargetMeta) && !string.IsNullOrWhiteSpace(unresolvedTargetMeta.ResolutionReason)
+                        ? unresolvedTargetMeta.ResolutionReason
+                        : null);
             }))
             .Concat(methodReadsPropertyEdges.Select(x => new MethodRelationNode(
                 x.Subject,
@@ -1381,6 +1389,7 @@ public sealed class ProjectStructureQueryService : IProjectStructureQueryService
             ParameterName = string.Empty;
             ParameterOrdinal = -1;
             ExternalAssemblyName = string.Empty;
+            ResolutionReason = string.Empty;
         }
 
         public EntityId Id { get; }
@@ -1456,6 +1465,8 @@ public sealed class ProjectStructureQueryService : IProjectStructureQueryService
         public int ParameterOrdinal { get; set; }
 
         public string ExternalAssemblyName { get; set; }
+
+        public string ResolutionReason { get; set; }
 
         public bool IsType(string entityType) => EntityType.Equals(entityType, StringComparison.OrdinalIgnoreCase);
     }

--- a/src/CodeLlmWiki.Query/ProjectStructure/ProjectStructureQueryService.cs
+++ b/src/CodeLlmWiki.Query/ProjectStructure/ProjectStructureQueryService.cs
@@ -393,6 +393,10 @@ public sealed class ProjectStructureQueryService : IProjectStructureQueryService
             {
                 meta.ParameterName = value;
             }
+            else if (triple.Predicate == CorePredicates.ExternalAssemblyName)
+            {
+                meta.ExternalAssemblyName = value;
+            }
         }
 
         return byId;
@@ -1101,14 +1105,35 @@ public sealed class ProjectStructureQueryService : IProjectStructureQueryService
                 null,
                 null,
                 GetReferenceResolutionStatus(x.Object, metadataById))))
-            .Concat(methodCallsEdges.Select(x => new MethodRelationNode(
-                x.Subject,
-                MethodRelationKind.Calls,
-                x.Object,
-                null,
-                null,
-                null,
-                GetReferenceResolutionStatus(x.Object, metadataById))))
+            .Concat(methodCallsEdges.Select(x =>
+            {
+                var resolutionStatus = GetReferenceResolutionStatus(x.Object, metadataById);
+                if (metadataById.TryGetValue(x.Object, out var targetMeta) && targetMeta.IsType("method-declaration"))
+                {
+                    return new MethodRelationNode(
+                        x.Subject,
+                        MethodRelationKind.Calls,
+                        x.Object,
+                        null,
+                        null,
+                        null,
+                        resolutionStatus);
+                }
+
+                return new MethodRelationNode(
+                    x.Subject,
+                    MethodRelationKind.Calls,
+                    null,
+                    null,
+                    new TypeReferenceNode(
+                        x.Object,
+                        metadataById.TryGetValue(x.Object, out var externalMeta) ? externalMeta.Name : x.Object.Value,
+                        resolutionStatus),
+                    metadataById.TryGetValue(x.Object, out var callTargetMeta) && !string.IsNullOrWhiteSpace(callTargetMeta.ExternalAssemblyName)
+                        ? callTargetMeta.ExternalAssemblyName
+                        : null,
+                    resolutionStatus);
+            }))
             .Concat(methodReadsPropertyEdges.Select(x => new MethodRelationNode(
                 x.Subject,
                 MethodRelationKind.ReadsProperty,
@@ -1355,6 +1380,7 @@ public sealed class ProjectStructureQueryService : IProjectStructureQueryService
             IsExtensionMethod = false;
             ParameterName = string.Empty;
             ParameterOrdinal = -1;
+            ExternalAssemblyName = string.Empty;
         }
 
         public EntityId Id { get; }
@@ -1428,6 +1454,8 @@ public sealed class ProjectStructureQueryService : IProjectStructureQueryService
         public string ParameterName { get; set; }
 
         public int ParameterOrdinal { get; set; }
+
+        public string ExternalAssemblyName { get; set; }
 
         public bool IsType(string entityType) => EntityType.Equals(entityType, StringComparison.OrdinalIgnoreCase);
     }

--- a/src/CodeLlmWiki.Wiki/ProjectStructure/ProjectStructureWikiRenderer.cs
+++ b/src/CodeLlmWiki.Wiki/ProjectStructure/ProjectStructureWikiRenderer.cs
@@ -827,11 +827,14 @@ public sealed class ProjectStructureWikiRenderer : IProjectStructureWikiRenderer
                 var assemblySuffix = string.IsNullOrWhiteSpace(relation.ExternalAssemblyName)
                     ? string.Empty
                     : $" ({relation.ExternalAssemblyName})";
+                var unresolvedReasonSuffix = string.IsNullOrWhiteSpace(relation.ResolutionReason)
+                    ? string.Empty
+                    : $": {relation.ResolutionReason}";
                 var statusSuffix = relation.ExternalTargetType.ResolutionStatus switch
                 {
                     DeclarationResolutionStatus.ExternalStub => " (external)",
-                    DeclarationResolutionStatus.SourceTextFallback => " (unresolved)",
-                    DeclarationResolutionStatus.Unresolved => " (unresolved)",
+                    DeclarationResolutionStatus.SourceTextFallback => $" (unresolved{unresolvedReasonSuffix})",
+                    DeclarationResolutionStatus.Unresolved => $" (unresolved{unresolvedReasonSuffix})",
                     _ => string.Empty,
                 };
                 sb.AppendLine($"- {relation.ExternalTargetType.DisplayText}{assemblySuffix}{statusSuffix}");

--- a/src/CodeLlmWiki.Wiki/ProjectStructure/ProjectStructureWikiRenderer.cs
+++ b/src/CodeLlmWiki.Wiki/ProjectStructure/ProjectStructureWikiRenderer.cs
@@ -110,6 +110,26 @@ public sealed class ProjectStructureWikiRenderer : IProjectStructureWikiRenderer
                     .Distinct()
                     .OrderBy(v => v.Value, StringComparer.Ordinal)
                     .ToArray());
+        var callRelationsBySourceMethodId = model.Declarations.Methods.Relations
+            .Where(x => x.Kind == MethodRelationKind.Calls)
+            .GroupBy(x => x.SourceMethodId)
+            .ToDictionary(
+                x => x.Key,
+                x => (IReadOnlyList<MethodRelationNode>)x
+                    .OrderBy(v => v.TargetMethodId?.Value ?? string.Empty, StringComparer.Ordinal)
+                    .ThenBy(v => v.ExternalTargetType?.DisplayText ?? string.Empty, StringComparer.Ordinal)
+                    .ThenBy(v => v.ExternalAssemblyName ?? string.Empty, StringComparer.Ordinal)
+                    .ToArray());
+        var calledByMethodIdsByTargetMethodId = model.Declarations.Methods.Relations
+            .Where(x => x.Kind == MethodRelationKind.Calls && x.TargetMethodId is not null)
+            .GroupBy(x => x.TargetMethodId!.Value)
+            .ToDictionary(
+                x => x.Key,
+                x => (IReadOnlyList<EntityId>)x
+                    .Select(v => v.SourceMethodId)
+                    .Distinct()
+                    .OrderBy(v => v.Value, StringComparer.Ordinal)
+                    .ToArray());
         var fileById = model.Files.ToDictionary(x => x.Id, x => x);
         var namespaceBacklinksByFileId = BuildNamespaceBacklinksByFileId(model.Declarations.Namespaces, fileById);
         var typeBacklinksByFileId = BuildTypeBacklinksByFileId(model.Declarations.Types, fileById);
@@ -134,6 +154,8 @@ public sealed class ProjectStructureWikiRenderer : IProjectStructureWikiRenderer
                 methodById,
                 implementedMethodIdsBySourceMethodId,
                 overriddenMethodIdsBySourceMethodId,
+                callRelationsBySourceMethodId,
+                calledByMethodIdsByTargetMethodId,
                 fileById,
                 resolver)));
         pages.AddRange(orderedFiles.Select(file => RenderFilePage(model.Repository, file, namespaceBacklinksByFileId, typeBacklinksByFileId, memberBacklinksByFileId, methodBacklinksByFileId, resolver, maxMergeEntriesPerFile)));
@@ -779,6 +801,47 @@ public sealed class ProjectStructureWikiRenderer : IProjectStructureWikiRenderer
         }
     }
 
+    private static void AppendOutgoingCallSection(
+        StringBuilder sb,
+        EntityId sourceMethodId,
+        IReadOnlyDictionary<EntityId, IReadOnlyList<MethodRelationNode>> callRelationsBySourceMethodId,
+        IReadOnlyDictionary<EntityId, MethodDeclarationNode> methodById,
+        WikiPathResolver resolver)
+    {
+        if (!callRelationsBySourceMethodId.TryGetValue(sourceMethodId, out var callRelations) || callRelations.Count == 0)
+        {
+            sb.AppendLine("- none");
+            return;
+        }
+
+        foreach (var relation in callRelations)
+        {
+            if (relation.TargetMethodId is { } targetMethodId && methodById.TryGetValue(targetMethodId, out var targetMethod))
+            {
+                sb.AppendLine($"- {resolver.ToWikiLink(targetMethod.Id, FormatMethodLinkAlias(targetMethod))}");
+                continue;
+            }
+
+            if (relation.ExternalTargetType is not null)
+            {
+                var assemblySuffix = string.IsNullOrWhiteSpace(relation.ExternalAssemblyName)
+                    ? string.Empty
+                    : $" ({relation.ExternalAssemblyName})";
+                var statusSuffix = relation.ExternalTargetType.ResolutionStatus switch
+                {
+                    DeclarationResolutionStatus.ExternalStub => " (external)",
+                    DeclarationResolutionStatus.SourceTextFallback => " (unresolved)",
+                    DeclarationResolutionStatus.Unresolved => " (unresolved)",
+                    _ => string.Empty,
+                };
+                sb.AppendLine($"- {relation.ExternalTargetType.DisplayText}{assemblySuffix}{statusSuffix}");
+                continue;
+            }
+
+            sb.AppendLine("- unresolved target");
+        }
+    }
+
     private static string FormatMethodLinkAlias(MethodDeclarationNode method)
     {
         var orderedParameters = method.Parameters
@@ -825,6 +888,8 @@ public sealed class ProjectStructureWikiRenderer : IProjectStructureWikiRenderer
         IReadOnlyDictionary<EntityId, MethodDeclarationNode> methodById,
         IReadOnlyDictionary<EntityId, IReadOnlyList<EntityId>> implementedMethodIdsBySourceMethodId,
         IReadOnlyDictionary<EntityId, IReadOnlyList<EntityId>> overriddenMethodIdsBySourceMethodId,
+        IReadOnlyDictionary<EntityId, IReadOnlyList<MethodRelationNode>> callRelationsBySourceMethodId,
+        IReadOnlyDictionary<EntityId, IReadOnlyList<EntityId>> calledByMethodIdsByTargetMethodId,
         IReadOnlyDictionary<EntityId, FileNode> fileById,
         WikiPathResolver resolver)
     {
@@ -885,6 +950,24 @@ public sealed class ProjectStructureWikiRenderer : IProjectStructureWikiRenderer
             sb,
             methodDeclaration.Id,
             overriddenMethodIdsBySourceMethodId,
+            methodById,
+            resolver);
+
+        sb.AppendLine();
+        sb.AppendLine("## Calls");
+        AppendOutgoingCallSection(
+            sb,
+            methodDeclaration.Id,
+            callRelationsBySourceMethodId,
+            methodById,
+            resolver);
+
+        sb.AppendLine();
+        sb.AppendLine("## Called By");
+        AppendMethodRelationshipSection(
+            sb,
+            methodDeclaration.Id,
+            calledByMethodIdsByTargetMethodId,
             methodById,
             resolver);
 

--- a/tests/CodeLlmWiki.Ingestion.Tests/DeclarationContractsVerticalSliceTests.cs
+++ b/tests/CodeLlmWiki.Ingestion.Tests/DeclarationContractsVerticalSliceTests.cs
@@ -67,6 +67,7 @@ public sealed class DeclarationContractsVerticalSliceTests
         Assert.Contains("core:writesField", predicateIds);
         Assert.Contains("core:isExtensionMethod", predicateIds);
         Assert.Contains("core:extendsType", predicateIds);
+        Assert.Contains("core:externalAssemblyName", predicateIds);
     }
 
     [Fact]

--- a/tests/CodeLlmWiki.Ingestion.Tests/DeclarationContractsVerticalSliceTests.cs
+++ b/tests/CodeLlmWiki.Ingestion.Tests/DeclarationContractsVerticalSliceTests.cs
@@ -68,6 +68,7 @@ public sealed class DeclarationContractsVerticalSliceTests
         Assert.Contains("core:isExtensionMethod", predicateIds);
         Assert.Contains("core:extendsType", predicateIds);
         Assert.Contains("core:externalAssemblyName", predicateIds);
+        Assert.Contains("core:resolutionReason", predicateIds);
     }
 
     [Fact]

--- a/tests/CodeLlmWiki.Ingestion.Tests/MethodCallsVerticalSliceTests.cs
+++ b/tests/CodeLlmWiki.Ingestion.Tests/MethodCallsVerticalSliceTests.cs
@@ -1,0 +1,176 @@
+using System.Diagnostics;
+using CodeLlmWiki.Contracts.Identity;
+using CodeLlmWiki.Ingestion.ProjectStructure;
+using CodeLlmWiki.Query.ProjectStructure;
+using CodeLlmWiki.Wiki.ProjectStructure;
+
+namespace CodeLlmWiki.Ingestion.Tests;
+
+public sealed class MethodCallsVerticalSliceTests
+{
+    [Fact]
+    public async Task Query_CapturesInternalCalls_ExternalUsage_AndExtensionMetadata()
+    {
+        var fixture = await MethodCallsFixture.CreateAsync();
+        var analyzer = new ProjectStructureAnalyzer(new StableIdGenerator());
+        var analysis = await analyzer.AnalyzeAsync(fixture.RepositoryPath, CancellationToken.None);
+        var model = new ProjectStructureQueryService(analysis.Triples).GetModel(analysis.RepositoryId);
+
+        var callerType = model.Declarations.Types.Single(x => x.Name == "Caller");
+        var calleeType = model.Declarations.Types.Single(x => x.Name == "Callee");
+        var extensionType = model.Declarations.Types.Single(x => x.Name == "CalleeExtensions");
+
+        var callAll = model.Declarations.Methods.Declarations.Single(x => x.DeclaringTypeId == callerType.Id && x.Name == "CallAll");
+        var invoke = model.Declarations.Methods.Declarations.Single(x => x.DeclaringTypeId == callerType.Id && x.Name == "Invoke");
+        var ping = model.Declarations.Methods.Declarations.Single(x => x.DeclaringTypeId == calleeType.Id && x.Name == "Ping");
+        var touch = model.Declarations.Methods.Declarations.Single(x => x.DeclaringTypeId == extensionType.Id && x.Name == "Touch");
+
+        Assert.True(touch.IsExtensionMethod);
+        Assert.Equal(calleeType.Id, touch.ExtendedType?.TypeId);
+
+        var outgoingCalls = model.Declarations.Methods.Relations
+            .Where(x => x.Kind == MethodRelationKind.Calls && x.SourceMethodId == callAll.Id)
+            .ToArray();
+
+        Assert.Contains(outgoingCalls, x => x.TargetMethodId == ping.Id);
+        Assert.Contains(outgoingCalls, x => x.TargetMethodId == touch.Id);
+        Assert.Contains(outgoingCalls, x => x.ExternalTargetType is not null && !string.IsNullOrWhiteSpace(x.ExternalAssemblyName));
+        Assert.Contains(outgoingCalls, x => x.TargetMethodId is null && x.ExternalTargetType?.ResolutionStatus == DeclarationResolutionStatus.Unresolved);
+        Assert.Contains(analysis.Diagnostics, x => x.Code == "method:call:resolution:failed");
+
+        var incomingCalls = model.Declarations.Methods.Relations
+            .Where(x => x.Kind == MethodRelationKind.Calls && x.TargetMethodId == callAll.Id)
+            .ToArray();
+
+        Assert.Contains(incomingCalls, x => x.SourceMethodId == invoke.Id);
+    }
+
+    [Fact]
+    public async Task Render_MethodPages_IncludeCallsAndCalledBySections()
+    {
+        var fixture = await MethodCallsFixture.CreateAsync();
+        var analyzer = new ProjectStructureAnalyzer(new StableIdGenerator());
+        var analysis = await analyzer.AnalyzeAsync(fixture.RepositoryPath, CancellationToken.None);
+        var model = new ProjectStructureQueryService(analysis.Triples).GetModel(analysis.RepositoryId);
+        var pages = new ProjectStructureWikiRenderer().Render(model);
+
+        var callAllPage = pages.Single(x =>
+            x.RelativePath.StartsWith("methods/Acme/Calls/Caller/", StringComparison.Ordinal)
+            && x.Markdown.Contains("method_signature: Acme.Calls.Caller.CallAll()", StringComparison.Ordinal));
+
+        Assert.Contains("## Calls", callAllPage.Markdown, StringComparison.Ordinal);
+        Assert.Contains("## Called By", callAllPage.Markdown, StringComparison.Ordinal);
+        Assert.Contains("Ping()", callAllPage.Markdown, StringComparison.Ordinal);
+        Assert.Contains("Touch(", callAllPage.Markdown, StringComparison.Ordinal);
+        Assert.Contains("external", callAllPage.Markdown, StringComparison.OrdinalIgnoreCase);
+        Assert.Contains("unresolved", callAllPage.Markdown, StringComparison.OrdinalIgnoreCase);
+        Assert.Contains("Invoke()", callAllPage.Markdown, StringComparison.Ordinal);
+    }
+
+    private sealed class MethodCallsFixture
+    {
+        private MethodCallsFixture(string repositoryPath)
+        {
+            RepositoryPath = repositoryPath;
+        }
+
+        public string RepositoryPath { get; }
+
+        public static async Task<MethodCallsFixture> CreateAsync()
+        {
+            var root = Path.Combine(Path.GetTempPath(), $"codellmwiki-method-calls-{Guid.NewGuid():N}", "method-call-repo");
+            Directory.CreateDirectory(root);
+
+            await File.WriteAllTextAsync(Path.Combine(root, "Sample.slnx"),
+                """
+                <Solution>
+                  <Project Path="src/App/App.csproj" />
+                </Solution>
+                """);
+
+            var appDir = Path.Combine(root, "src", "App");
+            Directory.CreateDirectory(appDir);
+            await File.WriteAllTextAsync(Path.Combine(appDir, "App.csproj"),
+                """
+                <Project Sdk="Microsoft.NET.Sdk">
+                  <PropertyGroup>
+                    <TargetFramework>net10.0</TargetFramework>
+                    <AssemblyName>Acme.Calls.App</AssemblyName>
+                  </PropertyGroup>
+                </Project>
+                """);
+
+            await File.WriteAllTextAsync(Path.Combine(appDir, "Calls.cs"),
+                """
+                using System;
+
+                namespace Acme.Calls;
+
+                public class Callee
+                {
+                    public void Ping() { }
+                }
+
+                public static class CalleeExtensions
+                {
+                    public static void Touch(this Callee callee)
+                    {
+                        callee.Ping();
+                    }
+                }
+
+                public class Caller
+                {
+                    private readonly Callee _callee = new();
+
+                    public void CallAll()
+                    {
+                        _callee.Ping();
+                        _callee.Touch();
+                        Console.WriteLine("hello");
+                        UnknownApi.Missing();
+                    }
+
+                    public void Invoke()
+                    {
+                        CallAll();
+                    }
+                }
+                """);
+
+            RunGit(root, "init", "-b", "main");
+            RunGit(root, "config", "user.email", "test@example.com");
+            RunGit(root, "config", "user.name", "Test User");
+            RunGit(root, "add", ".");
+            RunGit(root, "commit", "-m", "initial");
+
+            return new MethodCallsFixture(root);
+        }
+    }
+
+    private static void RunGit(string workingDirectory, params string[] args)
+    {
+        var startInfo = new ProcessStartInfo
+        {
+            FileName = "git",
+            WorkingDirectory = workingDirectory,
+            RedirectStandardOutput = true,
+            RedirectStandardError = true,
+        };
+
+        foreach (var arg in args)
+        {
+            startInfo.ArgumentList.Add(arg);
+        }
+
+        using var process = Process.Start(startInfo)!;
+        process.WaitForExit();
+
+        if (process.ExitCode != 0)
+        {
+            var stdOut = process.StandardOutput.ReadToEnd();
+            var stdErr = process.StandardError.ReadToEnd();
+            throw new InvalidOperationException($"git {string.Join(' ', args)} failed: {stdOut}\n{stdErr}");
+        }
+    }
+}

--- a/tests/CodeLlmWiki.Ingestion.Tests/MethodCallsVerticalSliceTests.cs
+++ b/tests/CodeLlmWiki.Ingestion.Tests/MethodCallsVerticalSliceTests.cs
@@ -46,6 +46,31 @@ public sealed class MethodCallsVerticalSliceTests
     }
 
     [Fact]
+    public async Task Query_DoesNotClassifyUnmatchedInternalMethodTargets_AsExternal()
+    {
+        var fixture = await MethodCallsFixture.CreateAsync();
+        var analyzer = new ProjectStructureAnalyzer(new StableIdGenerator());
+        var analysis = await analyzer.AnalyzeAsync(fixture.RepositoryPath, CancellationToken.None);
+        var model = new ProjectStructureQueryService(analysis.Triples).GetModel(analysis.RepositoryId);
+
+        var callerType = model.Declarations.Types.Single(x => x.Name == "Caller");
+        var callLocal = model.Declarations.Methods.Declarations.Single(x => x.DeclaringTypeId == callerType.Id && x.Name == "CallLocal");
+
+        var outgoingCalls = model.Declarations.Methods.Relations
+            .Where(x => x.Kind == MethodRelationKind.Calls && x.SourceMethodId == callLocal.Id)
+            .ToArray();
+
+        var unresolvedLocalCall = Assert.Single(outgoingCalls);
+        Assert.Null(unresolvedLocalCall.TargetMethodId);
+        Assert.NotNull(unresolvedLocalCall.ExternalTargetType);
+        Assert.Equal(DeclarationResolutionStatus.Unresolved, unresolvedLocalCall.ExternalTargetType!.ResolutionStatus);
+        Assert.Null(unresolvedLocalCall.ExternalAssemblyName);
+        Assert.DoesNotContain(outgoingCalls, x => x.ExternalTargetType?.ResolutionStatus == DeclarationResolutionStatus.ExternalStub);
+
+        Assert.Contains(analysis.Diagnostics, x => x.Code == "method:call:internal-target-unmatched");
+    }
+
+    [Fact]
     public async Task Render_MethodPages_IncludeCallsAndCalledBySections()
     {
         var fixture = await MethodCallsFixture.CreateAsync();
@@ -65,6 +90,13 @@ public sealed class MethodCallsVerticalSliceTests
         Assert.Contains("external", callAllPage.Markdown, StringComparison.OrdinalIgnoreCase);
         Assert.Contains("unresolved", callAllPage.Markdown, StringComparison.OrdinalIgnoreCase);
         Assert.Contains("Invoke()", callAllPage.Markdown, StringComparison.Ordinal);
+
+        var callLocalPage = pages.Single(x =>
+            x.RelativePath.StartsWith("methods/Acme/Calls/Caller/", StringComparison.Ordinal)
+            && x.Markdown.Contains("method_signature: Acme.Calls.Caller.CallLocal()", StringComparison.Ordinal));
+
+        Assert.Contains("Local", callLocalPage.Markdown, StringComparison.Ordinal);
+        Assert.Contains("internal-target-unmatched", callLocalPage.Markdown, StringComparison.Ordinal);
     }
 
     private sealed class MethodCallsFixture
@@ -134,6 +166,15 @@ public sealed class MethodCallsVerticalSliceTests
                     public void Invoke()
                     {
                         CallAll();
+                    }
+
+                    public void CallLocal()
+                    {
+                        void Local()
+                        {
+                        }
+
+                        Local();
                     }
                 }
                 """);


### PR DESCRIPTION
## Summary
- add semantic invocation analysis to project analyzer for method `calls` relationships
- resolve internal call targets where possible; degrade unresolved invocations with diagnostics and unresolved call-target provenance
- capture external call usage at external type + assembly granularity
- detect extension methods, flag them, and link to extended type via `extendsType`
- render method-page `Calls` and `Called By` sections deterministically
- extend ontology/contracts/query projection for `externalAssemblyName`
- add method-calls vertical-slice tests and mark issue 045 / phase 4 complete in local planning docs

## Validation
- dotnet test tests/CodeLlmWiki.Ingestion.Tests/CodeLlmWiki.Ingestion.Tests.csproj --filter FullyQualifiedName~MethodCallsVerticalSliceTests
- dotnet test

Closes #45