### PR TITLE
PRD 004 / #57: add scoped wiki link invariant publication gate

### DIFF
--- a/plans/004/004-phase-4-wiki-navigation-link-consistency.issue.057.md
+++ b/plans/004/004-phase-4-wiki-navigation-link-consistency.issue.057.md
@@ -3,8 +3,8 @@
 > Parent PRD: [PRD 004](./004-phase-4-wiki-navigation-link-consistency.prd.md)
 
 - Issue: [#57](https://github.com/vbfg1973/code-llm-wiki/issues/57)
-- [ ] Status: open
-- [ ] Completion date:
+- [x] Status: completed
+- [x] Completion date: 2026-04-18
 
 ## Notes
 
@@ -18,11 +18,11 @@ Add a scoped publication-time invariant validator for the two PRD 004 sections a
 
 ## Acceptance criteria
 
-- [ ] Publication invariant validator exists for namespace contained-type and file method sections and reports concrete violations.
-- [ ] Artifact publication fails when scoped link invariants are violated.
-- [ ] Invalid runs are not promoted to `latest` when scoped link invariants fail.
-- [ ] Publisher/validator tests cover pass/fail paths, including failure messaging and promotion behavior.
-- [ ] Golden/snapshot tests are updated only for intentional output deltas introduced by scoped link hardening.
+- [x] Publication invariant validator exists for namespace contained-type and file method sections and reports concrete violations.
+- [x] Artifact publication fails when scoped link invariants are violated.
+- [x] Invalid runs are not promoted to `latest` when scoped link invariants fail.
+- [x] Publisher/validator tests cover pass/fail paths, including failure messaging and promotion behavior.
+- [x] Golden/snapshot tests are updated only for intentional output deltas introduced by scoped link hardening.
 
 ## Blocked by
 

--- a/plans/004/004-phase-4-wiki-navigation-link-consistency.plan.md
+++ b/plans/004/004-phase-4-wiki-navigation-link-consistency.plan.md
@@ -6,7 +6,7 @@
 
 - [x] Phase 1: Namespace Contained-Type Linking Slice — completion date: 2026-04-18
 - [x] Phase 2: File Declared-Method Linking Slice — completion date: 2026-04-18
-- [ ] Phase 3: Publication Invariant Gate Slice — completion date:
+- [x] Phase 3: Publication Invariant Gate Slice — completion date: 2026-04-18
 
 ---
 

--- a/src/CodeLlmWiki.Cli/Features/Ingest/IWikiScopedLinkInvariantValidator.cs
+++ b/src/CodeLlmWiki.Cli/Features/Ingest/IWikiScopedLinkInvariantValidator.cs
@@ -1,0 +1,6 @@
+namespace CodeLlmWiki.Cli.Features.Ingest;
+
+public interface IWikiScopedLinkInvariantValidator
+{
+    WikiScopedLinkInvariantValidationResult Validate(WikiScopedLinkInvariantValidationRequest request);
+}

--- a/src/CodeLlmWiki.Cli/Features/Ingest/IngestionArtifactPublisher.cs
+++ b/src/CodeLlmWiki.Cli/Features/Ingest/IngestionArtifactPublisher.cs
@@ -10,11 +10,18 @@ namespace CodeLlmWiki.Cli.Features.Ingest;
 
 public sealed class IngestionArtifactPublisher : IIngestionArtifactPublisher
 {
+    private readonly IWikiScopedLinkInvariantValidator _wikiScopedLinkInvariantValidator;
+
     private static readonly JsonSerializerOptions JsonOptions = new()
     {
         WriteIndented = true,
         DefaultIgnoreCondition = JsonIgnoreCondition.WhenWritingNull,
     };
+
+    public IngestionArtifactPublisher(IWikiScopedLinkInvariantValidator? wikiScopedLinkInvariantValidator = null)
+    {
+        _wikiScopedLinkInvariantValidator = wikiScopedLinkInvariantValidator ?? new WikiScopedLinkInvariantValidator();
+    }
 
     public async Task<IngestionArtifactPublishResult> PublishAsync(
         IngestionArtifactPublishRequest request,
@@ -44,6 +51,13 @@ public sealed class IngestionArtifactPublisher : IIngestionArtifactPublisher
                 var pages = renderer.Render(model, request.MaxMergeEntriesPerFile)
                     .OrderBy(x => x.RelativePath, StringComparer.Ordinal)
                     .ToArray();
+
+                var validation = _wikiScopedLinkInvariantValidator.Validate(
+                    new WikiScopedLinkInvariantValidationRequest(model, pages));
+                if (!validation.IsValid)
+                {
+                    throw new InvalidOperationException(validation.ToFailureMessage());
+                }
 
                 wikiPageCount = pages.Length;
                 wikiDirectory = Path.Combine(runDirectory, "wiki");

--- a/src/CodeLlmWiki.Cli/Features/Ingest/WikiScopedLinkInvariantValidationRequest.cs
+++ b/src/CodeLlmWiki.Cli/Features/Ingest/WikiScopedLinkInvariantValidationRequest.cs
@@ -1,0 +1,8 @@
+using CodeLlmWiki.Query.ProjectStructure;
+using CodeLlmWiki.Wiki.ProjectStructure;
+
+namespace CodeLlmWiki.Cli.Features.Ingest;
+
+public sealed record WikiScopedLinkInvariantValidationRequest(
+    ProjectStructureWikiModel Model,
+    IReadOnlyList<WikiPage> Pages);

--- a/src/CodeLlmWiki.Cli/Features/Ingest/WikiScopedLinkInvariantValidationResult.cs
+++ b/src/CodeLlmWiki.Cli/Features/Ingest/WikiScopedLinkInvariantValidationResult.cs
@@ -1,0 +1,46 @@
+using System.Text;
+
+namespace CodeLlmWiki.Cli.Features.Ingest;
+
+public sealed record WikiScopedLinkInvariantValidationResult(IReadOnlyList<WikiScopedLinkInvariantViolation> Violations)
+{
+    public bool IsValid => Violations.Count == 0;
+
+    public string ToFailureMessage(int maxViolations = 20)
+    {
+        if (IsValid)
+        {
+            return "Scoped wiki link invariants passed.";
+        }
+
+        var builder = new StringBuilder();
+        builder.Append("Scoped wiki link invariants failed with ");
+        builder.Append(Violations.Count);
+        builder.Append(" violation(s).");
+
+        foreach (var violation in Violations.Take(Math.Max(1, maxViolations)))
+        {
+            builder.AppendLine();
+            builder.Append("- ");
+            builder.Append(violation.PageRelativePath);
+            builder.Append(':');
+            builder.Append(violation.LineNumber);
+            builder.Append(" [");
+            builder.Append(violation.SectionPath);
+            builder.Append("] ");
+            builder.Append(violation.Message);
+            builder.Append(" | ");
+            builder.Append(violation.LineText.Trim());
+        }
+
+        if (Violations.Count > maxViolations)
+        {
+            builder.AppendLine();
+            builder.Append("+ ");
+            builder.Append(Violations.Count - maxViolations);
+            builder.Append(" additional violation(s).");
+        }
+
+        return builder.ToString();
+    }
+}

--- a/src/CodeLlmWiki.Cli/Features/Ingest/WikiScopedLinkInvariantValidator.cs
+++ b/src/CodeLlmWiki.Cli/Features/Ingest/WikiScopedLinkInvariantValidator.cs
@@ -1,0 +1,279 @@
+using CodeLlmWiki.Contracts.Identity;
+using CodeLlmWiki.Query.ProjectStructure;
+using CodeLlmWiki.Wiki.ProjectStructure;
+
+namespace CodeLlmWiki.Cli.Features.Ingest;
+
+public sealed class WikiScopedLinkInvariantValidator : IWikiScopedLinkInvariantValidator
+{
+    private const string NamespaceSectionPath = "## Contained Types";
+    private const string FileMethodsSectionPath = "## Declared Symbols > ### Methods";
+
+    public WikiScopedLinkInvariantValidationResult Validate(WikiScopedLinkInvariantValidationRequest request)
+    {
+        ArgumentNullException.ThrowIfNull(request);
+        ArgumentNullException.ThrowIfNull(request.Model);
+        ArgumentNullException.ThrowIfNull(request.Pages);
+
+        var pageByEntityId = BuildPageIndex(request.Pages);
+        var methodCountByFileId = request.Model.Declarations.Methods.Declarations
+            .SelectMany(method => method.DeclarationFileIds.Select(fileId => (fileId, method.Id)))
+            .GroupBy(x => x.fileId)
+            .ToDictionary(
+                x => x.Key,
+                x => x.Select(v => v.Id)
+                    .Distinct()
+                    .Count());
+
+        var violations = new List<WikiScopedLinkInvariantViolation>();
+
+        foreach (var namespaceDeclaration in request.Model.Declarations.Namespaces)
+        {
+            if (namespaceDeclaration.ContainedTypeIds.Count == 0)
+            {
+                continue;
+            }
+
+            if (!TryGetEntityPage(pageByEntityId, namespaceDeclaration.Id, "namespace", out var page))
+            {
+                violations.Add(new WikiScopedLinkInvariantViolation(
+                    PageRelativePath: $"missing:{namespaceDeclaration.Id.Value}",
+                    SectionPath: NamespaceSectionPath,
+                    LineNumber: 1,
+                    LineText: "-",
+                    Message: "Missing namespace page for invariant validation."));
+                continue;
+            }
+
+            ValidateSectionBullets(page, NamespaceSectionPath, parentHeading: null, childHeading: "## Contained Types", violations);
+        }
+
+        foreach (var file in request.Model.Files)
+        {
+            if (!methodCountByFileId.TryGetValue(file.Id, out var methodCount) || methodCount == 0)
+            {
+                continue;
+            }
+
+            if (!TryGetEntityPage(pageByEntityId, file.Id, "file", out var page))
+            {
+                violations.Add(new WikiScopedLinkInvariantViolation(
+                    PageRelativePath: $"missing:{file.Id.Value}",
+                    SectionPath: FileMethodsSectionPath,
+                    LineNumber: 1,
+                    LineText: "-",
+                    Message: "Missing file page for invariant validation."));
+                continue;
+            }
+
+            ValidateSectionBullets(page, FileMethodsSectionPath, parentHeading: "## Declared Symbols", childHeading: "### Methods", violations);
+        }
+
+        var ordered = violations
+            .OrderBy(x => x.PageRelativePath, StringComparer.Ordinal)
+            .ThenBy(x => x.SectionPath, StringComparer.Ordinal)
+            .ThenBy(x => x.LineNumber)
+            .ThenBy(x => x.LineText, StringComparer.Ordinal)
+            .ToArray();
+
+        return new WikiScopedLinkInvariantValidationResult(ordered);
+    }
+
+    private static Dictionary<string, IndexedWikiPage> BuildPageIndex(IReadOnlyList<WikiPage> pages)
+    {
+        var index = new Dictionary<string, IndexedWikiPage>(StringComparer.Ordinal);
+
+        foreach (var page in pages)
+        {
+            if (!TryParseFrontMatter(page.Markdown, out var frontMatter))
+            {
+                continue;
+            }
+
+            if (!frontMatter.TryGetValue("entity_id", out var entityId) || string.IsNullOrWhiteSpace(entityId))
+            {
+                continue;
+            }
+
+            frontMatter.TryGetValue("entity_type", out var entityType);
+            index[entityId] = new IndexedWikiPage(page.RelativePath, page.Markdown, entityType ?? string.Empty);
+        }
+
+        return index;
+    }
+
+    private static bool TryGetEntityPage(
+        IReadOnlyDictionary<string, IndexedWikiPage> pageByEntityId,
+        EntityId entityId,
+        string expectedEntityType,
+        out IndexedWikiPage page)
+    {
+        if (pageByEntityId.TryGetValue(entityId.Value, out page)
+            && page.EntityType.Equals(expectedEntityType, StringComparison.Ordinal))
+        {
+            return true;
+        }
+
+        page = default;
+        return false;
+    }
+
+    private static void ValidateSectionBullets(
+        IndexedWikiPage page,
+        string sectionPath,
+        string? parentHeading,
+        string childHeading,
+        ICollection<WikiScopedLinkInvariantViolation> violations)
+    {
+        var lines = SplitLines(page.Markdown);
+        var sectionRange = FindSectionRange(lines, parentHeading, childHeading);
+        if (sectionRange is null)
+        {
+            violations.Add(new WikiScopedLinkInvariantViolation(
+                PageRelativePath: page.RelativePath,
+                SectionPath: sectionPath,
+                LineNumber: 1,
+                LineText: "-",
+                Message: "Scoped section heading not found."));
+            return;
+        }
+
+        var (start, end) = sectionRange.Value;
+        var sectionHasBullets = false;
+
+        for (var index = start + 1; index < end; index++)
+        {
+            var line = lines[index];
+            var trimmed = line.TrimStart();
+
+            if (!trimmed.StartsWith("- ", StringComparison.Ordinal))
+            {
+                continue;
+            }
+
+            sectionHasBullets = true;
+            if (!trimmed.StartsWith("- [[", StringComparison.Ordinal))
+            {
+                violations.Add(new WikiScopedLinkInvariantViolation(
+                    PageRelativePath: page.RelativePath,
+                    SectionPath: sectionPath,
+                    LineNumber: index + 1,
+                    LineText: line,
+                    Message: "Expected wiki link bullet for resolvable target."));
+            }
+        }
+
+        if (!sectionHasBullets)
+        {
+            violations.Add(new WikiScopedLinkInvariantViolation(
+                PageRelativePath: page.RelativePath,
+                SectionPath: sectionPath,
+                LineNumber: start + 1,
+                LineText: childHeading,
+                Message: "Scoped section contains no bullet entries."));
+        }
+    }
+
+    private static (int Start, int End)? FindSectionRange(
+        IReadOnlyList<string> lines,
+        string? parentHeading,
+        string childHeading)
+    {
+        if (parentHeading is null)
+        {
+            var child = FindHeading(lines, 0, lines.Count, childHeading);
+            if (child < 0)
+            {
+                return null;
+            }
+
+            return (child, FindNextHeading(lines, child + 1, "## "));
+        }
+
+        var parent = FindHeading(lines, 0, lines.Count, parentHeading);
+        if (parent < 0)
+        {
+            return null;
+        }
+
+        var parentEnd = FindNextHeading(lines, parent + 1, "## ");
+        var childInParent = FindHeading(lines, parent + 1, parentEnd, childHeading);
+        if (childInParent < 0)
+        {
+            return null;
+        }
+
+        var childEnd = FindNextHeading(lines, childInParent + 1, "### ", "## ");
+        return (childInParent, childEnd);
+    }
+
+    private static int FindHeading(IReadOnlyList<string> lines, int start, int end, string heading)
+    {
+        for (var index = start; index < end; index++)
+        {
+            if (lines[index].Trim().Equals(heading, StringComparison.Ordinal))
+            {
+                return index;
+            }
+        }
+
+        return -1;
+    }
+
+    private static int FindNextHeading(IReadOnlyList<string> lines, int start, params string[] prefixes)
+    {
+        for (var index = start; index < lines.Count; index++)
+        {
+            var trimmed = lines[index].TrimStart();
+            if (prefixes.Any(prefix => trimmed.StartsWith(prefix, StringComparison.Ordinal)))
+            {
+                return index;
+            }
+        }
+
+        return lines.Count;
+    }
+
+    private static IReadOnlyList<string> SplitLines(string markdown)
+    {
+        return markdown.Replace("\r\n", "\n", StringComparison.Ordinal).Split('\n');
+    }
+
+    private static bool TryParseFrontMatter(string markdown, out Dictionary<string, string> values)
+    {
+        values = new Dictionary<string, string>(StringComparer.Ordinal);
+        var lines = SplitLines(markdown);
+        if (lines.Count < 3 || !lines[0].Trim().Equals("---", StringComparison.Ordinal))
+        {
+            return false;
+        }
+
+        for (var index = 1; index < lines.Count; index++)
+        {
+            var line = lines[index].Trim();
+            if (line.Equals("---", StringComparison.Ordinal))
+            {
+                return values.Count > 0;
+            }
+
+            var separator = line.IndexOf(':');
+            if (separator <= 0)
+            {
+                continue;
+            }
+
+            var key = line[..separator].Trim();
+            var value = line[(separator + 1)..].Trim();
+            if (key.Length == 0)
+            {
+                continue;
+            }
+
+            values[key] = value;
+        }
+
+        return false;
+    }
+
+    private readonly record struct IndexedWikiPage(string RelativePath, string Markdown, string EntityType);
+}

--- a/src/CodeLlmWiki.Cli/Features/Ingest/WikiScopedLinkInvariantViolation.cs
+++ b/src/CodeLlmWiki.Cli/Features/Ingest/WikiScopedLinkInvariantViolation.cs
@@ -1,0 +1,8 @@
+namespace CodeLlmWiki.Cli.Features.Ingest;
+
+public sealed record WikiScopedLinkInvariantViolation(
+    string PageRelativePath,
+    string SectionPath,
+    int LineNumber,
+    string LineText,
+    string Message);

--- a/tests/CodeLlmWiki.Cli.Tests/IngestionArtifactPublisherTests.cs
+++ b/tests/CodeLlmWiki.Cli.Tests/IngestionArtifactPublisherTests.cs
@@ -157,6 +157,44 @@ public sealed class IngestionArtifactPublisherTests
         Assert.True(longestMethodFileNameLength <= 123, $"Unexpectedly long method wiki filename length: {longestMethodFileNameLength}");
     }
 
+    [Fact]
+    public async Task PublishAsync_Fails_AndDoesNotPromoteLatest_WhenScopedLinkInvariantsFail()
+    {
+        var fixture = await PublisherFixture.CreateAsync();
+        var analyzer = new ProjectStructureAnalyzer(new StableIdGenerator());
+        var analysis = await analyzer.AnalyzeAsync(fixture.RepositoryPath, CancellationToken.None);
+
+        var runResult = new IngestionRunResult(
+            Status: IngestionRunStatus.SucceededWithDiagnostics,
+            ExitCode: 0,
+            Diagnostics: analysis.Diagnostics,
+            RepositoryId: analysis.RepositoryId,
+            Triples: analysis.Triples);
+
+        var outputRoot = Path.Combine(Path.GetTempPath(), $"codellmwiki-artifacts-invariant-fail-{Guid.NewGuid():N}");
+        var latestDirectory = Path.Combine(outputRoot, "latest");
+        Directory.CreateDirectory(latestDirectory);
+        var markerPath = Path.Combine(latestDirectory, "marker.txt");
+        await File.WriteAllTextAsync(markerPath, "preserve");
+
+        var publisher = new IngestionArtifactPublisher(new FailingInvariantValidator());
+
+        var result = await publisher.PublishAsync(
+            new IngestionArtifactPublishRequest(
+                RepositoryPath: fixture.RepositoryPath,
+                OutputRootPath: outputRoot,
+                StartedAtUtc: new DateTimeOffset(2026, 1, 1, 0, 0, 0, TimeSpan.Zero),
+                CompletedAtUtc: new DateTimeOffset(2026, 1, 1, 0, 0, 5, TimeSpan.Zero),
+                RunResult: runResult),
+            CancellationToken.None);
+
+        Assert.False(result.Succeeded);
+        Assert.False(result.LatestPromoted);
+        Assert.True(File.Exists(markerPath));
+        Assert.Contains("Scoped wiki link invariants failed", result.FailureReason, StringComparison.Ordinal);
+        Assert.Contains("namespaces/Sample/App.md", result.FailureReason, StringComparison.Ordinal);
+    }
+
     private static int CountOccurrences(string value, string token)
     {
         var count = 0;
@@ -189,6 +227,22 @@ public sealed class IngestionArtifactPublisherTests
                 return $"{relative}\n{content}";
             })
             .ToArray();
+    }
+
+    private sealed class FailingInvariantValidator : IWikiScopedLinkInvariantValidator
+    {
+        public WikiScopedLinkInvariantValidationResult Validate(WikiScopedLinkInvariantValidationRequest request)
+        {
+            return new WikiScopedLinkInvariantValidationResult(
+                [
+                    new WikiScopedLinkInvariantViolation(
+                        PageRelativePath: "namespaces/Sample/App.md",
+                        SectionPath: "## Contained Types",
+                        LineNumber: 12,
+                        LineText: "- Worker (class)",
+                        Message: "Expected wiki link bullet for resolvable target.")
+                ]);
+        }
     }
 
     private sealed class PublisherFixture

--- a/tests/CodeLlmWiki.Cli.Tests/WikiScopedLinkInvariantValidatorTests.cs
+++ b/tests/CodeLlmWiki.Cli.Tests/WikiScopedLinkInvariantValidatorTests.cs
@@ -1,0 +1,150 @@
+using System.Diagnostics;
+using CodeLlmWiki.Cli.Features.Ingest;
+using CodeLlmWiki.Contracts.Identity;
+using CodeLlmWiki.Ingestion.ProjectStructure;
+using CodeLlmWiki.Query.ProjectStructure;
+using CodeLlmWiki.Wiki.ProjectStructure;
+
+namespace CodeLlmWiki.Cli.Tests;
+
+public sealed class WikiScopedLinkInvariantValidatorTests
+{
+    [Fact]
+    public async Task Validate_ReturnsValid_WhenScopedSectionsContainWikiLinks()
+    {
+        var fixture = await ValidatorFixture.CreateAsync();
+        var analyzer = new ProjectStructureAnalyzer(new StableIdGenerator());
+        var analysis = await analyzer.AnalyzeAsync(fixture.RepositoryPath, CancellationToken.None);
+        var model = new ProjectStructureQueryService(analysis.Triples).GetModel(analysis.RepositoryId);
+        var pages = new ProjectStructureWikiRenderer().Render(model);
+        var validator = new WikiScopedLinkInvariantValidator();
+
+        var result = validator.Validate(new WikiScopedLinkInvariantValidationRequest(model, pages));
+
+        Assert.True(result.IsValid);
+        Assert.Empty(result.Violations);
+    }
+
+    [Fact]
+    public async Task Validate_ReturnsConcreteViolations_WhenScopedSectionsContainPlainBullets()
+    {
+        var fixture = await ValidatorFixture.CreateAsync();
+        var analyzer = new ProjectStructureAnalyzer(new StableIdGenerator());
+        var analysis = await analyzer.AnalyzeAsync(fixture.RepositoryPath, CancellationToken.None);
+        var model = new ProjectStructureQueryService(analysis.Triples).GetModel(analysis.RepositoryId);
+        var pages = new ProjectStructureWikiRenderer().Render(model)
+            .Select(page =>
+            {
+                if (page.RelativePath == "namespaces/Sample/App.md")
+                {
+                    return page with
+                    {
+                        Markdown = page.Markdown.Replace(
+                            "- [[types/Sample/App/Worker|Worker]] (class)",
+                            "- Worker (class)",
+                            StringComparison.Ordinal),
+                    };
+                }
+
+                if (page.RelativePath == "files/src/App/Services.cs.md")
+                {
+                    var updated = page.Markdown
+                        .Replace("- [[methods/Sample/App/Worker/Run--no-params|Run()]] (method)", "- Run() (method)", StringComparison.Ordinal)
+                        .Replace("- [[methods/Sample/App/Worker/Load--int|Load(int)]] (method)", "- Load(int) (method)", StringComparison.Ordinal);
+                    return page with { Markdown = updated };
+                }
+
+                return page;
+            })
+            .ToArray();
+
+        var validator = new WikiScopedLinkInvariantValidator();
+
+        var result = validator.Validate(new WikiScopedLinkInvariantValidationRequest(model, pages));
+
+        Assert.False(result.IsValid);
+        Assert.True(result.Violations.Count >= 2);
+        Assert.Contains(result.Violations, x => x.PageRelativePath == "namespaces/Sample/App.md" && x.SectionPath == "## Contained Types" && x.LineNumber > 0);
+        Assert.Contains(result.Violations, x => x.PageRelativePath == "files/src/App/Services.cs.md" && x.SectionPath == "## Declared Symbols > ### Methods" && x.LineNumber > 0);
+    }
+
+    private sealed class ValidatorFixture
+    {
+        private ValidatorFixture(string repositoryPath)
+        {
+            RepositoryPath = repositoryPath;
+        }
+
+        public string RepositoryPath { get; }
+
+        public static async Task<ValidatorFixture> CreateAsync()
+        {
+            var root = Path.Combine(Path.GetTempPath(), $"codellmwiki-invariant-{Guid.NewGuid():N}", "fixture-repo");
+            Directory.CreateDirectory(root);
+
+            await File.WriteAllTextAsync(Path.Combine(root, "Sample.slnx"),
+                """
+                <Solution>
+                  <Project Path="src/App/App.csproj" />
+                </Solution>
+                """);
+
+            var appDir = Path.Combine(root, "src", "App");
+            Directory.CreateDirectory(appDir);
+            await File.WriteAllTextAsync(Path.Combine(appDir, "App.csproj"),
+                """
+                <Project Sdk="Microsoft.NET.Sdk">
+                  <PropertyGroup>
+                    <TargetFramework>net10.0</TargetFramework>
+                  </PropertyGroup>
+                </Project>
+                """);
+
+            await File.WriteAllTextAsync(Path.Combine(appDir, "Services.cs"),
+                """
+                namespace Sample.App;
+
+                public sealed class Worker
+                {
+                    public void Run() { }
+
+                    public void Load(int count) { }
+                }
+                """);
+
+            RunGit(root, "init", "-b", "main");
+            RunGit(root, "config", "user.email", "test@example.com");
+            RunGit(root, "config", "user.name", "Test User");
+            RunGit(root, "add", ".");
+            RunGit(root, "commit", "-m", "initial");
+
+            return new ValidatorFixture(root);
+        }
+    }
+
+    private static void RunGit(string workingDirectory, params string[] args)
+    {
+        var startInfo = new ProcessStartInfo
+        {
+            FileName = "git",
+            WorkingDirectory = workingDirectory,
+            RedirectStandardOutput = true,
+            RedirectStandardError = true,
+        };
+
+        foreach (var arg in args)
+        {
+            startInfo.ArgumentList.Add(arg);
+        }
+
+        using var process = Process.Start(startInfo)!;
+        process.WaitForExit();
+
+        if (process.ExitCode != 0)
+        {
+            var stdOut = process.StandardOutput.ReadToEnd();
+            var stdErr = process.StandardError.ReadToEnd();
+            throw new InvalidOperationException($"git {string.Join(' ', args)} failed: {stdOut}\n{stdErr}");
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- add a scoped wiki invariant validator module for:
  - namespace `## Contained Types`
  - file `## Declared Symbols > ### Methods`
- integrate validator into `IngestionArtifactPublisher` as a fail-fast gate before writing wiki/promoting latest
- return concrete violation details (page/section/line/text) in failure reason
- add validator pass/fail tests with concrete violation assertions
- add publisher integration test proving invariant failures do not promote `latest`
- update PRD 004 phase/issue checklist completion state

## Interface design pass
- evaluated 3 interface variants (minimal, extensible ruleset, common-case optimized)
- implemented common-case optimized contract: `Validate(request) -> result` with structured violations

## Testing
- dotnet test tests/CodeLlmWiki.Cli.Tests/CodeLlmWiki.Cli.Tests.csproj --filter "FullyQualifiedName~WikiScopedLinkInvariantValidatorTests|FullyQualifiedName~IngestionArtifactPublisherTests.PublishAsync_Fails_AndDoesNotPromoteLatest_WhenScopedLinkInvariantsFail"
- dotnet test CodeLlmWiki.slnx

Closes #57
