### PR TITLE
feat(dependencies): surface unknown and unresolved attribution

### DIFF
--- a/plans/005/005-phase-5-dependency-usage-mapping-and-package-provenance.issue.065.md
+++ b/plans/005/005-phase-5-dependency-usage-mapping-and-package-provenance.issue.065.md
@@ -3,8 +3,8 @@
 > Parent PRD: [PRD 005](./005-phase-5-dependency-usage-mapping-and-package-provenance.prd.md)
 
 - Issue: [#65](https://github.com/vbfg1973/code-llm-wiki/issues/65)
-- [ ] Status: open
-- [ ] Completion date:
+- [x] Status: completed
+- [x] Completion date: 2026-04-19
 
 ## Notes
 
@@ -18,10 +18,10 @@ Implement explicit unknown and unresolved dependency semantics across ingestion,
 
 ## Acceptance criteria
 
-- [ ] Unknown package attribution is emitted explicitly when deterministic mapping is unavailable.
-- [ ] Unresolved dependency entities with reason codes are emitted and queryable.
-- [ ] Package/wiki dependency views surface unknown/unresolved semantics explicitly.
-- [ ] Tests cover ambiguity and unresolved scenarios deterministically.
+- [x] Unknown package attribution is emitted explicitly when deterministic mapping is unavailable.
+- [x] Unresolved dependency entities with reason codes are emitted and queryable.
+- [x] Package/wiki dependency views surface unknown/unresolved semantics explicitly.
+- [x] Tests cover ambiguity and unresolved scenarios deterministically.
 
 ## Blocked by
 

--- a/src/CodeLlmWiki.Ingestion/ProjectStructure/ProjectStructureAnalyzer.cs
+++ b/src/CodeLlmWiki.Ingestion/ProjectStructure/ProjectStructureAnalyzer.cs
@@ -792,7 +792,11 @@ public sealed class ProjectStructureAnalyzer : IProjectStructureAnalyzer
                     }
                     else
                     {
-                        baseTypeId = GetOrCreateUnresolvedReferenceId(normalizedBaseType, unresolvedReferenceIdByText, triples);
+                        baseTypeId = GetOrCreateUnresolvedReferenceId(
+                            normalizedBaseType,
+                            "type-resolution-fallback",
+                            unresolvedReferenceIdByText,
+                            triples);
                         diagnostics.Add(new IngestionDiagnostic(
                             "type:resolution:fallback",
                             $"Unresolved base type '{baseType}' for '{representative.QualifiedName}'."));
@@ -830,7 +834,11 @@ public sealed class ProjectStructureAnalyzer : IProjectStructureAnalyzer
                     }
                     else
                     {
-                        interfaceTypeId = GetOrCreateUnresolvedReferenceId(normalizedInterfaceType, unresolvedReferenceIdByText, triples);
+                        interfaceTypeId = GetOrCreateUnresolvedReferenceId(
+                            normalizedInterfaceType,
+                            "type-resolution-fallback",
+                            unresolvedReferenceIdByText,
+                            triples);
                         diagnostics.Add(new IngestionDiagnostic(
                             "type:resolution:fallback",
                             $"Unresolved interface type '{interfaceType}' for '{representative.QualifiedName}'."));
@@ -1023,7 +1031,11 @@ public sealed class ProjectStructureAnalyzer : IProjectStructureAnalyzer
                     diagnostics.Add(new IngestionDiagnostic(
                         "type:resolution:fallback",
                         $"Unresolved return type '{pendingReturnTypeLink.ReturnTypeName}' for method '{pendingReturnTypeLink.MethodId.Value}'."));
-                    continue;
+                    resolvedReturnTypeId = GetOrCreateUnresolvedReferenceId(
+                        NormalizeTypeReferenceName(pendingReturnTypeLink.ReturnTypeName),
+                        "type-resolution-fallback",
+                        unresolvedReferenceIdByText,
+                        triples);
                 }
             }
 
@@ -1059,7 +1071,11 @@ public sealed class ProjectStructureAnalyzer : IProjectStructureAnalyzer
                     diagnostics.Add(new IngestionDiagnostic(
                         "type:resolution:fallback",
                         $"Unresolved extension target type '{pendingExtendedTypeLink.ExtendedTypeName}' for method '{pendingExtendedTypeLink.MethodId.Value}'."));
-                    continue;
+                    resolvedExtendedTypeId = GetOrCreateUnresolvedReferenceId(
+                        NormalizeTypeReferenceName(pendingExtendedTypeLink.ExtendedTypeName),
+                        "type-resolution-fallback",
+                        unresolvedReferenceIdByText,
+                        triples);
                 }
             }
 
@@ -1095,7 +1111,11 @@ public sealed class ProjectStructureAnalyzer : IProjectStructureAnalyzer
                     diagnostics.Add(new IngestionDiagnostic(
                         "type:resolution:fallback",
                         $"Unresolved parameter type '{pendingParameterTypeLink.DeclaredTypeName}' for parameter '{pendingParameterTypeLink.ParameterId.Value}'."));
-                    continue;
+                    resolvedParameterTypeId = GetOrCreateUnresolvedReferenceId(
+                        NormalizeTypeReferenceName(pendingParameterTypeLink.DeclaredTypeName),
+                        "type-resolution-fallback",
+                        unresolvedReferenceIdByText,
+                        triples);
                 }
             }
 
@@ -1986,16 +2006,19 @@ public sealed class ProjectStructureAnalyzer : IProjectStructureAnalyzer
 
     private EntityId GetOrCreateUnresolvedReferenceId(
         string referenceName,
+        string resolutionReason,
         Dictionary<string, EntityId> unresolvedReferenceIdByText,
         List<SemanticTriple> triples)
     {
-        if (unresolvedReferenceIdByText.TryGetValue(referenceName, out var existing))
+        var key = $"{resolutionReason}|{referenceName}";
+        if (unresolvedReferenceIdByText.TryGetValue(key, out var existing))
         {
             return existing;
         }
 
-        var unresolvedId = _stableIdGenerator.Create(new EntityKey("unresolved-type-reference", referenceName));
-        unresolvedReferenceIdByText[referenceName] = unresolvedId;
+        var unresolvedNaturalKey = $"{resolutionReason}:{referenceName}";
+        var unresolvedId = _stableIdGenerator.Create(new EntityKey("unresolved-type-reference", unresolvedNaturalKey));
+        unresolvedReferenceIdByText[key] = unresolvedId;
 
         AddEntityTriples(
             triples,
@@ -2003,6 +2026,10 @@ public sealed class ProjectStructureAnalyzer : IProjectStructureAnalyzer
             "unresolved-type-reference",
             referenceName,
             $"unresolved/{referenceName}");
+        triples.Add(new SemanticTriple(
+            new EntityNode(unresolvedId),
+            CorePredicates.ResolutionReason,
+            new LiteralNode(resolutionReason)));
 
         return unresolvedId;
     }

--- a/src/CodeLlmWiki.Query/ProjectStructure/DependencyAttributionCatalog.cs
+++ b/src/CodeLlmWiki.Query/ProjectStructure/DependencyAttributionCatalog.cs
@@ -1,0 +1,10 @@
+namespace CodeLlmWiki.Query.ProjectStructure;
+
+public sealed record DependencyAttributionCatalog(
+    UnknownDependencyUsageCatalog DeclarationUnknown,
+    UnknownDependencyUsageCatalog MethodBodyUnknown)
+{
+    public static DependencyAttributionCatalog Empty { get; } = new(
+        UnknownDependencyUsageCatalog.Empty,
+        UnknownDependencyUsageCatalog.Empty);
+}

--- a/src/CodeLlmWiki.Query/ProjectStructure/IUnknownDependencyUsageProjector.cs
+++ b/src/CodeLlmWiki.Query/ProjectStructure/IUnknownDependencyUsageProjector.cs
@@ -1,0 +1,6 @@
+namespace CodeLlmWiki.Query.ProjectStructure;
+
+public interface IUnknownDependencyUsageProjector
+{
+    UnknownDependencyUsageCatalog Project(UnknownDependencyUsageProjectionRequest request);
+}

--- a/src/CodeLlmWiki.Query/ProjectStructure/ProjectStructureQueryService.cs
+++ b/src/CodeLlmWiki.Query/ProjectStructure/ProjectStructureQueryService.cs
@@ -224,6 +224,26 @@ public sealed class ProjectStructureQueryService : IProjectStructureQueryService
                 declarations.Namespaces,
                 declarations.Types,
                 declarations.Methods.Declarations));
+        var declarationUnknownDependencyUsage = new UnknownDependencyUsageProjector().Project(
+            new UnknownDependencyUsageProjectionRequest(
+                CorePredicates.DependsOnTypeDeclaration,
+                _triples,
+                projects,
+                packages,
+                files,
+                declarations.Namespaces,
+                declarations.Types,
+                declarations.Methods.Declarations));
+        var methodBodyUnknownDependencyUsage = new UnknownDependencyUsageProjector().Project(
+            new UnknownDependencyUsageProjectionRequest(
+                CorePredicates.DependsOnTypeInMethodBody,
+                _triples,
+                projects,
+                packages,
+                files,
+                declarations.Namespaces,
+                declarations.Types,
+                declarations.Methods.Declarations));
         packages = packages
             .Select(package => package with
             {
@@ -246,6 +266,9 @@ public sealed class ProjectStructureQueryService : IProjectStructureQueryService
         return new ProjectStructureWikiModel(repository, solutions, projects, packages, files, submodules)
         {
             Declarations = declarations,
+            DependencyAttribution = new DependencyAttributionCatalog(
+                declarationUnknownDependencyUsage,
+                methodBodyUnknownDependencyUsage),
         };
     }
 

--- a/src/CodeLlmWiki.Query/ProjectStructure/ProjectStructureWikiModel.cs
+++ b/src/CodeLlmWiki.Query/ProjectStructure/ProjectStructureWikiModel.cs
@@ -9,4 +9,5 @@ public sealed record ProjectStructureWikiModel(
     IReadOnlyList<SubmoduleNode> Submodules)
 {
     public DeclarationCatalog Declarations { get; init; } = DeclarationCatalog.Empty;
+    public DependencyAttributionCatalog DependencyAttribution { get; init; } = DependencyAttributionCatalog.Empty;
 }

--- a/src/CodeLlmWiki.Query/ProjectStructure/UnknownDependencyMethodUsageNode.cs
+++ b/src/CodeLlmWiki.Query/ProjectStructure/UnknownDependencyMethodUsageNode.cs
@@ -1,0 +1,11 @@
+using CodeLlmWiki.Contracts.Identity;
+
+namespace CodeLlmWiki.Query.ProjectStructure;
+
+public sealed record UnknownDependencyMethodUsageNode(
+    EntityId MethodId,
+    string MethodSignature,
+    string TargetTypeName,
+    string AttributionReason,
+    string TargetResolutionReason,
+    int UsageCount);

--- a/src/CodeLlmWiki.Query/ProjectStructure/UnknownDependencyNamespaceUsageNode.cs
+++ b/src/CodeLlmWiki.Query/ProjectStructure/UnknownDependencyNamespaceUsageNode.cs
@@ -1,0 +1,9 @@
+using CodeLlmWiki.Contracts.Identity;
+
+namespace CodeLlmWiki.Query.ProjectStructure;
+
+public sealed record UnknownDependencyNamespaceUsageNode(
+    EntityId? NamespaceId,
+    string NamespaceName,
+    int UsageCount,
+    IReadOnlyList<UnknownDependencyTypeUsageNode> Types);

--- a/src/CodeLlmWiki.Query/ProjectStructure/UnknownDependencyTypeUsageNode.cs
+++ b/src/CodeLlmWiki.Query/ProjectStructure/UnknownDependencyTypeUsageNode.cs
@@ -1,0 +1,9 @@
+using CodeLlmWiki.Contracts.Identity;
+
+namespace CodeLlmWiki.Query.ProjectStructure;
+
+public sealed record UnknownDependencyTypeUsageNode(
+    EntityId TypeId,
+    string TypeName,
+    int UsageCount,
+    IReadOnlyList<UnknownDependencyMethodUsageNode> Methods);

--- a/src/CodeLlmWiki.Query/ProjectStructure/UnknownDependencyUsageCatalog.cs
+++ b/src/CodeLlmWiki.Query/ProjectStructure/UnknownDependencyUsageCatalog.cs
@@ -1,0 +1,8 @@
+namespace CodeLlmWiki.Query.ProjectStructure;
+
+public sealed record UnknownDependencyUsageCatalog(
+    int UsageCount,
+    IReadOnlyList<UnknownDependencyNamespaceUsageNode> Namespaces)
+{
+    public static UnknownDependencyUsageCatalog Empty { get; } = new(0, []);
+}

--- a/src/CodeLlmWiki.Query/ProjectStructure/UnknownDependencyUsageProjectionRequest.cs
+++ b/src/CodeLlmWiki.Query/ProjectStructure/UnknownDependencyUsageProjectionRequest.cs
@@ -1,0 +1,13 @@
+using CodeLlmWiki.Contracts.Graph;
+
+namespace CodeLlmWiki.Query.ProjectStructure;
+
+public sealed record UnknownDependencyUsageProjectionRequest(
+    PredicateId DependencyPredicate,
+    IReadOnlyList<SemanticTriple> Triples,
+    IReadOnlyList<ProjectNode> Projects,
+    IReadOnlyList<PackageNode> Packages,
+    IReadOnlyList<FileNode> Files,
+    IReadOnlyList<NamespaceDeclarationNode> Namespaces,
+    IReadOnlyList<TypeDeclarationNode> Types,
+    IReadOnlyList<MethodDeclarationNode> Methods);

--- a/src/CodeLlmWiki.Query/ProjectStructure/UnknownDependencyUsageProjector.cs
+++ b/src/CodeLlmWiki.Query/ProjectStructure/UnknownDependencyUsageProjector.cs
@@ -1,0 +1,261 @@
+using System.Text;
+using CodeLlmWiki.Contracts.Graph;
+using CodeLlmWiki.Contracts.Identity;
+
+namespace CodeLlmWiki.Query.ProjectStructure;
+
+public sealed class UnknownDependencyUsageProjector : IUnknownDependencyUsageProjector
+{
+    public UnknownDependencyUsageCatalog Project(UnknownDependencyUsageProjectionRequest request)
+    {
+        ArgumentNullException.ThrowIfNull(request);
+
+        var metadataById = BuildMetadata(request.Triples);
+        var methodById = request.Methods.ToDictionary(x => x.Id, x => x);
+        var typeById = request.Types.ToDictionary(x => x.Id, x => x);
+        var namespaceById = request.Namespaces.ToDictionary(x => x.Id, x => x);
+        var packageAttributionResolver = new ProjectScopedPackageAttributionResolver(
+            request.Projects,
+            request.Packages,
+            request.Files,
+            request.Methods);
+
+        var rows = request.Triples
+            .Where(x => x.Predicate == request.DependencyPredicate)
+            .Where(x => x.Subject is EntityNode && x.Object is EntityNode)
+            .Select(x => (MethodId: ((EntityNode)x.Subject).Id, TargetTypeId: ((EntityNode)x.Object).Id))
+            .Where(x => methodById.ContainsKey(x.MethodId))
+            .Select(x => BuildUsageRow(
+                x.MethodId,
+                x.TargetTypeId,
+                methodById,
+                typeById,
+                namespaceById,
+                request.Packages,
+                metadataById,
+                packageAttributionResolver))
+            .Where(x => x is not null)
+            .Select(x => x!)
+            .ToArray();
+
+        var namespaces = rows
+            .GroupBy(x => (x.NamespaceId, x.NamespaceName))
+            .Select(ns =>
+            {
+                var types = ns
+                    .GroupBy(x => (x.TypeId, x.TypeName))
+                    .Select(type =>
+                    {
+                        var methods = type
+                            .GroupBy(x => (
+                                x.MethodId,
+                                x.MethodSignature,
+                                x.TargetTypeName,
+                                x.AttributionReason,
+                                x.TargetResolutionReason))
+                            .Select(method => new UnknownDependencyMethodUsageNode(
+                                MethodId: method.Key.MethodId,
+                                MethodSignature: method.Key.MethodSignature,
+                                TargetTypeName: method.Key.TargetTypeName,
+                                AttributionReason: method.Key.AttributionReason,
+                                TargetResolutionReason: method.Key.TargetResolutionReason,
+                                UsageCount: method.Sum(x => x.UsageCount)))
+                            .OrderByDescending(x => x.UsageCount)
+                            .ThenBy(x => x.MethodSignature, StringComparer.Ordinal)
+                            .ThenBy(x => x.TargetTypeName, StringComparer.Ordinal)
+                            .ThenBy(x => x.AttributionReason, StringComparer.Ordinal)
+                            .ThenBy(x => x.TargetResolutionReason, StringComparer.Ordinal)
+                            .ThenBy(x => x.MethodId.Value, StringComparer.Ordinal)
+                            .ToArray();
+
+                        return new UnknownDependencyTypeUsageNode(
+                            TypeId: type.Key.TypeId,
+                            TypeName: type.Key.TypeName,
+                            UsageCount: type.Sum(x => x.UsageCount),
+                            Methods: methods);
+                    })
+                    .OrderByDescending(x => x.UsageCount)
+                    .ThenBy(x => x.TypeName, StringComparer.Ordinal)
+                    .ThenBy(x => x.TypeId.Value, StringComparer.Ordinal)
+                    .ToArray();
+
+                return new UnknownDependencyNamespaceUsageNode(
+                    NamespaceId: ns.Key.NamespaceId,
+                    NamespaceName: ns.Key.NamespaceName,
+                    UsageCount: ns.Sum(x => x.UsageCount),
+                    Types: types);
+            })
+            .OrderByDescending(x => x.UsageCount)
+            .ThenBy(x => x.NamespaceName, StringComparer.Ordinal)
+            .ThenBy(x => x.NamespaceId?.Value ?? string.Empty, StringComparer.Ordinal)
+            .ToArray();
+
+        return new UnknownDependencyUsageCatalog(
+            UsageCount: rows.Sum(x => x.UsageCount),
+            Namespaces: namespaces);
+    }
+
+    private static UsageRow? BuildUsageRow(
+        EntityId methodId,
+        EntityId targetTypeId,
+        IReadOnlyDictionary<EntityId, MethodDeclarationNode> methodById,
+        IReadOnlyDictionary<EntityId, TypeDeclarationNode> typeById,
+        IReadOnlyDictionary<EntityId, NamespaceDeclarationNode> namespaceById,
+        IReadOnlyList<PackageNode> packages,
+        IReadOnlyDictionary<EntityId, ProjectionMetadata> metadataById,
+        IProjectScopedPackageAttributionResolver packageAttributionResolver)
+    {
+        if (!methodById.TryGetValue(methodId, out var method)
+            || !typeById.TryGetValue(method.DeclaringTypeId, out var declaringType)
+            || !metadataById.TryGetValue(targetTypeId, out var targetTypeMeta))
+        {
+            return null;
+        }
+
+        var attribution = packageAttributionResolver.Resolve(methodId, targetTypeMeta.Name);
+        if (attribution.Status == PackageAttributionStatus.Attributed)
+        {
+            return null;
+        }
+
+        if (!ShouldIncludeUnknown(targetTypeMeta, attribution, packages))
+        {
+            return null;
+        }
+
+        var namespaceName = declaringType.NamespaceId is { } namespaceId && namespaceById.TryGetValue(namespaceId, out var namespaceDeclaration)
+            ? namespaceDeclaration.Name
+            : "<global>";
+
+        return new UsageRow(
+            NamespaceId: declaringType.NamespaceId,
+            NamespaceName: namespaceName,
+            TypeId: declaringType.Id,
+            TypeName: declaringType.Name,
+            MethodId: method.Id,
+            MethodSignature: method.Signature,
+            TargetTypeName: targetTypeMeta.Name,
+            AttributionReason: ToSnakeCase(attribution.Reason.ToString()),
+            TargetResolutionReason: targetTypeMeta.ResolutionReason,
+            UsageCount: 1);
+    }
+
+    private static bool ShouldIncludeUnknown(
+        ProjectionMetadata targetTypeMeta,
+        PackageAttributionResolution attribution,
+        IReadOnlyList<PackageNode> packages)
+    {
+        if (attribution.Reason == PackageAttributionReason.AmbiguousProjectScopedMatch)
+        {
+            return true;
+        }
+
+        if (string.Equals(targetTypeMeta.EntityType, "unresolved-type-reference", StringComparison.Ordinal))
+        {
+            return true;
+        }
+
+        if (attribution.Reason != PackageAttributionReason.NoProjectScopedMatch)
+        {
+            return false;
+        }
+
+        return packages.Any(package => PackageMatchesReference(package, targetTypeMeta.Name));
+    }
+
+    private static bool PackageMatchesReference(PackageNode package, string referenceName)
+    {
+        if (string.IsNullOrWhiteSpace(referenceName))
+        {
+            return false;
+        }
+
+        return referenceName.Equals(package.Name, StringComparison.OrdinalIgnoreCase)
+               || referenceName.StartsWith(package.Name + ".", StringComparison.OrdinalIgnoreCase)
+               || referenceName.Equals(package.CanonicalKey, StringComparison.OrdinalIgnoreCase)
+               || referenceName.StartsWith(package.CanonicalKey + ".", StringComparison.OrdinalIgnoreCase);
+    }
+
+    private static Dictionary<EntityId, ProjectionMetadata> BuildMetadata(IReadOnlyList<SemanticTriple> triples)
+    {
+        var metadataById = new Dictionary<EntityId, ProjectionMetadata>();
+
+        foreach (var triple in triples)
+        {
+            if (triple.Subject is not EntityNode subject || triple.Object is not LiteralNode literal)
+            {
+                continue;
+            }
+
+            if (!metadataById.TryGetValue(subject.Id, out var metadata))
+            {
+                metadata = new ProjectionMetadata();
+                metadataById[subject.Id] = metadata;
+            }
+
+            var value = literal.Value?.ToString() ?? string.Empty;
+            if (triple.Predicate == CorePredicates.HasName)
+            {
+                metadata.Name = value;
+            }
+            else if (triple.Predicate == CorePredicates.EntityType)
+            {
+                metadata.EntityType = value;
+            }
+            else if (triple.Predicate == CorePredicates.ResolutionReason)
+            {
+                metadata.ResolutionReason = value;
+            }
+        }
+
+        return metadataById;
+    }
+
+    private static string ToSnakeCase(string value)
+    {
+        if (string.IsNullOrWhiteSpace(value))
+        {
+            return string.Empty;
+        }
+
+        var sb = new StringBuilder(value.Length + 8);
+        for (var i = 0; i < value.Length; i++)
+        {
+            var c = value[i];
+            if (char.IsUpper(c))
+            {
+                if (i > 0)
+                {
+                    sb.Append('_');
+                }
+
+                sb.Append(char.ToLowerInvariant(c));
+            }
+            else
+            {
+                sb.Append(c);
+            }
+        }
+
+        return sb.ToString();
+    }
+
+    private sealed class ProjectionMetadata
+    {
+        public string Name { get; set; } = string.Empty;
+        public string EntityType { get; set; } = string.Empty;
+        public string ResolutionReason { get; set; } = string.Empty;
+    }
+
+    private sealed record UsageRow(
+        EntityId? NamespaceId,
+        string NamespaceName,
+        EntityId TypeId,
+        string TypeName,
+        EntityId MethodId,
+        string MethodSignature,
+        string TargetTypeName,
+        string AttributionReason,
+        string TargetResolutionReason,
+        int UsageCount);
+}

--- a/src/CodeLlmWiki.Wiki/ProjectStructure/ProjectStructureWikiRenderer.cs
+++ b/src/CodeLlmWiki.Wiki/ProjectStructure/ProjectStructureWikiRenderer.cs
@@ -192,6 +192,11 @@ public sealed class ProjectStructureWikiRenderer : IProjectStructureWikiRenderer
         pages.AddRange(orderedSolutions.Select(solution => RenderSolutionPage(model.Repository.Id.Value, solution, projectById, resolver)));
         pages.AddRange(orderedProjects.Select(project => RenderProjectPage(model.Repository.Id.Value, project, packageById, resolver)));
         pages.AddRange(orderedPackages.Select(package => RenderPackagePage(model.Repository.Id.Value, package, methodById, resolver)));
+        if (model.DependencyAttribution.DeclarationUnknown.UsageCount > 0
+            || model.DependencyAttribution.MethodBodyUnknown.UsageCount > 0)
+        {
+            pages.Add(RenderUnknownPackageAttributionPage(model.Repository.Id.Value, model.DependencyAttribution, methodById, resolver));
+        }
         pages.AddRange(orderedNamespaces.Select(namespaceDeclaration => RenderNamespacePage(model.Repository.Id.Value, namespaceDeclaration, namespaceById, typeById, resolver)));
         pages.AddRange(orderedTypes.Select(typeDeclaration =>
             RenderTypePage(
@@ -487,6 +492,86 @@ public sealed class ProjectStructureWikiRenderer : IProjectStructureWikiRenderer
                     KeyValue("package_key", package.CanonicalKey),
                 ],
                 sb.ToString().TrimEnd()));
+    }
+
+    private static WikiPage RenderUnknownPackageAttributionPage(
+        string repositoryId,
+        DependencyAttributionCatalog dependencyAttribution,
+        IReadOnlyDictionary<EntityId, MethodDeclarationNode> methodById,
+        WikiPathResolver resolver)
+    {
+        const string pagePath = "packages/unknown-package-attribution.md";
+
+        var sb = new StringBuilder();
+        sb.AppendLine("# Unknown Package Attribution");
+
+        AppendUnknownDependencyUsageSection(
+            sb,
+            "Declaration Dependency Usage (Unknown Package Attribution)",
+            dependencyAttribution.DeclarationUnknown,
+            methodById,
+            resolver);
+        AppendUnknownDependencyUsageSection(
+            sb,
+            "Method Body Dependency Usage (Unknown Package Attribution)",
+            dependencyAttribution.MethodBodyUnknown,
+            methodById,
+            resolver);
+
+        return new WikiPage(
+            RelativePath: pagePath,
+            Title: "Unknown Package Attribution",
+            Markdown: WithFrontMatter(
+                [
+                    KeyValue("entity_id", $"dependency-attribution:unknown:{repositoryId}"),
+                    KeyValue("entity_type", "dependency-attribution-unknown"),
+                    KeyValue("repository_id", repositoryId),
+                ],
+                sb.ToString().TrimEnd()));
+    }
+
+    private static void AppendUnknownDependencyUsageSection(
+        StringBuilder sb,
+        string heading,
+        UnknownDependencyUsageCatalog catalog,
+        IReadOnlyDictionary<EntityId, MethodDeclarationNode> methodById,
+        WikiPathResolver resolver)
+    {
+        sb.AppendLine();
+        sb.AppendLine($"## {heading}");
+
+        if (catalog.UsageCount == 0)
+        {
+            sb.AppendLine("- none");
+            return;
+        }
+
+        foreach (var namespaceUsage in catalog.Namespaces)
+        {
+            var namespaceDisplay = namespaceUsage.NamespaceId is { } namespaceId
+                ? resolver.ToWikiLink(namespaceId, namespaceUsage.NamespaceName)
+                : namespaceUsage.NamespaceName;
+            sb.AppendLine($"- {namespaceDisplay} ({namespaceUsage.UsageCount})");
+
+            foreach (var typeUsage in namespaceUsage.Types)
+            {
+                var typeDisplay = resolver.ToWikiLink(typeUsage.TypeId, typeUsage.TypeName);
+                sb.AppendLine($"  - {typeDisplay} ({typeUsage.UsageCount})");
+
+                foreach (var methodUsage in typeUsage.Methods)
+                {
+                    var methodAlias = methodById.TryGetValue(methodUsage.MethodId, out var method)
+                        ? FormatMethodLinkAlias(method)
+                        : methodUsage.MethodSignature;
+                    var methodDisplay = resolver.ToWikiLink(methodUsage.MethodId, methodAlias);
+                    var reasonSuffix = string.IsNullOrWhiteSpace(methodUsage.TargetResolutionReason)
+                        ? string.Empty
+                        : $", resolution: {methodUsage.TargetResolutionReason}";
+                    sb.AppendLine(
+                        $"    - {methodDisplay} -> `{methodUsage.TargetTypeName}` (attribution: {methodUsage.AttributionReason}{reasonSuffix}) ({methodUsage.UsageCount})");
+                }
+            }
+        }
     }
 
     private static IReadOnlyDictionary<EntityId, IReadOnlyList<NamespaceDeclarationNode>> BuildNamespaceBacklinksByFileId(
@@ -1535,6 +1620,15 @@ public sealed class ProjectStructureWikiRenderer : IProjectStructureWikiRenderer
             model.Packages
                 .OrderBy(x => x.Name, StringComparer.Ordinal)
                 .Select(x => new IndexRow(x.Name, x.Name, x.Id.Value, resolver.ToWikiLink(x.Id, x.Name)))
+                .Concat(
+                    model.DependencyAttribution.DeclarationUnknown.UsageCount > 0
+                    || model.DependencyAttribution.MethodBodyUnknown.UsageCount > 0
+                        ? [new IndexRow(
+                            "Unknown Package Attribution",
+                            "packages/unknown-package-attribution.md",
+                            $"dependency-attribution:unknown:{model.Repository.Id.Value}",
+                            ToWikiLink("packages/unknown-package-attribution", "Unknown Package Attribution"))]
+                        : [])
                 .ToArray());
 
         AppendTable(

--- a/tests/CodeLlmWiki.Ingestion.Tests/PackageDependencyVerticalSliceTests.cs
+++ b/tests/CodeLlmWiki.Ingestion.Tests/PackageDependencyVerticalSliceTests.cs
@@ -295,6 +295,27 @@ public sealed class PackageDependencyVerticalSliceTests
     }
 
     [Fact]
+    public async Task Render_UnknownPackageAttributionPage_IsDeterministicAcrossRuns()
+    {
+        var fixture = await PackageDependencyFixture.CreateAsync(includeAmbiguousPackageInNoAssets: true, includeUnresolvedSignatureInNoAssets: true);
+        var analyzer = new ProjectStructureAnalyzer(new StableIdGenerator());
+
+        var first = await analyzer.AnalyzeAsync(fixture.RepositoryPath, CancellationToken.None);
+        var firstModel = new ProjectStructureQueryService(first.Triples).GetModel(first.RepositoryId);
+        var firstPage = new ProjectStructureWikiRenderer()
+            .Render(firstModel)
+            .Single(page => page.RelativePath == "packages/unknown-package-attribution.md");
+
+        var second = await analyzer.AnalyzeAsync(fixture.RepositoryPath, CancellationToken.None);
+        var secondModel = new ProjectStructureQueryService(second.Triples).GetModel(second.RepositoryId);
+        var secondPage = new ProjectStructureWikiRenderer()
+            .Render(secondModel)
+            .Single(page => page.RelativePath == "packages/unknown-package-attribution.md");
+
+        Assert.Equal(firstPage.Markdown, secondPage.Markdown);
+    }
+
+    [Fact]
     public async Task Ontology_ContainsPackagePredicates_AndStillValidates()
     {
         var ontologyPath = Path.GetFullPath(Path.Combine(AppContext.BaseDirectory, "..", "..", "..", "..", "..", "ontology", "ontology.v1.yaml"));

--- a/tests/CodeLlmWiki.Ingestion.Tests/PackageDependencyVerticalSliceTests.cs
+++ b/tests/CodeLlmWiki.Ingestion.Tests/PackageDependencyVerticalSliceTests.cs
@@ -229,6 +229,72 @@ public sealed class PackageDependencyVerticalSliceTests
     }
 
     [Fact]
+    public async Task Query_ProjectsUnknownPackageAttribution_WhenProjectScopedMatchIsAmbiguous()
+    {
+        var fixture = await PackageDependencyFixture.CreateAsync(includeAmbiguousPackageInNoAssets: true);
+        var analyzer = new ProjectStructureAnalyzer(new StableIdGenerator());
+        var analysis = await analyzer.AnalyzeAsync(fixture.RepositoryPath, CancellationToken.None);
+        var model = new ProjectStructureQueryService(analysis.Triples).GetModel(analysis.RepositoryId);
+
+        Assert.True(model.DependencyAttribution.DeclarationUnknown.UsageCount > 0);
+        Assert.True(model.DependencyAttribution.MethodBodyUnknown.UsageCount > 0);
+
+        var declarationMethodSignatures = model.DependencyAttribution.DeclarationUnknown.Namespaces
+            .SelectMany(x => x.Types)
+            .SelectMany(x => x.Methods)
+            .Select(x => x.MethodSignature)
+            .ToArray();
+        Assert.Contains(declarationMethodSignatures, x => x.Contains("Normalize(", StringComparison.Ordinal));
+
+        var declarationReasons = model.DependencyAttribution.DeclarationUnknown.Namespaces
+            .SelectMany(x => x.Types)
+            .SelectMany(x => x.Methods)
+            .Select(x => x.AttributionReason)
+            .ToHashSet(StringComparer.Ordinal);
+        Assert.Contains("ambiguous_project_scoped_match", declarationReasons);
+    }
+
+    [Fact]
+    public async Task Query_ProjectsUnresolvedDependencyEntities_WithReasonCodes()
+    {
+        var fixture = await PackageDependencyFixture.CreateAsync(includeUnresolvedSignatureInNoAssets: true);
+        var analyzer = new ProjectStructureAnalyzer(new StableIdGenerator());
+        var analysis = await analyzer.AnalyzeAsync(fixture.RepositoryPath, CancellationToken.None);
+        var model = new ProjectStructureQueryService(analysis.Triples).GetModel(analysis.RepositoryId);
+
+        var unresolvedEntityTypes = analysis.Triples
+            .Where(x => x.Predicate == CorePredicates.EntityType && x.Object is LiteralNode literal)
+            .Select(x => ((LiteralNode)x.Object).Value?.ToString() ?? string.Empty)
+            .ToArray();
+        Assert.Contains("unresolved-type-reference", unresolvedEntityTypes);
+
+        var unresolvedReasons = model.DependencyAttribution.DeclarationUnknown.Namespaces
+            .SelectMany(x => x.Types)
+            .SelectMany(x => x.Methods)
+            .Select(x => x.TargetResolutionReason)
+            .Where(x => !string.IsNullOrWhiteSpace(x))
+            .ToArray();
+        Assert.Contains("type-resolution-fallback", unresolvedReasons);
+    }
+
+    [Fact]
+    public async Task Render_IncludesUnknownPackageAttributionPage_WhenUnknownUsageExists()
+    {
+        var fixture = await PackageDependencyFixture.CreateAsync(includeAmbiguousPackageInNoAssets: true, includeUnresolvedSignatureInNoAssets: true);
+        var analyzer = new ProjectStructureAnalyzer(new StableIdGenerator());
+        var analysis = await analyzer.AnalyzeAsync(fixture.RepositoryPath, CancellationToken.None);
+        var model = new ProjectStructureQueryService(analysis.Triples).GetModel(analysis.RepositoryId);
+
+        var pages = new ProjectStructureWikiRenderer().Render(model);
+        var unknownPage = pages.Single(page => page.RelativePath == "packages/unknown-package-attribution.md");
+
+        Assert.Contains("## Declaration Dependency Usage (Unknown Package Attribution)", unknownPage.Markdown, StringComparison.Ordinal);
+        Assert.Contains("## Method Body Dependency Usage (Unknown Package Attribution)", unknownPage.Markdown, StringComparison.Ordinal);
+        Assert.Contains("ambiguous_project_scoped_match", unknownPage.Markdown, StringComparison.Ordinal);
+        Assert.Contains("type-resolution-fallback", unknownPage.Markdown, StringComparison.Ordinal);
+    }
+
+    [Fact]
     public async Task Ontology_ContainsPackagePredicates_AndStillValidates()
     {
         var ontologyPath = Path.GetFullPath(Path.Combine(AppContext.BaseDirectory, "..", "..", "..", "..", "..", "ontology", "ontology.v1.yaml"));
@@ -257,7 +323,9 @@ public sealed class PackageDependencyVerticalSliceTests
 
         public string RepositoryPath { get; }
 
-        public static async Task<PackageDependencyFixture> CreateAsync()
+        public static async Task<PackageDependencyFixture> CreateAsync(
+            bool includeAmbiguousPackageInNoAssets = false,
+            bool includeUnresolvedSignatureInNoAssets = false)
         {
             var root = Path.Combine(Path.GetTempPath(), $"codellmwiki-packages-{Guid.NewGuid():N}", "package-repo");
             Directory.CreateDirectory(root);
@@ -336,9 +404,18 @@ public sealed class PackageDependencyVerticalSliceTests
                                    <ItemGroup>
                                      <PackageReference Include="Newtonsoft.Json" Version="12.0.1" />
                                      <PackageReference Include="Serilog" Version="3.1.0" />
+                                     __NO_ASSETS_OPTIONAL_PACKAGE__
                                    </ItemGroup>
                                  </Project>
                                  """;
+            if (includeAmbiguousPackageInNoAssets)
+            {
+                noAssetsCsproj = noAssetsCsproj.Replace("__NO_ASSETS_OPTIONAL_PACKAGE__", "<PackageReference Include=\"Newtonsoft\" Version=\"1.0.0\" />", StringComparison.Ordinal);
+            }
+            else
+            {
+                noAssetsCsproj = noAssetsCsproj.Replace("__NO_ASSETS_OPTIONAL_PACKAGE__", string.Empty, StringComparison.Ordinal);
+            }
             await File.WriteAllTextAsync(Path.Combine(noAssetsDir, "NoAssets.csproj"), noAssetsCsproj);
             await File.WriteAllTextAsync(Path.Combine(noAssetsDir, "NoAssetsUsage.cs"),
                 """
@@ -361,6 +438,18 @@ public sealed class PackageDependencyVerticalSliceTests
                     }
                 }
                 """);
+            if (includeUnresolvedSignatureInNoAssets)
+            {
+                await File.WriteAllTextAsync(Path.Combine(noAssetsDir, "NoAssetsUnresolvedUsage.cs"),
+                    """
+                    namespace App.NoAssets;
+
+                    public sealed class NoAssetsUnresolvedFacade
+                    {
+                        public Missing[] Resolve(Missing[] payload) => payload;
+                    }
+                    """);
+            }
 
             var prefixOnlyDir = Path.Combine(root, "src", "PrefixOnly");
             Directory.CreateDirectory(prefixOnlyDir);


### PR DESCRIPTION
## Summary
- emit unresolved declaration dependency entities (with `core:resolutionReason`) instead of dropping unresolved signature dependencies
- add unknown dependency attribution projection for both declaration and method-body provenance
- expose unknown/unresolved dependency semantics in query model and publish `packages/unknown-package-attribution.md`
- extend package dependency vertical-slice tests for ambiguous attribution and unresolved reason propagation

## Validation
- dotnet test tests/CodeLlmWiki.Ingestion.Tests/CodeLlmWiki.Ingestion.Tests.csproj --filter FullyQualifiedName~PackageDependencyVerticalSliceTests --nologo
- dotnet test CodeLlmWiki.slnx --nologo

Closes #65
