### PR TITLE
feat: target-first package declaration dependencies (PRD 006 / #74)

### DIFF
--- a/src/CodeLlmWiki.Query/ProjectStructure/DeclarationDependencyTargetFirstProjector.cs
+++ b/src/CodeLlmWiki.Query/ProjectStructure/DeclarationDependencyTargetFirstProjector.cs
@@ -1,0 +1,161 @@
+using CodeLlmWiki.Contracts.Graph;
+using CodeLlmWiki.Contracts.Identity;
+
+namespace CodeLlmWiki.Query.ProjectStructure;
+
+public sealed class DeclarationDependencyTargetFirstProjector : IDeclarationDependencyTargetFirstProjector
+{
+    public IReadOnlyDictionary<EntityId, PackageDeclarationDependencyTargetFirstCatalog> Project(DeclarationDependencyUsageProjectionRequest request)
+    {
+        ArgumentNullException.ThrowIfNull(request);
+
+        var metadataById = BuildMetadata(request.Triples);
+        var methodById = request.Methods.ToDictionary(x => x.Id, x => x);
+        var typeById = request.Types.ToDictionary(x => x.Id, x => x);
+        var packageById = request.Packages.ToDictionary(x => x.Id, x => x);
+        var packageAttributionResolver = new ProjectScopedPackageAttributionResolver(
+            request.Projects,
+            request.Packages,
+            request.Files,
+            request.Methods);
+
+        var rows = request.Triples
+            .Where(x => x.Predicate == CorePredicates.DependsOnTypeDeclaration)
+            .Where(x => x.Subject is EntityNode && x.Object is EntityNode)
+            .Select(x => (MethodId: ((EntityNode)x.Subject).Id, TargetTypeId: ((EntityNode)x.Object).Id))
+            .Where(x => methodById.ContainsKey(x.MethodId))
+            .Select(x => BuildUsageRow(
+                x.MethodId,
+                x.TargetTypeId,
+                methodById,
+                typeById,
+                packageById,
+                packageAttributionResolver,
+                metadataById))
+            .Where(x => x is not null)
+            .Select(x => x!)
+            .ToArray();
+
+        return rows
+            .GroupBy(x => x.PackageId)
+            .ToDictionary(
+                x => x.Key,
+                x =>
+                {
+                    var externalTypes = x
+                        .GroupBy(v => (v.ExternalTypeId, v.ExternalTypeDisplayName))
+                        .Select(target =>
+                        {
+                            var internalTypes = target
+                                .GroupBy(v => (v.InternalTypeId, v.InternalTypeName))
+                                .Select(internalType => new PackageDeclarationInternalTypeUsageNode(
+                                    InternalTypeId: internalType.Key.InternalTypeId,
+                                    InternalTypeName: internalType.Key.InternalTypeName,
+                                    UsageCount: internalType.Sum(v => v.UsageCount)))
+                                .OrderBy(v => v.InternalTypeName, StringComparer.Ordinal)
+                                .ThenBy(v => v.InternalTypeId.Value, StringComparer.Ordinal)
+                                .ToArray();
+
+                            return new PackageDeclarationExternalTypeUsageNode(
+                                ExternalTypeId: target.Key.ExternalTypeId,
+                                ExternalTypeDisplayName: target.Key.ExternalTypeDisplayName,
+                                UsageCount: target.Sum(v => v.UsageCount),
+                                InternalTypes: internalTypes);
+                        })
+                        .OrderBy(v => v.ExternalTypeDisplayName, StringComparer.Ordinal)
+                        .ThenBy(v => v.ExternalTypeId.Value, StringComparer.Ordinal)
+                        .ToArray();
+
+                    return new PackageDeclarationDependencyTargetFirstCatalog(
+                        UsageCount: x.Sum(v => v.UsageCount),
+                        ExternalTypes: externalTypes);
+                });
+    }
+
+    private static UsageRow? BuildUsageRow(
+        EntityId methodId,
+        EntityId targetTypeId,
+        IReadOnlyDictionary<EntityId, MethodDeclarationNode> methodById,
+        IReadOnlyDictionary<EntityId, TypeDeclarationNode> typeById,
+        IReadOnlyDictionary<EntityId, PackageNode> packageById,
+        IProjectScopedPackageAttributionResolver packageAttributionResolver,
+        IReadOnlyDictionary<EntityId, ProjectionMetadata> metadataById)
+    {
+        if (!methodById.TryGetValue(methodId, out var method)
+            || !typeById.TryGetValue(method.DeclaringTypeId, out var internalType)
+            || !metadataById.TryGetValue(targetTypeId, out var targetTypeMetadata))
+        {
+            return null;
+        }
+
+        var attribution = packageAttributionResolver.Resolve(methodId, targetTypeMetadata.Name);
+        if (attribution.Status != PackageAttributionStatus.Attributed
+            || attribution.PackageId is null
+            || !packageById.TryGetValue(attribution.PackageId.Value, out var package))
+        {
+            return null;
+        }
+
+        var externalTypeName = string.IsNullOrWhiteSpace(targetTypeMetadata.Name)
+            ? targetTypeId.Value
+            : targetTypeMetadata.Name;
+
+        return new UsageRow(
+            PackageId: package.Id,
+            ExternalTypeId: targetTypeId,
+            ExternalTypeDisplayName: externalTypeName,
+            InternalTypeId: internalType.Id,
+            InternalTypeName: internalType.Name,
+            UsageCount: 1);
+    }
+
+    private static Dictionary<EntityId, ProjectionMetadata> BuildMetadata(IReadOnlyList<SemanticTriple> triples)
+    {
+        var metadataById = new Dictionary<EntityId, ProjectionMetadata>();
+
+        foreach (var triple in triples)
+        {
+            if (triple.Subject is not EntityNode subject || triple.Object is not LiteralNode literal)
+            {
+                continue;
+            }
+
+            if (!metadataById.TryGetValue(subject.Id, out var metadata))
+            {
+                metadata = new ProjectionMetadata();
+                metadataById[subject.Id] = metadata;
+            }
+
+            var value = literal.Value?.ToString() ?? string.Empty;
+            if (triple.Predicate == CorePredicates.HasName)
+            {
+                metadata.Name = value;
+            }
+            else if (triple.Predicate == CorePredicates.HasPath)
+            {
+                metadata.Path = value;
+            }
+            else if (triple.Predicate == CorePredicates.EntityType)
+            {
+                metadata.EntityType = value;
+            }
+        }
+
+        return metadataById;
+    }
+
+    private sealed class ProjectionMetadata
+    {
+        public string Name { get; set; } = string.Empty;
+        public string Path { get; set; } = string.Empty;
+        public string EntityType { get; set; } = string.Empty;
+    }
+
+    private sealed record UsageRow(
+        EntityId PackageId,
+        EntityId ExternalTypeId,
+        string ExternalTypeDisplayName,
+        EntityId InternalTypeId,
+        string InternalTypeName,
+        int UsageCount);
+}

--- a/src/CodeLlmWiki.Query/ProjectStructure/IDeclarationDependencyTargetFirstProjector.cs
+++ b/src/CodeLlmWiki.Query/ProjectStructure/IDeclarationDependencyTargetFirstProjector.cs
@@ -1,0 +1,9 @@
+using CodeLlmWiki.Contracts.Identity;
+
+namespace CodeLlmWiki.Query.ProjectStructure;
+
+public interface IDeclarationDependencyTargetFirstProjector
+{
+    IReadOnlyDictionary<EntityId, PackageDeclarationDependencyTargetFirstCatalog> Project(
+        DeclarationDependencyUsageProjectionRequest request);
+}

--- a/src/CodeLlmWiki.Query/ProjectStructure/PackageDeclarationDependencyTargetFirstCatalog.cs
+++ b/src/CodeLlmWiki.Query/ProjectStructure/PackageDeclarationDependencyTargetFirstCatalog.cs
@@ -1,0 +1,8 @@
+namespace CodeLlmWiki.Query.ProjectStructure;
+
+public sealed record PackageDeclarationDependencyTargetFirstCatalog(
+    int UsageCount,
+    IReadOnlyList<PackageDeclarationExternalTypeUsageNode> ExternalTypes)
+{
+    public static PackageDeclarationDependencyTargetFirstCatalog Empty { get; } = new(0, []);
+}

--- a/src/CodeLlmWiki.Query/ProjectStructure/PackageDeclarationExternalTypeUsageNode.cs
+++ b/src/CodeLlmWiki.Query/ProjectStructure/PackageDeclarationExternalTypeUsageNode.cs
@@ -1,0 +1,9 @@
+using CodeLlmWiki.Contracts.Identity;
+
+namespace CodeLlmWiki.Query.ProjectStructure;
+
+public sealed record PackageDeclarationExternalTypeUsageNode(
+    EntityId ExternalTypeId,
+    string ExternalTypeDisplayName,
+    int UsageCount,
+    IReadOnlyList<PackageDeclarationInternalTypeUsageNode> InternalTypes);

--- a/src/CodeLlmWiki.Query/ProjectStructure/PackageDeclarationInternalTypeUsageNode.cs
+++ b/src/CodeLlmWiki.Query/ProjectStructure/PackageDeclarationInternalTypeUsageNode.cs
@@ -1,0 +1,8 @@
+using CodeLlmWiki.Contracts.Identity;
+
+namespace CodeLlmWiki.Query.ProjectStructure;
+
+public sealed record PackageDeclarationInternalTypeUsageNode(
+    EntityId InternalTypeId,
+    string InternalTypeName,
+    int UsageCount);

--- a/src/CodeLlmWiki.Query/ProjectStructure/PackageNode.cs
+++ b/src/CodeLlmWiki.Query/ProjectStructure/PackageNode.cs
@@ -11,5 +11,6 @@ public sealed record PackageNode(
     IReadOnlyList<PackageProjectMembershipNode> ProjectMemberships)
 {
     public PackageDeclarationDependencyUsageCatalog DeclarationDependencyUsage { get; init; } = PackageDeclarationDependencyUsageCatalog.Empty;
+    public PackageDeclarationDependencyTargetFirstCatalog DeclarationDependencyTargetFirst { get; init; } = PackageDeclarationDependencyTargetFirstCatalog.Empty;
     public PackageMethodBodyDependencyUsageCatalog MethodBodyDependencyUsage { get; init; } = PackageMethodBodyDependencyUsageCatalog.Empty;
 }

--- a/src/CodeLlmWiki.Query/ProjectStructure/ProjectStructureQueryService.cs
+++ b/src/CodeLlmWiki.Query/ProjectStructure/ProjectStructureQueryService.cs
@@ -215,6 +215,15 @@ public sealed class ProjectStructureQueryService : IProjectStructureQueryService
                 declarations.Namespaces,
                 declarations.Types,
                 declarations.Methods.Declarations));
+        var declarationDependencyTargetFirstByPackageId = new DeclarationDependencyTargetFirstProjector().Project(
+            new DeclarationDependencyUsageProjectionRequest(
+                _triples,
+                projects,
+                packages,
+                files,
+                declarations.Namespaces,
+                declarations.Types,
+                declarations.Methods.Declarations));
         var methodBodyDependencyUsageByPackageId = new MethodBodyDependencyUsageProjector().Project(
             new MethodBodyDependencyUsageProjectionRequest(
                 _triples,
@@ -250,6 +259,9 @@ public sealed class ProjectStructureQueryService : IProjectStructureQueryService
                 DeclarationDependencyUsage = declarationDependencyUsageByPackageId.TryGetValue(package.Id, out var usage)
                     ? usage
                     : PackageDeclarationDependencyUsageCatalog.Empty,
+                DeclarationDependencyTargetFirst = declarationDependencyTargetFirstByPackageId.TryGetValue(package.Id, out var targetFirstUsage)
+                    ? targetFirstUsage
+                    : PackageDeclarationDependencyTargetFirstCatalog.Empty,
                 MethodBodyDependencyUsage = methodBodyDependencyUsageByPackageId.TryGetValue(package.Id, out var methodBodyUsage)
                     ? methodBodyUsage
                     : PackageMethodBodyDependencyUsageCatalog.Empty,

--- a/src/CodeLlmWiki.Wiki/ProjectStructure/ProjectStructureWikiRenderer.cs
+++ b/src/CodeLlmWiki.Wiki/ProjectStructure/ProjectStructureWikiRenderer.cs
@@ -450,31 +450,21 @@ public sealed class ProjectStructureWikiRenderer : IProjectStructureWikiRenderer
                 $"| {resolver.ToMarkdownLink(membership.ProjectId, membership.ProjectName)} | `{membership.ProjectPath}` | `{declaredVersion}` | `{resolvedVersion}` |");
         }
 
-        if (package.DeclarationDependencyUsage.UsageCount > 0)
+        if (package.DeclarationDependencyTargetFirst.UsageCount > 0)
         {
             sb.AppendLine();
-            sb.AppendLine("## Declaration Dependency Usage");
+            sb.AppendLine("## Declaration Dependencies (External Type -> Internal Type)");
 
-            foreach (var namespaceUsage in package.DeclarationDependencyUsage.Namespaces)
+            foreach (var externalType in package.DeclarationDependencyTargetFirst.ExternalTypes)
             {
-                var namespaceDisplay = namespaceUsage.NamespaceId is { } namespaceId
-                    ? resolver.ToWikiLink(namespaceId, namespaceUsage.NamespaceName)
-                    : namespaceUsage.NamespaceName;
-                sb.AppendLine($"- {namespaceDisplay} ({namespaceUsage.UsageCount})");
+                var anchor = WikiPathResolver.BuildPackageExternalTypeAnchor(package.CanonicalKey, externalType.ExternalTypeDisplayName);
+                sb.AppendLine($"<a id=\"{anchor}\"></a>");
+                sb.AppendLine($"- `{externalType.ExternalTypeDisplayName}` ({externalType.UsageCount})");
 
-                foreach (var typeUsage in namespaceUsage.Types)
+                foreach (var internalType in externalType.InternalTypes)
                 {
-                    var typeDisplay = resolver.ToWikiLink(typeUsage.TypeId, typeUsage.TypeName);
-                    sb.AppendLine($"  - {typeDisplay} ({typeUsage.UsageCount})");
-
-                    foreach (var methodUsage in typeUsage.Methods)
-                    {
-                        var methodAlias = methodById.TryGetValue(methodUsage.MethodId, out var method)
-                            ? FormatMethodLinkAlias(method)
-                            : methodUsage.MethodSignature;
-                        var methodDisplay = resolver.ToWikiLink(methodUsage.MethodId, methodAlias);
-                        sb.AppendLine($"    - {methodDisplay} ({methodUsage.UsageCount})");
-                    }
+                    var internalTypeDisplay = resolver.ToWikiLink(internalType.InternalTypeId, internalType.InternalTypeName);
+                    sb.AppendLine($"  - {internalTypeDisplay} ({internalType.UsageCount})");
                 }
             }
         }

--- a/tests/CodeLlmWiki.Ingestion.Tests/PackageDependencyVerticalSliceTests.cs
+++ b/tests/CodeLlmWiki.Ingestion.Tests/PackageDependencyVerticalSliceTests.cs
@@ -134,7 +134,24 @@ public sealed class PackageDependencyVerticalSliceTests
     }
 
     [Fact]
-    public async Task Render_PackagePage_IncludesDeclarationDependencyUsageSection_WhenUsageExists()
+    public async Task Query_ProjectsTargetFirstDeclarationDependencies_ByExternalTypeAndInternalType()
+    {
+        var fixture = await PackageDependencyFixture.CreateAsync();
+        var analyzer = new ProjectStructureAnalyzer(new StableIdGenerator());
+        var analysis = await analyzer.AnalyzeAsync(fixture.RepositoryPath, CancellationToken.None);
+        var model = new ProjectStructureQueryService(analysis.Triples).GetModel(analysis.RepositoryId);
+
+        var package = model.Packages.Single(x => x.Name == "Newtonsoft.Json");
+        Assert.True(package.DeclarationDependencyTargetFirst.UsageCount > 0);
+        Assert.NotEmpty(package.DeclarationDependencyTargetFirst.ExternalTypes);
+
+        var jToken = package.DeclarationDependencyTargetFirst.ExternalTypes
+            .Single(x => x.ExternalTypeDisplayName == "Newtonsoft.Json.Linq.JToken");
+        Assert.Contains(jToken.InternalTypes, x => x.InternalTypeName == "SerializerFacade");
+    }
+
+    [Fact]
+    public async Task Render_PackagePage_UsesTargetFirstDeclarationDependencySection_WhenUsageExists()
     {
         var fixture = await PackageDependencyFixture.CreateAsync();
         var analyzer = new ProjectStructureAnalyzer(new StableIdGenerator());
@@ -145,10 +162,11 @@ public sealed class PackageDependencyVerticalSliceTests
         var packagePage = pages.Single(page => page.RelativePath.StartsWith("packages/", StringComparison.Ordinal)
             && page.Markdown.Contains("# Package: Newtonsoft.Json", StringComparison.Ordinal));
 
-        Assert.Contains("## Declaration Dependency Usage", packagePage.Markdown, StringComparison.Ordinal);
+        Assert.Contains("## Declaration Dependencies (External Type -> Internal Type)", packagePage.Markdown, StringComparison.Ordinal);
+        Assert.DoesNotContain("## Declaration Dependency Usage", packagePage.Markdown, StringComparison.Ordinal);
+        Assert.Contains("Newtonsoft.Json.Linq.JToken", packagePage.Markdown, StringComparison.Ordinal);
         Assert.Contains("SerializerFacade", packagePage.Markdown, StringComparison.Ordinal);
-        Assert.Contains("- [[methods/", packagePage.Markdown, StringComparison.Ordinal);
-        Assert.Contains("Normalize(", packagePage.Markdown, StringComparison.Ordinal);
+        Assert.Contains("- [[types/App/WithAssets/SerializerFacade|SerializerFacade]]", packagePage.Markdown, StringComparison.Ordinal);
     }
 
     [Fact]


### PR DESCRIPTION
## Summary
- add target-first declaration dependency projection grouped as external type -> internal type
- keep existing caller-first declaration projection for compatibility, but remove caller-first declaration section from package pages
- render package declaration dependencies with deterministic external-type anchors for deep-linking
- add query/render regression tests for target-first declaration behavior

## Testing
- dotnet test CodeLlmWiki.slnx

Closes #74