### PR TITLE
feat(dependencies): enforce project-scoped package attribution

### DIFF
--- a/plans/005/005-phase-5-dependency-usage-mapping-and-package-provenance.issue.064.md
+++ b/plans/005/005-phase-5-dependency-usage-mapping-and-package-provenance.issue.064.md
@@ -3,8 +3,8 @@
 > Parent PRD: [PRD 005](./005-phase-5-dependency-usage-mapping-and-package-provenance.prd.md)
 
 - Issue: [#64](https://github.com/vbfg1973/code-llm-wiki/issues/64)
-- [ ] Status: open
-- [ ] Completion date:
+- [x] Status: completed
+- [x] Completion date: 2026-04-19
 
 ## Notes
 
@@ -18,10 +18,10 @@ Implement deterministic, project-scoped package attribution for external depende
 
 ## Acceptance criteria
 
-- [ ] External dependency package attribution uses source method/type project context.
-- [ ] Deterministic mapping is applied only when attribution certainty is available.
-- [ ] Query/package projections and wiki output reflect project-correct package attribution in mixed-version scenarios.
-- [ ] Tests cover mixed-version multi-project attribution behavior deterministically.
+- [x] External dependency package attribution uses source method/type project context.
+- [x] Deterministic mapping is applied only when attribution certainty is available.
+- [x] Query/package projections and wiki output reflect project-correct package attribution in mixed-version scenarios.
+- [x] Tests cover mixed-version multi-project attribution behavior deterministically.
 
 ## Blocked by
 

--- a/plans/005/005-phase-5-dependency-usage-mapping-and-package-provenance.plan.md
+++ b/plans/005/005-phase-5-dependency-usage-mapping-and-package-provenance.plan.md
@@ -6,7 +6,7 @@
 
 - [x] Phase 1: Declaration Dependency Usage Vertical Slice — completion date: 2026-04-19
 - [x] Phase 2: Method-Body Dependency Usage Vertical Slice — completion date: 2026-04-19
-- [ ] Phase 3: Project-Scoped Package Attribution + Unknown/Unresolved Semantics Slice — completion date:
+- [x] Phase 3: Project-Scoped Package Attribution + Unknown/Unresolved Semantics Slice — completion date: 2026-04-19
 - [ ] Phase 4: Rollup, Determinism, and Contract Hardening Slice — completion date:
 
 ---

--- a/src/CodeLlmWiki.Query/ProjectStructure/DeclarationDependencyUsageProjector.cs
+++ b/src/CodeLlmWiki.Query/ProjectStructure/DeclarationDependencyUsageProjector.cs
@@ -14,7 +14,11 @@ public sealed class DeclarationDependencyUsageProjector : IDeclarationDependency
         var typeById = request.Types.ToDictionary(x => x.Id, x => x);
         var namespaceById = request.Namespaces.ToDictionary(x => x.Id, x => x);
         var packageById = request.Packages.ToDictionary(x => x.Id, x => x);
-        var fileById = request.Files.ToDictionary(x => x.Id, x => x);
+        var packageAttributionResolver = new ProjectScopedPackageAttributionResolver(
+            request.Projects,
+            request.Packages,
+            request.Files,
+            request.Methods);
 
         var rows = request.Triples
             .Where(x => x.Predicate == CorePredicates.DependsOnTypeDeclaration)
@@ -28,8 +32,7 @@ public sealed class DeclarationDependencyUsageProjector : IDeclarationDependency
                 typeById,
                 namespaceById,
                 packageById,
-                fileById,
-                request.Projects,
+                packageAttributionResolver,
                 metadataById))
             .Where(x => x is not null)
             .Select(x => x!)
@@ -95,19 +98,20 @@ public sealed class DeclarationDependencyUsageProjector : IDeclarationDependency
         IReadOnlyDictionary<EntityId, TypeDeclarationNode> typeById,
         IReadOnlyDictionary<EntityId, NamespaceDeclarationNode> namespaceById,
         IReadOnlyDictionary<EntityId, PackageNode> packageById,
-        IReadOnlyDictionary<EntityId, FileNode> fileById,
-        IReadOnlyList<ProjectNode> projects,
+        IProjectScopedPackageAttributionResolver packageAttributionResolver,
         IReadOnlyDictionary<EntityId, ProjectionMetadata> metadataById)
     {
         if (!methodById.TryGetValue(methodId, out var method)
             || !typeById.TryGetValue(method.DeclaringTypeId, out var declaringType)
-            || !TryResolveMethodProject(method, fileById, projects, out var project)
             || !metadataById.TryGetValue(targetTypeId, out var targetTypeMeta))
         {
             return null;
         }
 
-        if (!TryResolvePackage(project, packageById, targetTypeMeta.Name, out var package))
+        var attribution = packageAttributionResolver.Resolve(methodId, targetTypeMeta.Name);
+        if (attribution.Status != PackageAttributionStatus.Attributed
+            || attribution.PackageId is null
+            || !packageById.TryGetValue(attribution.PackageId.Value, out var package))
         {
             return null;
         }
@@ -125,84 +129,6 @@ public sealed class DeclarationDependencyUsageProjector : IDeclarationDependency
             MethodId: method.Id,
             MethodSignature: method.Signature,
             UsageCount: 1);
-    }
-
-    private static bool TryResolveMethodProject(
-        MethodDeclarationNode method,
-        IReadOnlyDictionary<EntityId, FileNode> fileById,
-        IReadOnlyList<ProjectNode> projects,
-        out ProjectNode project)
-    {
-        var declarationFilePaths = method.DeclarationFileIds
-            .Where(fileById.ContainsKey)
-            .Select(id => fileById[id].Path)
-            .OrderBy(x => x, StringComparer.Ordinal)
-            .ToArray();
-
-        foreach (var declarationFilePath in declarationFilePaths)
-        {
-            var candidate = projects
-                .Where(p => IsFileWithinProject(p.Path, declarationFilePath))
-                .OrderBy(p => p.Path, StringComparer.Ordinal)
-                .ThenBy(p => p.Name, StringComparer.Ordinal)
-                .ThenBy(p => p.Id.Value, StringComparer.Ordinal)
-                .FirstOrDefault();
-
-            if (candidate is not null)
-            {
-                project = candidate;
-                return true;
-            }
-        }
-
-        project = default!;
-        return false;
-    }
-
-    private static bool IsFileWithinProject(string projectPath, string filePath)
-    {
-        var projectDirectory = Path.GetDirectoryName(projectPath)?.Replace('\\', '/') ?? string.Empty;
-        var normalizedFilePath = filePath.Replace('\\', '/');
-
-        return normalizedFilePath.Equals(projectDirectory, StringComparison.Ordinal)
-            || normalizedFilePath.StartsWith(projectDirectory + "/", StringComparison.Ordinal);
-    }
-
-    private static bool TryResolvePackage(
-        ProjectNode sourceProject,
-        IReadOnlyDictionary<EntityId, PackageNode> packageById,
-        string referenceName,
-        out PackageNode package)
-    {
-        var candidates = sourceProject.PackageIds
-            .Where(packageById.ContainsKey)
-            .Select(id => packageById[id])
-            .Where(p => PackageMatchesReference(p, referenceName))
-            .OrderBy(p => p.Name, StringComparer.Ordinal)
-            .ThenBy(p => p.Id.Value, StringComparer.Ordinal)
-            .ToArray();
-
-        if (candidates.Length == 1)
-        {
-            package = candidates[0];
-            return true;
-        }
-
-        package = default!;
-        return false;
-    }
-
-    private static bool PackageMatchesReference(PackageNode package, string referenceName)
-    {
-        if (string.IsNullOrWhiteSpace(referenceName))
-        {
-            return false;
-        }
-
-        return referenceName.Equals(package.Name, StringComparison.OrdinalIgnoreCase)
-               || referenceName.StartsWith(package.Name + ".", StringComparison.OrdinalIgnoreCase)
-               || referenceName.Equals(package.CanonicalKey, StringComparison.OrdinalIgnoreCase)
-               || referenceName.StartsWith(package.CanonicalKey + ".", StringComparison.OrdinalIgnoreCase);
     }
 
     private static Dictionary<EntityId, ProjectionMetadata> BuildMetadata(IReadOnlyList<SemanticTriple> triples)

--- a/src/CodeLlmWiki.Query/ProjectStructure/IProjectScopedPackageAttributionResolver.cs
+++ b/src/CodeLlmWiki.Query/ProjectStructure/IProjectScopedPackageAttributionResolver.cs
@@ -1,0 +1,8 @@
+using CodeLlmWiki.Contracts.Identity;
+
+namespace CodeLlmWiki.Query.ProjectStructure;
+
+public interface IProjectScopedPackageAttributionResolver
+{
+    PackageAttributionResolution Resolve(EntityId sourceMethodId, string targetReferenceName);
+}

--- a/src/CodeLlmWiki.Query/ProjectStructure/MethodBodyDependencyUsageProjector.cs
+++ b/src/CodeLlmWiki.Query/ProjectStructure/MethodBodyDependencyUsageProjector.cs
@@ -14,7 +14,11 @@ public sealed class MethodBodyDependencyUsageProjector : IMethodBodyDependencyUs
         var typeById = request.Types.ToDictionary(x => x.Id, x => x);
         var namespaceById = request.Namespaces.ToDictionary(x => x.Id, x => x);
         var packageById = request.Packages.ToDictionary(x => x.Id, x => x);
-        var fileById = request.Files.ToDictionary(x => x.Id, x => x);
+        var packageAttributionResolver = new ProjectScopedPackageAttributionResolver(
+            request.Projects,
+            request.Packages,
+            request.Files,
+            request.Methods);
 
         var rows = request.Triples
             .Where(x => x.Predicate == CorePredicates.DependsOnTypeInMethodBody)
@@ -28,8 +32,7 @@ public sealed class MethodBodyDependencyUsageProjector : IMethodBodyDependencyUs
                 typeById,
                 namespaceById,
                 packageById,
-                fileById,
-                request.Projects,
+                packageAttributionResolver,
                 metadataById))
             .Where(x => x is not null)
             .Select(x => x!)
@@ -95,19 +98,20 @@ public sealed class MethodBodyDependencyUsageProjector : IMethodBodyDependencyUs
         IReadOnlyDictionary<EntityId, TypeDeclarationNode> typeById,
         IReadOnlyDictionary<EntityId, NamespaceDeclarationNode> namespaceById,
         IReadOnlyDictionary<EntityId, PackageNode> packageById,
-        IReadOnlyDictionary<EntityId, FileNode> fileById,
-        IReadOnlyList<ProjectNode> projects,
+        IProjectScopedPackageAttributionResolver packageAttributionResolver,
         IReadOnlyDictionary<EntityId, ProjectionMetadata> metadataById)
     {
         if (!methodById.TryGetValue(methodId, out var method)
             || !typeById.TryGetValue(method.DeclaringTypeId, out var declaringType)
-            || !TryResolveMethodProject(method, fileById, projects, out var project)
             || !metadataById.TryGetValue(targetTypeId, out var targetTypeMeta))
         {
             return null;
         }
 
-        if (!TryResolvePackage(project, packageById, targetTypeMeta.Name, out var package))
+        var attribution = packageAttributionResolver.Resolve(methodId, targetTypeMeta.Name);
+        if (attribution.Status != PackageAttributionStatus.Attributed
+            || attribution.PackageId is null
+            || !packageById.TryGetValue(attribution.PackageId.Value, out var package))
         {
             return null;
         }
@@ -125,84 +129,6 @@ public sealed class MethodBodyDependencyUsageProjector : IMethodBodyDependencyUs
             MethodId: method.Id,
             MethodSignature: method.Signature,
             UsageCount: 1);
-    }
-
-    private static bool TryResolveMethodProject(
-        MethodDeclarationNode method,
-        IReadOnlyDictionary<EntityId, FileNode> fileById,
-        IReadOnlyList<ProjectNode> projects,
-        out ProjectNode project)
-    {
-        var declarationFilePaths = method.DeclarationFileIds
-            .Where(fileById.ContainsKey)
-            .Select(id => fileById[id].Path)
-            .OrderBy(x => x, StringComparer.Ordinal)
-            .ToArray();
-
-        foreach (var declarationFilePath in declarationFilePaths)
-        {
-            var candidate = projects
-                .Where(p => IsFileWithinProject(p.Path, declarationFilePath))
-                .OrderBy(p => p.Path, StringComparer.Ordinal)
-                .ThenBy(p => p.Name, StringComparer.Ordinal)
-                .ThenBy(p => p.Id.Value, StringComparer.Ordinal)
-                .FirstOrDefault();
-
-            if (candidate is not null)
-            {
-                project = candidate;
-                return true;
-            }
-        }
-
-        project = default!;
-        return false;
-    }
-
-    private static bool IsFileWithinProject(string projectPath, string filePath)
-    {
-        var projectDirectory = Path.GetDirectoryName(projectPath)?.Replace('\\', '/') ?? string.Empty;
-        var normalizedFilePath = filePath.Replace('\\', '/');
-
-        return normalizedFilePath.Equals(projectDirectory, StringComparison.Ordinal)
-            || normalizedFilePath.StartsWith(projectDirectory + "/", StringComparison.Ordinal);
-    }
-
-    private static bool TryResolvePackage(
-        ProjectNode sourceProject,
-        IReadOnlyDictionary<EntityId, PackageNode> packageById,
-        string referenceName,
-        out PackageNode package)
-    {
-        var candidates = sourceProject.PackageIds
-            .Where(packageById.ContainsKey)
-            .Select(id => packageById[id])
-            .Where(p => PackageMatchesReference(p, referenceName))
-            .OrderBy(p => p.Name, StringComparer.Ordinal)
-            .ThenBy(p => p.Id.Value, StringComparer.Ordinal)
-            .ToArray();
-
-        if (candidates.Length == 1)
-        {
-            package = candidates[0];
-            return true;
-        }
-
-        package = default!;
-        return false;
-    }
-
-    private static bool PackageMatchesReference(PackageNode package, string referenceName)
-    {
-        if (string.IsNullOrWhiteSpace(referenceName))
-        {
-            return false;
-        }
-
-        return referenceName.Equals(package.Name, StringComparison.OrdinalIgnoreCase)
-               || referenceName.StartsWith(package.Name + ".", StringComparison.OrdinalIgnoreCase)
-               || referenceName.Equals(package.CanonicalKey, StringComparison.OrdinalIgnoreCase)
-               || referenceName.StartsWith(package.CanonicalKey + ".", StringComparison.OrdinalIgnoreCase);
     }
 
     private static Dictionary<EntityId, ProjectionMetadata> BuildMetadata(IReadOnlyList<SemanticTriple> triples)

--- a/src/CodeLlmWiki.Query/ProjectStructure/PackageAttributionReason.cs
+++ b/src/CodeLlmWiki.Query/ProjectStructure/PackageAttributionReason.cs
@@ -1,0 +1,10 @@
+namespace CodeLlmWiki.Query.ProjectStructure;
+
+public enum PackageAttributionReason
+{
+    None = 0,
+    SourceMethodNotFound = 1,
+    SourceProjectNotFound = 2,
+    NoProjectScopedMatch = 3,
+    AmbiguousProjectScopedMatch = 4,
+}

--- a/src/CodeLlmWiki.Query/ProjectStructure/PackageAttributionResolution.cs
+++ b/src/CodeLlmWiki.Query/ProjectStructure/PackageAttributionResolution.cs
@@ -1,0 +1,10 @@
+using CodeLlmWiki.Contracts.Identity;
+
+namespace CodeLlmWiki.Query.ProjectStructure;
+
+public sealed record PackageAttributionResolution(
+    PackageAttributionStatus Status,
+    EntityId? SourceProjectId,
+    EntityId? PackageId,
+    PackageAttributionReason Reason,
+    IReadOnlyList<EntityId> OrderedCandidatePackageIds);

--- a/src/CodeLlmWiki.Query/ProjectStructure/PackageAttributionStatus.cs
+++ b/src/CodeLlmWiki.Query/ProjectStructure/PackageAttributionStatus.cs
@@ -1,0 +1,7 @@
+namespace CodeLlmWiki.Query.ProjectStructure;
+
+public enum PackageAttributionStatus
+{
+    Attributed = 0,
+    Unknown = 1,
+}

--- a/src/CodeLlmWiki.Query/ProjectStructure/ProjectScopedPackageAttributionResolver.cs
+++ b/src/CodeLlmWiki.Query/ProjectStructure/ProjectScopedPackageAttributionResolver.cs
@@ -1,0 +1,153 @@
+using CodeLlmWiki.Contracts.Identity;
+
+namespace CodeLlmWiki.Query.ProjectStructure;
+
+public sealed class ProjectScopedPackageAttributionResolver : IProjectScopedPackageAttributionResolver
+{
+    private readonly IReadOnlyDictionary<EntityId, MethodDeclarationNode> _methodById;
+    private readonly IReadOnlyDictionary<EntityId, FileNode> _fileById;
+    private readonly IReadOnlyDictionary<EntityId, PackageNode> _packageById;
+    private readonly IReadOnlyList<ProjectNode> _projects;
+
+    public ProjectScopedPackageAttributionResolver(
+        IReadOnlyList<ProjectNode> projects,
+        IReadOnlyList<PackageNode> packages,
+        IReadOnlyList<FileNode> files,
+        IReadOnlyList<MethodDeclarationNode> methods)
+    {
+        ArgumentNullException.ThrowIfNull(projects);
+        ArgumentNullException.ThrowIfNull(packages);
+        ArgumentNullException.ThrowIfNull(files);
+        ArgumentNullException.ThrowIfNull(methods);
+
+        _projects = projects;
+        _packageById = packages.ToDictionary(x => x.Id, x => x);
+        _fileById = files.ToDictionary(x => x.Id, x => x);
+        _methodById = methods.ToDictionary(x => x.Id, x => x);
+    }
+
+    public PackageAttributionResolution Resolve(EntityId sourceMethodId, string targetReferenceName)
+    {
+        if (!_methodById.TryGetValue(sourceMethodId, out var sourceMethod))
+        {
+            return new PackageAttributionResolution(
+                Status: PackageAttributionStatus.Unknown,
+                SourceProjectId: null,
+                PackageId: null,
+                Reason: PackageAttributionReason.SourceMethodNotFound,
+                OrderedCandidatePackageIds: []);
+        }
+
+        if (!TryResolveSourceProject(sourceMethod, out var sourceProject))
+        {
+            return new PackageAttributionResolution(
+                Status: PackageAttributionStatus.Unknown,
+                SourceProjectId: null,
+                PackageId: null,
+                Reason: PackageAttributionReason.SourceProjectNotFound,
+                OrderedCandidatePackageIds: []);
+        }
+
+        var candidates = sourceProject.PackageIds
+            .Where(_packageById.ContainsKey)
+            .Select(packageId => _packageById[packageId])
+            .Where(package => PackageMatchesReference(package, targetReferenceName))
+            .OrderBy(package => package.Name, StringComparer.Ordinal)
+            .ThenBy(package => package.Id.Value, StringComparer.Ordinal)
+            .Select(package => package.Id)
+            .ToArray();
+
+        if (candidates.Length == 0)
+        {
+            return new PackageAttributionResolution(
+                Status: PackageAttributionStatus.Unknown,
+                SourceProjectId: sourceProject.Id,
+                PackageId: null,
+                Reason: PackageAttributionReason.NoProjectScopedMatch,
+                OrderedCandidatePackageIds: []);
+        }
+
+        if (candidates.Length > 1)
+        {
+            return new PackageAttributionResolution(
+                Status: PackageAttributionStatus.Unknown,
+                SourceProjectId: sourceProject.Id,
+                PackageId: null,
+                Reason: PackageAttributionReason.AmbiguousProjectScopedMatch,
+                OrderedCandidatePackageIds: candidates);
+        }
+
+        return new PackageAttributionResolution(
+            Status: PackageAttributionStatus.Attributed,
+            SourceProjectId: sourceProject.Id,
+            PackageId: candidates[0],
+            Reason: PackageAttributionReason.None,
+            OrderedCandidatePackageIds: candidates);
+    }
+
+    private bool TryResolveSourceProject(MethodDeclarationNode sourceMethod, out ProjectNode sourceProject)
+    {
+        var declarationFilePaths = sourceMethod.DeclarationFileIds
+            .Where(_fileById.ContainsKey)
+            .Select(fileId => _fileById[fileId].Path)
+            .OrderBy(path => path, StringComparer.Ordinal)
+            .ToArray();
+
+        foreach (var declarationFilePath in declarationFilePaths)
+        {
+            var candidate = _projects
+                .Where(project => IsFileWithinProject(project.Path, declarationFilePath))
+                .Select(project =>
+                {
+                    var projectDirectory = NormalizeProjectDirectory(project.Path);
+                    return new
+                    {
+                        Project = project,
+                        Directory = projectDirectory,
+                    };
+                })
+                .OrderByDescending(x => x.Directory.Length)
+                .ThenBy(x => x.Project.Path, StringComparer.Ordinal)
+                .ThenBy(x => x.Project.Name, StringComparer.Ordinal)
+                .ThenBy(x => x.Project.Id.Value, StringComparer.Ordinal)
+                .Select(x => x.Project)
+                .FirstOrDefault();
+
+            if (candidate is not null)
+            {
+                sourceProject = candidate;
+                return true;
+            }
+        }
+
+        sourceProject = default!;
+        return false;
+    }
+
+    private static bool IsFileWithinProject(string projectPath, string filePath)
+    {
+        var projectDirectory = NormalizeProjectDirectory(projectPath);
+        var normalizedFilePath = filePath.Replace('\\', '/');
+
+        return normalizedFilePath.Equals(projectDirectory, StringComparison.Ordinal)
+            || normalizedFilePath.StartsWith(projectDirectory + "/", StringComparison.Ordinal);
+    }
+
+    private static string NormalizeProjectDirectory(string projectPath)
+    {
+        return (Path.GetDirectoryName(projectPath) ?? string.Empty).Replace('\\', '/');
+    }
+
+    private static bool PackageMatchesReference(PackageNode package, string referenceName)
+    {
+        if (string.IsNullOrWhiteSpace(referenceName))
+        {
+            return false;
+        }
+
+        return referenceName.Equals(package.Name, StringComparison.OrdinalIgnoreCase)
+               || referenceName.StartsWith(package.Name + ".", StringComparison.OrdinalIgnoreCase)
+               || referenceName.Equals(package.CanonicalKey, StringComparison.OrdinalIgnoreCase)
+               || referenceName.StartsWith(package.CanonicalKey + ".", StringComparison.OrdinalIgnoreCase);
+    }
+}

--- a/tests/CodeLlmWiki.Ingestion.Tests/PackageDependencyVerticalSliceTests.cs
+++ b/tests/CodeLlmWiki.Ingestion.Tests/PackageDependencyVerticalSliceTests.cs
@@ -20,7 +20,7 @@ public sealed class PackageDependencyVerticalSliceTests
         var query = new ProjectStructureQueryService(analysis.Triples);
         var model = query.GetModel(analysis.RepositoryId);
 
-        Assert.Equal(2, model.Packages.Count);
+        Assert.Equal(3, model.Packages.Count);
 
         var withAssetsProject = model.Projects.Single(x => x.Name == "WithAssets");
         var withAssetsPackages = withAssetsProject.PackageIds
@@ -89,7 +89,7 @@ public sealed class PackageDependencyVerticalSliceTests
         var pages = renderer.Render(model);
 
         Assert.True(pages.Count >= 7, $"Expected at least 7 pages but got {pages.Count}.");
-        Assert.Equal(2, pages.Count(x => x.RelativePath.StartsWith("packages/", StringComparison.Ordinal)));
+        Assert.Equal(3, pages.Count(x => x.RelativePath.StartsWith("packages/", StringComparison.Ordinal)));
         Assert.Contains(pages, page => page.RelativePath.StartsWith("projects/", StringComparison.Ordinal) && page.Markdown.Contains("[[packages/", StringComparison.Ordinal));
         Assert.Contains(pages, page => page.RelativePath == "index/repository-index.md");
 
@@ -188,6 +188,47 @@ public sealed class PackageDependencyVerticalSliceTests
     }
 
     [Fact]
+    public async Task Query_UsesProjectScopedAttribution_InMixedVersionRepository()
+    {
+        var fixture = await PackageDependencyFixture.CreateAsync();
+        var analyzer = new ProjectStructureAnalyzer(new StableIdGenerator());
+        var analysis = await analyzer.AnalyzeAsync(fixture.RepositoryPath, CancellationToken.None);
+        var model = new ProjectStructureQueryService(analysis.Triples).GetModel(analysis.RepositoryId);
+
+        var newtonsoftJson = model.Packages.Single(x => x.Name == "Newtonsoft.Json");
+
+        var declarationNamespaces = newtonsoftJson.DeclarationDependencyUsage.Namespaces
+            .Select(x => x.NamespaceName)
+            .OrderBy(x => x, StringComparer.Ordinal)
+            .ToArray();
+        Assert.Equal(["App.NoAssets", "App.WithAssets"], declarationNamespaces);
+
+        var methodBodyNamespaces = newtonsoftJson.MethodBodyDependencyUsage.Namespaces
+            .Select(x => x.NamespaceName)
+            .OrderBy(x => x, StringComparer.Ordinal)
+            .ToArray();
+        Assert.Equal(["App.NoAssets", "App.WithAssets"], methodBodyNamespaces);
+
+        var noAssetsMembership = newtonsoftJson.ProjectMemberships.Single(x => x.ProjectName == "NoAssets");
+        var withAssetsMembership = newtonsoftJson.ProjectMemberships.Single(x => x.ProjectName == "WithAssets");
+        Assert.Equal("12.0.1", noAssetsMembership.DeclaredVersion);
+        Assert.Equal("13.0.3", withAssetsMembership.DeclaredVersion);
+    }
+
+    [Fact]
+    public async Task Query_DoesNotMisattribute_ToPrefixOverlappingPackageOutsideSourceProject()
+    {
+        var fixture = await PackageDependencyFixture.CreateAsync();
+        var analyzer = new ProjectStructureAnalyzer(new StableIdGenerator());
+        var analysis = await analyzer.AnalyzeAsync(fixture.RepositoryPath, CancellationToken.None);
+        var model = new ProjectStructureQueryService(analysis.Triples).GetModel(analysis.RepositoryId);
+
+        var prefixPackage = model.Packages.Single(x => x.Name == "Newtonsoft");
+        Assert.Equal(0, prefixPackage.DeclarationDependencyUsage.UsageCount);
+        Assert.Equal(0, prefixPackage.MethodBodyDependencyUsage.UsageCount);
+    }
+
+    [Fact]
     public async Task Ontology_ContainsPackagePredicates_AndStillValidates()
     {
         var ontologyPath = Path.GetFullPath(Path.Combine(AppContext.BaseDirectory, "..", "..", "..", "..", "..", "ontology", "ontology.v1.yaml"));
@@ -226,6 +267,7 @@ public sealed class PackageDependencyVerticalSliceTests
                        <Solution>
                          <Project Path="src/WithAssets/WithAssets.csproj" />
                          <Project Path="src/NoAssets/NoAssets.csproj" />
+                         <Project Path="src/PrefixOnly/PrefixOnly.csproj" />
                        </Solution>
                        """;
             await File.WriteAllTextAsync(solutionPath, slnx);
@@ -305,6 +347,41 @@ public sealed class PackageDependencyVerticalSliceTests
                 public sealed class NoAssetsFacade
                 {
                     public void Track(Serilog.ILogger logger) { }
+                }
+                """);
+            await File.WriteAllTextAsync(Path.Combine(noAssetsDir, "NoAssetsJsonUsage.cs"),
+                """
+                namespace App.NoAssets;
+
+                public sealed class NoAssetsJsonFacade
+                {
+                    public Newtonsoft.Json.Linq.JToken Normalize(Newtonsoft.Json.Linq.JObject payload)
+                    {
+                        return Newtonsoft.Json.Linq.JToken.FromObject(payload);
+                    }
+                }
+                """);
+
+            var prefixOnlyDir = Path.Combine(root, "src", "PrefixOnly");
+            Directory.CreateDirectory(prefixOnlyDir);
+            var prefixOnlyCsproj = """
+                                   <Project Sdk="Microsoft.NET.Sdk">
+                                     <PropertyGroup>
+                                       <TargetFramework>net10.0</TargetFramework>
+                                     </PropertyGroup>
+                                     <ItemGroup>
+                                       <PackageReference Include="Newtonsoft" Version="1.0.0" />
+                                     </ItemGroup>
+                                   </Project>
+                                   """;
+            await File.WriteAllTextAsync(Path.Combine(prefixOnlyDir, "PrefixOnly.csproj"), prefixOnlyCsproj);
+            await File.WriteAllTextAsync(Path.Combine(prefixOnlyDir, "PrefixOnlyUsage.cs"),
+                """
+                namespace App.PrefixOnly;
+
+                public sealed class PrefixOnlyFacade
+                {
+                    public string Name() => nameof(PrefixOnlyFacade);
                 }
                 """);
 


### PR DESCRIPTION
## Summary
- add a shared `ProjectScopedPackageAttributionResolver` with deterministic project and package selection rules
- route both declaration and method-body dependency projectors through the shared resolver
- add mixed-version and prefix-overlap attribution tests to validate project-context correctness

## Validation
- dotnet test tests/CodeLlmWiki.Ingestion.Tests/CodeLlmWiki.Ingestion.Tests.csproj --filter FullyQualifiedName~PackageDependencyVerticalSliceTests --nologo
- dotnet test CodeLlmWiki.slnx --nologo

Closes #64
