### PR TITLE
PRD 003 / Issue 046: read-write data flow and type count scalars

### DIFF
--- a/plans/003/003-phase-3-dotnet-method-extraction-and-relations.issue.046.md
+++ b/plans/003/003-phase-3-dotnet-method-extraction-and-relations.issue.046.md
@@ -3,8 +3,8 @@
 > Parent PRD: [PRD 003](./003-phase-3-dotnet-method-extraction-and-relations.prd.md)
 
 - Issue: [#46](https://github.com/vbfg1973/code-llm-wiki/issues/46)
-- [ ] Status: open
-- [ ] Completion date:
+- [x] Status: complete
+- [x] Completion date: 2026-04-18
 
 ## Notes
 
@@ -18,10 +18,10 @@ Add internal property/field read-write data-flow extraction from methods and pub
 
 ## Acceptance criteria
 
-- [ ] Internal data-flow edges are captured for `reads_property`, `writes_property`, `reads_field`, and `writes_field`.
-- [ ] Type pages render per-property read/write counts with deterministic reader/writer method link lists, including explicit zero counts.
-- [ ] Type front matter publishes approved structural count scalars (`constructor_count`, `method_count`, `property_count`, `field_count`, `enum_member_count`, `record_parameter_count`, `behavioral_method_count`).
-- [ ] Method pages render deterministic `Reads`/`Writes` sections for internal targets.
+- [x] Internal data-flow edges are captured for `reads_property`, `writes_property`, `reads_field`, and `writes_field`.
+- [x] Type pages render per-property read/write counts with deterministic reader/writer method link lists, including explicit zero counts.
+- [x] Type front matter publishes approved structural count scalars (`constructor_count`, `method_count`, `property_count`, `field_count`, `enum_member_count`, `record_parameter_count`, `behavioral_method_count`).
+- [x] Method pages render deterministic `Reads`/`Writes` sections for internal targets.
 
 ## Blocked by
 

--- a/plans/003/003-phase-3-dotnet-method-extraction-and-relations.plan.md
+++ b/plans/003/003-phase-3-dotnet-method-extraction-and-relations.plan.md
@@ -8,7 +8,7 @@
 - [x] Phase 2: Method Declaration and Method Page Vertical Slice — completion date: 2026-04-18
 - [x] Phase 3: Implements and Overrides Relationship Vertical Slice — completion date: 2026-04-18
 - [x] Phase 4: Calls, External Usage, and Extension Method Vertical Slice — completion date: 2026-04-18
-- [ ] Phase 5: Read-Write Data-Flow and Type Count Scalars Vertical Slice — completion date:
+- [x] Phase 5: Read-Write Data-Flow and Type Count Scalars Vertical Slice — completion date: 2026-04-18
 - [ ] Phase 6: Publication Determinism, Validation, and CI Gates — completion date:
 
 ---

--- a/src/CodeLlmWiki.Ingestion/ProjectStructure/ProjectStructureAnalyzer.cs
+++ b/src/CodeLlmWiki.Ingestion/ProjectStructure/ProjectStructureAnalyzer.cs
@@ -6,6 +6,7 @@ using CodeLlmWiki.Contracts.Graph;
 using CodeLlmWiki.Contracts.Identity;
 using CodeLlmWiki.Query.ProjectStructure;
 using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.Operations;
 using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
 using Microsoft.Build.Construction;
@@ -353,6 +354,7 @@ public sealed class ProjectStructureAnalyzer : IProjectStructureAnalyzer
         var pendingMethodReturnTypeLinks = new List<PendingMethodReturnTypeLink>();
         var pendingMethodExtendedTypeLinks = new List<PendingMethodExtendedTypeLink>();
         var pendingMethodParameterTypeLinks = new List<PendingMethodParameterTypeLink>();
+        var memberIdByDeclarationLocation = new Dictionary<MemberDeclarationLocationKey, EntityId>();
         var methodIdByDeclarationLocation = new Dictionary<MethodDeclarationLocationKey, EntityId>();
         var externalStubIdByReference = new Dictionary<string, EntityId>(StringComparer.Ordinal);
         var unresolvedReferenceIdByText = new Dictionary<string, EntityId>(StringComparer.Ordinal);
@@ -544,6 +546,7 @@ public sealed class ProjectStructureAnalyzer : IProjectStructureAnalyzer
                              .ThenBy(x => x.Line)
                              .ThenBy(x => x.Column))
                 {
+                    memberIdByDeclarationLocation[new MemberDeclarationLocationKey(location.RelativeFilePath, location.Line, location.Column)] = memberId;
                     triples.Add(new SemanticTriple(
                         new EntityNode(memberId),
                         CorePredicates.DeclarationSourceLocation,
@@ -952,6 +955,7 @@ public sealed class ProjectStructureAnalyzer : IProjectStructureAnalyzer
             sourceFiles,
             typeIdByQualifiedName,
             methodCandidatesByTypeId,
+            memberIdByDeclarationLocation,
             methodIdByDeclarationLocation,
             externalStubIdByReference,
             unresolvedCallTargetIdByText,
@@ -1091,6 +1095,7 @@ public sealed class ProjectStructureAnalyzer : IProjectStructureAnalyzer
         IReadOnlyList<string> sourceFiles,
         IReadOnlyDictionary<string, EntityId> typeIdByQualifiedName,
         IReadOnlyDictionary<EntityId, List<MethodRelationshipCandidate>> methodCandidatesByTypeId,
+        IReadOnlyDictionary<MemberDeclarationLocationKey, EntityId> memberIdByDeclarationLocation,
         IReadOnlyDictionary<MethodDeclarationLocationKey, EntityId> methodIdByDeclarationLocation,
         Dictionary<string, EntityId> externalStubIdByReference,
         Dictionary<string, EntityId> unresolvedCallTargetIdByText,
@@ -1160,6 +1165,13 @@ public sealed class ProjectStructureAnalyzer : IProjectStructureAnalyzer
                     unresolvedCallTargetIdByText,
                     triples,
                     diagnostics);
+
+                AddMemberReadWriteEdges(
+                    methodDeclaration,
+                    sourceMethodId,
+                    semanticModel,
+                    memberIdByDeclarationLocation,
+                    triples);
             }
 
             foreach (var constructorDeclaration in root.DescendantNodes().OfType<ConstructorDeclarationSyntax>())
@@ -1185,6 +1197,13 @@ public sealed class ProjectStructureAnalyzer : IProjectStructureAnalyzer
                     unresolvedCallTargetIdByText,
                     triples,
                     diagnostics);
+
+                AddMemberReadWriteEdges(
+                    constructorDeclaration,
+                    sourceMethodId,
+                    semanticModel,
+                    memberIdByDeclarationLocation,
+                    triples);
             }
         }
     }
@@ -1310,6 +1329,214 @@ public sealed class ProjectStructureAnalyzer : IProjectStructureAnalyzer
                 CorePredicates.Calls,
                 new EntityNode(externalTypeId)));
         }
+    }
+
+    private static void AddMemberReadWriteEdges(
+        MemberDeclarationSyntax declaration,
+        EntityId sourceMethodId,
+        SemanticModel semanticModel,
+        IReadOnlyDictionary<MemberDeclarationLocationKey, EntityId> memberIdByDeclarationLocation,
+        List<SemanticTriple> triples)
+    {
+        var operationRoot = GetOperationRootForBody(declaration, semanticModel);
+        if (operationRoot is null)
+        {
+            return;
+        }
+
+        var emitted = new HashSet<(PredicateId Predicate, EntityId TargetMember)>();
+
+        foreach (var operation in EnumerateOperations(operationRoot))
+        {
+            switch (operation)
+            {
+                case IPropertyReferenceOperation propertyReference:
+                    EmitMemberReadWriteTriples(
+                        propertyReference,
+                        propertyReference.Property,
+                        isField: false,
+                        sourceMethodId,
+                        memberIdByDeclarationLocation,
+                        emitted,
+                        triples);
+                    break;
+                case IFieldReferenceOperation fieldReference when !fieldReference.Field.IsImplicitlyDeclared:
+                    EmitMemberReadWriteTriples(
+                        fieldReference,
+                        fieldReference.Field,
+                        isField: true,
+                        sourceMethodId,
+                        memberIdByDeclarationLocation,
+                        emitted,
+                        triples);
+                    break;
+            }
+        }
+    }
+
+    private static void EmitMemberReadWriteTriples(
+        IOperation memberReference,
+        ISymbol symbol,
+        bool isField,
+        EntityId sourceMethodId,
+        IReadOnlyDictionary<MemberDeclarationLocationKey, EntityId> memberIdByDeclarationLocation,
+        HashSet<(PredicateId Predicate, EntityId TargetMember)> emitted,
+        List<SemanticTriple> triples)
+    {
+        var targetMemberId = ResolveInternalMemberId(symbol, memberIdByDeclarationLocation);
+        if (targetMemberId is null)
+        {
+            return;
+        }
+
+        var (isRead, isWrite) = DetermineReferenceAccess(memberReference);
+
+        if (isRead)
+        {
+            var predicate = isField ? CorePredicates.ReadsField : CorePredicates.ReadsProperty;
+            if (emitted.Add((predicate, targetMemberId.Value)))
+            {
+                triples.Add(new SemanticTriple(
+                    new EntityNode(sourceMethodId),
+                    predicate,
+                    new EntityNode(targetMemberId.Value)));
+            }
+        }
+
+        if (isWrite)
+        {
+            var predicate = isField ? CorePredicates.WritesField : CorePredicates.WritesProperty;
+            if (emitted.Add((predicate, targetMemberId.Value)))
+            {
+                triples.Add(new SemanticTriple(
+                    new EntityNode(sourceMethodId),
+                    predicate,
+                    new EntityNode(targetMemberId.Value)));
+            }
+        }
+    }
+
+    private static IOperation? GetOperationRootForBody(
+        MemberDeclarationSyntax declaration,
+        SemanticModel semanticModel)
+    {
+        return declaration switch
+        {
+            MethodDeclarationSyntax method when method.Body is not null => semanticModel.GetOperation(method.Body),
+            MethodDeclarationSyntax method when method.ExpressionBody is not null => semanticModel.GetOperation(method.ExpressionBody.Expression),
+            ConstructorDeclarationSyntax ctor when ctor.Body is not null => semanticModel.GetOperation(ctor.Body),
+            ConstructorDeclarationSyntax ctor when ctor.ExpressionBody is not null => semanticModel.GetOperation(ctor.ExpressionBody.Expression),
+            _ => null,
+        };
+    }
+
+    private static IEnumerable<IOperation> EnumerateOperations(IOperation root)
+    {
+        var stack = new Stack<IOperation>();
+        stack.Push(root);
+
+        while (stack.Count > 0)
+        {
+            var current = stack.Pop();
+            yield return current;
+
+            foreach (var child in current.ChildOperations.Reverse())
+            {
+                stack.Push(child);
+            }
+        }
+    }
+
+    private static (bool IsRead, bool IsWrite) DetermineReferenceAccess(IOperation memberReference)
+    {
+        var current = memberReference;
+        var parent = memberReference.Parent;
+
+        while (parent is IConversionOperation or IParenthesizedOperation)
+        {
+            current = parent;
+            parent = parent.Parent;
+        }
+
+        if (parent is INameOfOperation)
+        {
+            return (false, false);
+        }
+
+        if (parent is ISimpleAssignmentOperation simpleAssignment && IsTargetOperation(simpleAssignment.Target, current))
+        {
+            return (false, true);
+        }
+
+        if (parent is ICompoundAssignmentOperation compoundAssignment && IsTargetOperation(compoundAssignment.Target, current))
+        {
+            return (true, true);
+        }
+
+        if (parent is IIncrementOrDecrementOperation incrementOrDecrement && IsTargetOperation(incrementOrDecrement.Target, current))
+        {
+            return (true, true);
+        }
+
+        if (parent is IArgumentOperation argument && IsTargetOperation(argument.Value, current))
+        {
+            return argument.Parameter?.RefKind switch
+            {
+                RefKind.Out => (false, true),
+                RefKind.Ref => (true, true),
+                _ => (true, false),
+            };
+        }
+
+        return (true, false);
+    }
+
+    private static bool IsTargetOperation(IOperation target, IOperation candidate)
+    {
+        var unwrappedTarget = UnwrapNonSemanticOperation(target);
+        var unwrappedCandidate = UnwrapNonSemanticOperation(candidate);
+
+        return ReferenceEquals(unwrappedTarget, unwrappedCandidate)
+               || (
+                   ReferenceEquals(unwrappedTarget.Syntax.SyntaxTree, unwrappedCandidate.Syntax.SyntaxTree)
+                   && unwrappedTarget.Syntax.Span.Equals(unwrappedCandidate.Syntax.Span));
+    }
+
+    private static IOperation UnwrapNonSemanticOperation(IOperation operation)
+    {
+        var current = operation;
+        while (current is IConversionOperation or IParenthesizedOperation)
+        {
+            var previous = current;
+            current = current.ChildOperations.FirstOrDefault() ?? current;
+            if (ReferenceEquals(current, previous))
+            {
+                break;
+            }
+        }
+
+        return current;
+    }
+
+    private static EntityId? ResolveInternalMemberId(
+        ISymbol symbol,
+        IReadOnlyDictionary<MemberDeclarationLocationKey, EntityId> memberIdByDeclarationLocation)
+    {
+        foreach (var location in symbol.Locations.Where(static x => x.IsInSource))
+        {
+            var lineSpan = location.GetLineSpan();
+            var key = new MemberDeclarationLocationKey(
+                location.SourceTree?.FilePath ?? string.Empty,
+                lineSpan.StartLinePosition.Line + 1,
+                lineSpan.StartLinePosition.Character + 1);
+
+            if (memberIdByDeclarationLocation.TryGetValue(key, out var memberId))
+            {
+                return memberId;
+            }
+        }
+
+        return null;
     }
 
     private static IReadOnlyList<MetadataReference> BuildCompilationReferences(List<IngestionDiagnostic> diagnostics)
@@ -1807,6 +2034,8 @@ public sealed class ProjectStructureAnalyzer : IProjectStructureAnalyzer
         string DeclaredTypeName,
         IReadOnlyList<string> ImportedNamespaces,
         IReadOnlyDictionary<string, string> ImportedAliases);
+
+    private sealed record MemberDeclarationLocationKey(string RelativeFilePath, int Line, int Column);
 
     private sealed record MethodDeclarationLocationKey(string RelativeFilePath, int Line, int Column);
 

--- a/src/CodeLlmWiki.Wiki/ProjectStructure/ProjectStructureWikiRenderer.cs
+++ b/src/CodeLlmWiki.Wiki/ProjectStructure/ProjectStructureWikiRenderer.cs
@@ -130,6 +130,54 @@ public sealed class ProjectStructureWikiRenderer : IProjectStructureWikiRenderer
                     .Distinct()
                     .OrderBy(v => v.Value, StringComparer.Ordinal)
                     .ToArray());
+        var readMethodIdsByTargetMemberId = model.Declarations.Methods.Relations
+            .Where(x =>
+                (x.Kind == MethodRelationKind.ReadsProperty || x.Kind == MethodRelationKind.ReadsField)
+                && x.TargetMemberId is not null)
+            .GroupBy(x => x.TargetMemberId!.Value)
+            .ToDictionary(
+                x => x.Key,
+                x => (IReadOnlyList<EntityId>)x
+                    .Select(v => v.SourceMethodId)
+                    .Distinct()
+                    .OrderBy(v => v.Value, StringComparer.Ordinal)
+                    .ToArray());
+        var writeMethodIdsByTargetMemberId = model.Declarations.Methods.Relations
+            .Where(x =>
+                (x.Kind == MethodRelationKind.WritesProperty || x.Kind == MethodRelationKind.WritesField)
+                && x.TargetMemberId is not null)
+            .GroupBy(x => x.TargetMemberId!.Value)
+            .ToDictionary(
+                x => x.Key,
+                x => (IReadOnlyList<EntityId>)x
+                    .Select(v => v.SourceMethodId)
+                    .Distinct()
+                    .OrderBy(v => v.Value, StringComparer.Ordinal)
+                    .ToArray());
+        var readMemberIdsBySourceMethodId = model.Declarations.Methods.Relations
+            .Where(x =>
+                (x.Kind == MethodRelationKind.ReadsProperty || x.Kind == MethodRelationKind.ReadsField)
+                && x.TargetMemberId is not null)
+            .GroupBy(x => x.SourceMethodId)
+            .ToDictionary(
+                x => x.Key,
+                x => (IReadOnlyList<EntityId>)x
+                    .Select(v => v.TargetMemberId!.Value)
+                    .Distinct()
+                    .OrderBy(v => v.Value, StringComparer.Ordinal)
+                    .ToArray());
+        var writeMemberIdsBySourceMethodId = model.Declarations.Methods.Relations
+            .Where(x =>
+                (x.Kind == MethodRelationKind.WritesProperty || x.Kind == MethodRelationKind.WritesField)
+                && x.TargetMemberId is not null)
+            .GroupBy(x => x.SourceMethodId)
+            .ToDictionary(
+                x => x.Key,
+                x => (IReadOnlyList<EntityId>)x
+                    .Select(v => v.TargetMemberId!.Value)
+                    .Distinct()
+                    .OrderBy(v => v.Value, StringComparer.Ordinal)
+                    .ToArray());
         var fileById = model.Files.ToDictionary(x => x.Id, x => x);
         var namespaceBacklinksByFileId = BuildNamespaceBacklinksByFileId(model.Declarations.Namespaces, fileById);
         var typeBacklinksByFileId = BuildTypeBacklinksByFileId(model.Declarations.Types, fileById);
@@ -145,16 +193,31 @@ public sealed class ProjectStructureWikiRenderer : IProjectStructureWikiRenderer
         pages.AddRange(orderedProjects.Select(project => RenderProjectPage(model.Repository.Id.Value, project, packageById, resolver)));
         pages.AddRange(orderedPackages.Select(package => RenderPackagePage(model.Repository.Id.Value, package, resolver)));
         pages.AddRange(orderedNamespaces.Select(namespaceDeclaration => RenderNamespacePage(model.Repository.Id.Value, namespaceDeclaration, namespaceById, typeById, resolver)));
-        pages.AddRange(orderedTypes.Select(typeDeclaration => RenderTypePage(model.Repository.Id.Value, typeDeclaration, namespaceById, typeById, memberById, methodById, fileById, orderedProjects, resolver)));
+        pages.AddRange(orderedTypes.Select(typeDeclaration =>
+            RenderTypePage(
+                model.Repository.Id.Value,
+                typeDeclaration,
+                namespaceById,
+                typeById,
+                memberById,
+                methodById,
+                readMethodIdsByTargetMemberId,
+                writeMethodIdsByTargetMemberId,
+                fileById,
+                orderedProjects,
+                resolver)));
         pages.AddRange(orderedMethods.Select(method =>
             RenderMethodPage(
                 model.Repository.Id.Value,
                 method,
                 typeById,
                 methodById,
+                memberById,
                 implementedMethodIdsBySourceMethodId,
                 overriddenMethodIdsBySourceMethodId,
                 callRelationsBySourceMethodId,
+                readMemberIdsBySourceMethodId,
+                writeMemberIdsBySourceMethodId,
                 calledByMethodIdsByTargetMethodId,
                 fileById,
                 resolver)));
@@ -567,6 +630,8 @@ public sealed class ProjectStructureWikiRenderer : IProjectStructureWikiRenderer
         IReadOnlyDictionary<EntityId, TypeDeclarationNode> typeById,
         IReadOnlyDictionary<EntityId, MemberDeclarationNode> memberById,
         IReadOnlyDictionary<EntityId, MethodDeclarationNode> methodById,
+        IReadOnlyDictionary<EntityId, IReadOnlyList<EntityId>> readMethodIdsByTargetMemberId,
+        IReadOnlyDictionary<EntityId, IReadOnlyList<EntityId>> writeMethodIdsByTargetMemberId,
         IReadOnlyDictionary<EntityId, FileNode> fileById,
         IReadOnlyList<ProjectNode> projects,
         WikiPathResolver resolver)
@@ -635,6 +700,29 @@ public sealed class ProjectStructureWikiRenderer : IProjectStructureWikiRenderer
         sb.AppendLine("## Methods");
         AppendMethodSection(sb, typeDeclaration, methodById, resolver);
 
+        sb.AppendLine();
+        sb.AppendLine("## Member Data Flow");
+        AppendMemberDataFlowSection(
+            sb,
+            "Properties",
+            typeDeclaration,
+            memberById,
+            methodById,
+            readMethodIdsByTargetMemberId,
+            writeMethodIdsByTargetMemberId,
+            MemberDeclarationKind.Property,
+            resolver);
+        AppendMemberDataFlowSection(
+            sb,
+            "Fields",
+            typeDeclaration,
+            memberById,
+            methodById,
+            readMethodIdsByTargetMemberId,
+            writeMethodIdsByTargetMemberId,
+            MemberDeclarationKind.Field,
+            resolver);
+
         if (typeDeclaration.GenericParameters.Count > 0 || typeDeclaration.GenericConstraints.Count > 0)
         {
             sb.AppendLine();
@@ -670,6 +758,13 @@ public sealed class ProjectStructureWikiRenderer : IProjectStructureWikiRenderer
             KeyValue("type_kind", typeDeclaration.Kind.ToString().ToLowerInvariant()),
             KeyValue("type_path", typeDeclaration.Path),
             KeyValue("accessibility", typeDeclaration.Accessibility.ToString().ToLowerInvariant()),
+            KeyValue("constructor_count", CountMethods(typeDeclaration, methodById, MethodDeclarationKind.Constructor).ToString()),
+            KeyValue("method_count", CountMethods(typeDeclaration, methodById, MethodDeclarationKind.Method).ToString()),
+            KeyValue("property_count", CountMembers(typeDeclaration, memberById, MemberDeclarationKind.Property).ToString()),
+            KeyValue("field_count", CountMembers(typeDeclaration, memberById, MemberDeclarationKind.Field).ToString()),
+            KeyValue("enum_member_count", CountMembers(typeDeclaration, memberById, MemberDeclarationKind.EnumMember).ToString()),
+            KeyValue("record_parameter_count", CountMembers(typeDeclaration, memberById, MemberDeclarationKind.RecordParameter).ToString()),
+            KeyValue("behavioral_method_count", CountMethods(typeDeclaration, methodById, MethodDeclarationKind.Method).ToString()),
         };
 
         if (typeDeclaration.IsNestedType)
@@ -775,6 +870,86 @@ public sealed class ProjectStructureWikiRenderer : IProjectStructureWikiRenderer
         }
     }
 
+    private static void AppendMemberDataFlowSection(
+        StringBuilder sb,
+        string sectionName,
+        TypeDeclarationNode typeDeclaration,
+        IReadOnlyDictionary<EntityId, MemberDeclarationNode> memberById,
+        IReadOnlyDictionary<EntityId, MethodDeclarationNode> methodById,
+        IReadOnlyDictionary<EntityId, IReadOnlyList<EntityId>> readMethodIdsByTargetMemberId,
+        IReadOnlyDictionary<EntityId, IReadOnlyList<EntityId>> writeMethodIdsByTargetMemberId,
+        MemberDeclarationKind expectedKind,
+        WikiPathResolver resolver)
+    {
+        var members = typeDeclaration.MemberIds
+            .Where(memberById.ContainsKey)
+            .Select(id => memberById[id])
+            .Where(member => member.Kind == expectedKind)
+            .OrderBy(member => member.Name, StringComparer.Ordinal)
+            .ThenBy(member => member.Id.Value, StringComparer.Ordinal)
+            .ToArray();
+
+        sb.AppendLine($"### {sectionName}");
+        if (members.Length == 0)
+        {
+            sb.AppendLine("- none");
+            return;
+        }
+
+        sb.AppendLine("| member | read_count | write_count | readers | writers |");
+        sb.AppendLine("| --- | ---: | ---: | --- | --- |");
+
+        foreach (var member in members)
+        {
+            var readers = readMethodIdsByTargetMemberId.TryGetValue(member.Id, out var readMethodIds)
+                ? readMethodIds
+                    .Where(methodById.ContainsKey)
+                    .Select(id => methodById[id])
+                    .OrderBy(x => x.Kind.ToString(), StringComparer.Ordinal)
+                    .ThenBy(x => x.Signature, StringComparer.Ordinal)
+                    .ThenBy(x => x.Id.Value, StringComparer.Ordinal)
+                    .Select(x => resolver.ToWikiLink(x.Id, FormatMethodLinkAlias(x)))
+                    .ToArray()
+                : [];
+            var writers = writeMethodIdsByTargetMemberId.TryGetValue(member.Id, out var writeMethodIds)
+                ? writeMethodIds
+                    .Where(methodById.ContainsKey)
+                    .Select(id => methodById[id])
+                    .OrderBy(x => x.Kind.ToString(), StringComparer.Ordinal)
+                    .ThenBy(x => x.Signature, StringComparer.Ordinal)
+                    .ThenBy(x => x.Id.Value, StringComparer.Ordinal)
+                    .Select(x => resolver.ToWikiLink(x.Id, FormatMethodLinkAlias(x)))
+                    .ToArray()
+                : [];
+
+            var readersCell = readers.Length == 0 ? "none" : string.Join(", ", readers);
+            var writersCell = writers.Length == 0 ? "none" : string.Join(", ", writers);
+            sb.AppendLine($"| {member.Name} | {readers.Length} | {writers.Length} | {readersCell} | {writersCell} |");
+        }
+    }
+
+    private static int CountMethods(
+        TypeDeclarationNode typeDeclaration,
+        IReadOnlyDictionary<EntityId, MethodDeclarationNode> methodById,
+        MethodDeclarationKind methodKind)
+    {
+        return typeDeclaration.MethodIds
+            .Where(methodById.ContainsKey)
+            .Select(id => methodById[id])
+            .Count(x => x.Kind == methodKind);
+    }
+
+    private static int CountMembers(
+        TypeDeclarationNode typeDeclaration,
+        IReadOnlyDictionary<EntityId, MemberDeclarationNode> memberById,
+        MemberDeclarationKind memberKind)
+    {
+        return typeDeclaration.MemberIds
+            .Where(memberById.ContainsKey)
+            .Select(id => memberById[id])
+            .Count(x => x.Kind == memberKind);
+    }
+
     private static void AppendMethodRelationshipSection(
         StringBuilder sb,
         EntityId sourceMethodId,
@@ -798,6 +973,47 @@ public sealed class ProjectStructureWikiRenderer : IProjectStructureWikiRenderer
             {
                 sb.AppendLine("- unresolved target");
             }
+        }
+    }
+
+    private static void AppendMethodMemberAccessSection(
+        StringBuilder sb,
+        EntityId sourceMethodId,
+        IReadOnlyDictionary<EntityId, IReadOnlyList<EntityId>> targetMemberIdsBySourceMethodId,
+        IReadOnlyDictionary<EntityId, MemberDeclarationNode> memberById,
+        IReadOnlyDictionary<EntityId, TypeDeclarationNode> typeById,
+        WikiPathResolver resolver)
+    {
+        if (!targetMemberIdsBySourceMethodId.TryGetValue(sourceMethodId, out var targetMemberIds) || targetMemberIds.Count == 0)
+        {
+            sb.AppendLine("- none");
+            return;
+        }
+
+        var members = targetMemberIds
+            .Where(memberById.ContainsKey)
+            .Select(id => memberById[id])
+            .OrderBy(x => x.Kind.ToString(), StringComparer.Ordinal)
+            .ThenBy(x => x.Name, StringComparer.Ordinal)
+            .ThenBy(x => x.Id.Value, StringComparer.Ordinal)
+            .ToArray();
+
+        if (members.Length == 0)
+        {
+            sb.AppendLine("- none");
+            return;
+        }
+
+        foreach (var member in members)
+        {
+            var kind = member.Kind.ToString().ToLowerInvariant();
+            if (typeById.TryGetValue(member.DeclaringTypeId, out var declaringType))
+            {
+                sb.AppendLine($"- {kind}: {member.Name} ({resolver.ToWikiLink(declaringType.Id, declaringType.Name)})");
+                continue;
+            }
+
+            sb.AppendLine($"- {kind}: {member.Name}");
         }
     }
 
@@ -889,9 +1105,12 @@ public sealed class ProjectStructureWikiRenderer : IProjectStructureWikiRenderer
         MethodDeclarationNode methodDeclaration,
         IReadOnlyDictionary<EntityId, TypeDeclarationNode> typeById,
         IReadOnlyDictionary<EntityId, MethodDeclarationNode> methodById,
+        IReadOnlyDictionary<EntityId, MemberDeclarationNode> memberById,
         IReadOnlyDictionary<EntityId, IReadOnlyList<EntityId>> implementedMethodIdsBySourceMethodId,
         IReadOnlyDictionary<EntityId, IReadOnlyList<EntityId>> overriddenMethodIdsBySourceMethodId,
         IReadOnlyDictionary<EntityId, IReadOnlyList<MethodRelationNode>> callRelationsBySourceMethodId,
+        IReadOnlyDictionary<EntityId, IReadOnlyList<EntityId>> readMemberIdsBySourceMethodId,
+        IReadOnlyDictionary<EntityId, IReadOnlyList<EntityId>> writeMemberIdsBySourceMethodId,
         IReadOnlyDictionary<EntityId, IReadOnlyList<EntityId>> calledByMethodIdsByTargetMethodId,
         IReadOnlyDictionary<EntityId, FileNode> fileById,
         WikiPathResolver resolver)
@@ -963,6 +1182,26 @@ public sealed class ProjectStructureWikiRenderer : IProjectStructureWikiRenderer
             methodDeclaration.Id,
             callRelationsBySourceMethodId,
             methodById,
+            resolver);
+
+        sb.AppendLine();
+        sb.AppendLine("## Reads");
+        AppendMethodMemberAccessSection(
+            sb,
+            methodDeclaration.Id,
+            readMemberIdsBySourceMethodId,
+            memberById,
+            typeById,
+            resolver);
+
+        sb.AppendLine();
+        sb.AppendLine("## Writes");
+        AppendMethodMemberAccessSection(
+            sb,
+            methodDeclaration.Id,
+            writeMemberIdsBySourceMethodId,
+            memberById,
+            typeById,
             resolver);
 
         sb.AppendLine();

--- a/tests/CodeLlmWiki.Ingestion.Tests/ReadWriteDataFlowVerticalSliceTests.cs
+++ b/tests/CodeLlmWiki.Ingestion.Tests/ReadWriteDataFlowVerticalSliceTests.cs
@@ -26,6 +26,7 @@ public sealed class ReadWriteDataFlowVerticalSliceTests
         var readName = model.Declarations.Methods.Declarations.Single(x => x.DeclaringTypeId == workerType.Id && x.Name == "ReadName");
         var updateName = model.Declarations.Methods.Declarations.Single(x => x.DeclaringTypeId == workerType.Id && x.Name == "UpdateName");
         var bumpCounter = model.Declarations.Methods.Declarations.Single(x => x.DeclaringTypeId == workerType.Id && x.Name == "BumpCounter");
+        var readExternalLength = model.Declarations.Methods.Declarations.Single(x => x.DeclaringTypeId == workerType.Id && x.Name == "ReadExternalLength");
 
         Assert.Contains(model.Declarations.Methods.Relations, x =>
             x.Kind == MethodRelationKind.ReadsProperty
@@ -48,6 +49,7 @@ public sealed class ReadWriteDataFlowVerticalSliceTests
             && x.TargetMemberId == counterMember.Id);
 
         Assert.DoesNotContain(model.Declarations.Methods.Relations, x => x.TargetMemberId == unusedMember.Id);
+        Assert.DoesNotContain(model.Declarations.Methods.Relations, x => x.SourceMethodId == readExternalLength.Id && x.TargetMemberId is not null);
     }
 
     [Fact]
@@ -147,6 +149,11 @@ public sealed class ReadWriteDataFlowVerticalSliceTests
                     public void BumpCounter()
                     {
                         _model.Counter++;
+                    }
+
+                    public int ReadExternalLength()
+                    {
+                        return string.Empty.Length;
                     }
                 }
                 """);

--- a/tests/CodeLlmWiki.Ingestion.Tests/ReadWriteDataFlowVerticalSliceTests.cs
+++ b/tests/CodeLlmWiki.Ingestion.Tests/ReadWriteDataFlowVerticalSliceTests.cs
@@ -1,0 +1,189 @@
+using System.Diagnostics;
+using CodeLlmWiki.Contracts.Identity;
+using CodeLlmWiki.Ingestion.ProjectStructure;
+using CodeLlmWiki.Query.ProjectStructure;
+using CodeLlmWiki.Wiki.ProjectStructure;
+
+namespace CodeLlmWiki.Ingestion.Tests;
+
+public sealed class ReadWriteDataFlowVerticalSliceTests
+{
+    [Fact]
+    public async Task Query_CapturesInternalPropertyAndFieldReadWriteEdges()
+    {
+        var fixture = await DataFlowFixture.CreateAsync();
+        var analyzer = new ProjectStructureAnalyzer(new StableIdGenerator());
+        var analysis = await analyzer.AnalyzeAsync(fixture.RepositoryPath, CancellationToken.None);
+        var model = new ProjectStructureQueryService(analysis.Triples).GetModel(analysis.RepositoryId);
+
+        var modelType = model.Declarations.Types.Single(x => x.Name == "Model");
+        var workerType = model.Declarations.Types.Single(x => x.Name == "Worker");
+
+        var nameMember = model.Declarations.Members.Single(x => x.DeclaringTypeId == modelType.Id && x.Name == "Name");
+        var unusedMember = model.Declarations.Members.Single(x => x.DeclaringTypeId == modelType.Id && x.Name == "Unused");
+        var counterMember = model.Declarations.Members.Single(x => x.DeclaringTypeId == modelType.Id && x.Name == "Counter");
+
+        var readName = model.Declarations.Methods.Declarations.Single(x => x.DeclaringTypeId == workerType.Id && x.Name == "ReadName");
+        var updateName = model.Declarations.Methods.Declarations.Single(x => x.DeclaringTypeId == workerType.Id && x.Name == "UpdateName");
+        var bumpCounter = model.Declarations.Methods.Declarations.Single(x => x.DeclaringTypeId == workerType.Id && x.Name == "BumpCounter");
+
+        Assert.Contains(model.Declarations.Methods.Relations, x =>
+            x.Kind == MethodRelationKind.ReadsProperty
+            && x.SourceMethodId == readName.Id
+            && x.TargetMemberId == nameMember.Id);
+
+        Assert.Contains(model.Declarations.Methods.Relations, x =>
+            x.Kind == MethodRelationKind.WritesProperty
+            && x.SourceMethodId == updateName.Id
+            && x.TargetMemberId == nameMember.Id);
+
+        Assert.Contains(model.Declarations.Methods.Relations, x =>
+            x.Kind == MethodRelationKind.ReadsField
+            && x.SourceMethodId == bumpCounter.Id
+            && x.TargetMemberId == counterMember.Id);
+
+        Assert.Contains(model.Declarations.Methods.Relations, x =>
+            x.Kind == MethodRelationKind.WritesField
+            && x.SourceMethodId == bumpCounter.Id
+            && x.TargetMemberId == counterMember.Id);
+
+        Assert.DoesNotContain(model.Declarations.Methods.Relations, x => x.TargetMemberId == unusedMember.Id);
+    }
+
+    [Fact]
+    public async Task Render_TypeAndMethodPages_IncludeDataFlowSectionsAndScalars()
+    {
+        var fixture = await DataFlowFixture.CreateAsync();
+        var analyzer = new ProjectStructureAnalyzer(new StableIdGenerator());
+        var analysis = await analyzer.AnalyzeAsync(fixture.RepositoryPath, CancellationToken.None);
+        var model = new ProjectStructureQueryService(analysis.Triples).GetModel(analysis.RepositoryId);
+        var pages = new ProjectStructureWikiRenderer().Render(model);
+
+        var modelTypePage = pages.Single(x =>
+            x.RelativePath == "types/Acme/Data/Model.md");
+
+        Assert.Contains("constructor_count: 0", modelTypePage.Markdown, StringComparison.Ordinal);
+        Assert.Contains("method_count: 0", modelTypePage.Markdown, StringComparison.Ordinal);
+        Assert.Contains("property_count: 2", modelTypePage.Markdown, StringComparison.Ordinal);
+        Assert.Contains("field_count: 1", modelTypePage.Markdown, StringComparison.Ordinal);
+        Assert.Contains("enum_member_count: 0", modelTypePage.Markdown, StringComparison.Ordinal);
+        Assert.Contains("record_parameter_count: 0", modelTypePage.Markdown, StringComparison.Ordinal);
+        Assert.Contains("behavioral_method_count: 0", modelTypePage.Markdown, StringComparison.Ordinal);
+        Assert.Contains("## Member Data Flow", modelTypePage.Markdown, StringComparison.Ordinal);
+        Assert.Contains("| Name | 1 | 1 |", modelTypePage.Markdown, StringComparison.Ordinal);
+        Assert.Contains("| Unused | 0 | 0 | none | none |", modelTypePage.Markdown, StringComparison.Ordinal);
+        Assert.Contains("| Counter | 1 | 1 |", modelTypePage.Markdown, StringComparison.Ordinal);
+        Assert.Contains("ReadName", modelTypePage.Markdown, StringComparison.Ordinal);
+        Assert.Contains("UpdateName", modelTypePage.Markdown, StringComparison.Ordinal);
+        Assert.Contains("BumpCounter", modelTypePage.Markdown, StringComparison.Ordinal);
+
+        var bumpCounterPage = pages.Single(x =>
+            x.RelativePath.StartsWith("methods/Acme/Data/Worker/", StringComparison.Ordinal)
+            && x.Markdown.Contains("method_signature: Acme.Data.Worker.BumpCounter()", StringComparison.Ordinal));
+
+        Assert.Contains("## Reads", bumpCounterPage.Markdown, StringComparison.Ordinal);
+        Assert.Contains("## Writes", bumpCounterPage.Markdown, StringComparison.Ordinal);
+        Assert.Contains("field: Counter", bumpCounterPage.Markdown, StringComparison.Ordinal);
+    }
+
+    private sealed class DataFlowFixture
+    {
+        private DataFlowFixture(string repositoryPath)
+        {
+            RepositoryPath = repositoryPath;
+        }
+
+        public string RepositoryPath { get; }
+
+        public static async Task<DataFlowFixture> CreateAsync()
+        {
+            var root = Path.Combine(Path.GetTempPath(), $"codellmwiki-data-flow-{Guid.NewGuid():N}", "data-flow-repo");
+            Directory.CreateDirectory(root);
+
+            await File.WriteAllTextAsync(Path.Combine(root, "Sample.slnx"),
+                """
+                <Solution>
+                  <Project Path="src/App/App.csproj" />
+                </Solution>
+                """);
+
+            var appDir = Path.Combine(root, "src", "App");
+            Directory.CreateDirectory(appDir);
+            await File.WriteAllTextAsync(Path.Combine(appDir, "App.csproj"),
+                """
+                <Project Sdk="Microsoft.NET.Sdk">
+                  <PropertyGroup>
+                    <TargetFramework>net10.0</TargetFramework>
+                    <AssemblyName>Acme.Data.App</AssemblyName>
+                  </PropertyGroup>
+                </Project>
+                """);
+
+            await File.WriteAllTextAsync(Path.Combine(appDir, "Data.cs"),
+                """
+                namespace Acme.Data;
+
+                public class Model
+                {
+                    public string Name { get; set; } = string.Empty;
+                    public string Unused { get; set; } = string.Empty;
+                    public int Counter;
+                }
+
+                public class Worker
+                {
+                    private readonly Model _model = new();
+
+                    public string ReadName()
+                    {
+                        return _model.Name;
+                    }
+
+                    public void UpdateName(string value)
+                    {
+                        _model.Name = value;
+                    }
+
+                    public void BumpCounter()
+                    {
+                        _model.Counter++;
+                    }
+                }
+                """);
+
+            RunGit(root, "init", "-b", "main");
+            RunGit(root, "config", "user.email", "test@example.com");
+            RunGit(root, "config", "user.name", "Test User");
+            RunGit(root, "add", ".");
+            RunGit(root, "commit", "-m", "initial");
+
+            return new DataFlowFixture(root);
+        }
+    }
+
+    private static void RunGit(string workingDirectory, params string[] args)
+    {
+        var startInfo = new ProcessStartInfo
+        {
+            FileName = "git",
+            WorkingDirectory = workingDirectory,
+            RedirectStandardOutput = true,
+            RedirectStandardError = true,
+        };
+
+        foreach (var arg in args)
+        {
+            startInfo.ArgumentList.Add(arg);
+        }
+
+        using var process = Process.Start(startInfo)!;
+        process.WaitForExit();
+
+        if (process.ExitCode != 0)
+        {
+            var stdOut = process.StandardOutput.ReadToEnd();
+            var stdErr = process.StandardError.ReadToEnd();
+            throw new InvalidOperationException($"git {string.Join(' ', args)} failed: {stdOut}\n{stdErr}");
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- capture internal `readsProperty`, `writesProperty`, `readsField`, and `writesField` edges from Roslyn operation trees
- render method-level `Reads`/`Writes` sections and type-level member data-flow tables with explicit zero counts
- add approved type front matter count scalars for Dataview/POCO heuristics
- add end-to-end vertical-slice tests for ingestion/query/wiki rendering

## Validation
- dotnet test

## Issue
- #46
