### PR TITLE
feat: target-first package method-body dependencies (PRD 006 / #75)

### DIFF
--- a/src/CodeLlmWiki.Query/ProjectStructure/IMethodBodyDependencyTargetFirstProjector.cs
+++ b/src/CodeLlmWiki.Query/ProjectStructure/IMethodBodyDependencyTargetFirstProjector.cs
@@ -1,0 +1,9 @@
+using CodeLlmWiki.Contracts.Identity;
+
+namespace CodeLlmWiki.Query.ProjectStructure;
+
+public interface IMethodBodyDependencyTargetFirstProjector
+{
+    IReadOnlyDictionary<EntityId, PackageMethodBodyDependencyTargetFirstCatalog> Project(
+        MethodBodyDependencyUsageProjectionRequest request);
+}

--- a/src/CodeLlmWiki.Query/ProjectStructure/MethodBodyDependencyTargetFirstProjector.cs
+++ b/src/CodeLlmWiki.Query/ProjectStructure/MethodBodyDependencyTargetFirstProjector.cs
@@ -1,0 +1,161 @@
+using CodeLlmWiki.Contracts.Graph;
+using CodeLlmWiki.Contracts.Identity;
+
+namespace CodeLlmWiki.Query.ProjectStructure;
+
+public sealed class MethodBodyDependencyTargetFirstProjector : IMethodBodyDependencyTargetFirstProjector
+{
+    public IReadOnlyDictionary<EntityId, PackageMethodBodyDependencyTargetFirstCatalog> Project(MethodBodyDependencyUsageProjectionRequest request)
+    {
+        ArgumentNullException.ThrowIfNull(request);
+
+        var metadataById = BuildMetadata(request.Triples);
+        var methodById = request.Methods.ToDictionary(x => x.Id, x => x);
+        var typeById = request.Types.ToDictionary(x => x.Id, x => x);
+        var packageById = request.Packages.ToDictionary(x => x.Id, x => x);
+        var packageAttributionResolver = new ProjectScopedPackageAttributionResolver(
+            request.Projects,
+            request.Packages,
+            request.Files,
+            request.Methods);
+
+        var rows = request.Triples
+            .Where(x => x.Predicate == CorePredicates.DependsOnTypeInMethodBody)
+            .Where(x => x.Subject is EntityNode && x.Object is EntityNode)
+            .Select(x => (MethodId: ((EntityNode)x.Subject).Id, TargetTypeId: ((EntityNode)x.Object).Id))
+            .Where(x => methodById.ContainsKey(x.MethodId))
+            .Select(x => BuildUsageRow(
+                x.MethodId,
+                x.TargetTypeId,
+                methodById,
+                typeById,
+                packageById,
+                packageAttributionResolver,
+                metadataById))
+            .Where(x => x is not null)
+            .Select(x => x!)
+            .ToArray();
+
+        return rows
+            .GroupBy(x => x.PackageId)
+            .ToDictionary(
+                x => x.Key,
+                x =>
+                {
+                    var externalTypes = x
+                        .GroupBy(v => (v.ExternalTypeId, v.ExternalTypeDisplayName))
+                        .Select(target =>
+                        {
+                            var internalMethods = target
+                                .GroupBy(v => (v.InternalMethodId, v.InternalMethodDisplayName))
+                                .Select(internalMethod => new PackageMethodBodyInternalMethodUsageNode(
+                                    InternalMethodId: internalMethod.Key.InternalMethodId,
+                                    InternalMethodDisplayName: internalMethod.Key.InternalMethodDisplayName,
+                                    UsageCount: internalMethod.Sum(v => v.UsageCount)))
+                                .OrderBy(v => v.InternalMethodDisplayName, StringComparer.Ordinal)
+                                .ThenBy(v => v.InternalMethodId.Value, StringComparer.Ordinal)
+                                .ToArray();
+
+                            return new PackageMethodBodyExternalTypeUsageNode(
+                                ExternalTypeId: target.Key.ExternalTypeId,
+                                ExternalTypeDisplayName: target.Key.ExternalTypeDisplayName,
+                                UsageCount: target.Sum(v => v.UsageCount),
+                                InternalMethods: internalMethods);
+                        })
+                        .OrderBy(v => v.ExternalTypeDisplayName, StringComparer.Ordinal)
+                        .ThenBy(v => v.ExternalTypeId.Value, StringComparer.Ordinal)
+                        .ToArray();
+
+                    return new PackageMethodBodyDependencyTargetFirstCatalog(
+                        UsageCount: x.Sum(v => v.UsageCount),
+                        ExternalTypes: externalTypes);
+                });
+    }
+
+    private static UsageRow? BuildUsageRow(
+        EntityId methodId,
+        EntityId targetTypeId,
+        IReadOnlyDictionary<EntityId, MethodDeclarationNode> methodById,
+        IReadOnlyDictionary<EntityId, TypeDeclarationNode> typeById,
+        IReadOnlyDictionary<EntityId, PackageNode> packageById,
+        IProjectScopedPackageAttributionResolver packageAttributionResolver,
+        IReadOnlyDictionary<EntityId, ProjectionMetadata> metadataById)
+    {
+        if (!methodById.TryGetValue(methodId, out var method)
+            || !typeById.TryGetValue(method.DeclaringTypeId, out _)
+            || !metadataById.TryGetValue(targetTypeId, out var targetTypeMetadata))
+        {
+            return null;
+        }
+
+        var attribution = packageAttributionResolver.Resolve(methodId, targetTypeMetadata.Name);
+        if (attribution.Status != PackageAttributionStatus.Attributed
+            || attribution.PackageId is null
+            || !packageById.TryGetValue(attribution.PackageId.Value, out var package))
+        {
+            return null;
+        }
+
+        var externalTypeName = string.IsNullOrWhiteSpace(targetTypeMetadata.Name)
+            ? targetTypeId.Value
+            : targetTypeMetadata.Name;
+
+        return new UsageRow(
+            PackageId: package.Id,
+            ExternalTypeId: targetTypeId,
+            ExternalTypeDisplayName: externalTypeName,
+            InternalMethodId: method.Id,
+            InternalMethodDisplayName: method.Signature,
+            UsageCount: 1);
+    }
+
+    private static Dictionary<EntityId, ProjectionMetadata> BuildMetadata(IReadOnlyList<SemanticTriple> triples)
+    {
+        var metadataById = new Dictionary<EntityId, ProjectionMetadata>();
+
+        foreach (var triple in triples)
+        {
+            if (triple.Subject is not EntityNode subject || triple.Object is not LiteralNode literal)
+            {
+                continue;
+            }
+
+            if (!metadataById.TryGetValue(subject.Id, out var metadata))
+            {
+                metadata = new ProjectionMetadata();
+                metadataById[subject.Id] = metadata;
+            }
+
+            var value = literal.Value?.ToString() ?? string.Empty;
+            if (triple.Predicate == CorePredicates.HasName)
+            {
+                metadata.Name = value;
+            }
+            else if (triple.Predicate == CorePredicates.HasPath)
+            {
+                metadata.Path = value;
+            }
+            else if (triple.Predicate == CorePredicates.EntityType)
+            {
+                metadata.EntityType = value;
+            }
+        }
+
+        return metadataById;
+    }
+
+    private sealed class ProjectionMetadata
+    {
+        public string Name { get; set; } = string.Empty;
+        public string Path { get; set; } = string.Empty;
+        public string EntityType { get; set; } = string.Empty;
+    }
+
+    private sealed record UsageRow(
+        EntityId PackageId,
+        EntityId ExternalTypeId,
+        string ExternalTypeDisplayName,
+        EntityId InternalMethodId,
+        string InternalMethodDisplayName,
+        int UsageCount);
+}

--- a/src/CodeLlmWiki.Query/ProjectStructure/PackageMethodBodyDependencyTargetFirstCatalog.cs
+++ b/src/CodeLlmWiki.Query/ProjectStructure/PackageMethodBodyDependencyTargetFirstCatalog.cs
@@ -1,0 +1,8 @@
+namespace CodeLlmWiki.Query.ProjectStructure;
+
+public sealed record PackageMethodBodyDependencyTargetFirstCatalog(
+    int UsageCount,
+    IReadOnlyList<PackageMethodBodyExternalTypeUsageNode> ExternalTypes)
+{
+    public static PackageMethodBodyDependencyTargetFirstCatalog Empty { get; } = new(0, []);
+}

--- a/src/CodeLlmWiki.Query/ProjectStructure/PackageMethodBodyExternalTypeUsageNode.cs
+++ b/src/CodeLlmWiki.Query/ProjectStructure/PackageMethodBodyExternalTypeUsageNode.cs
@@ -1,0 +1,9 @@
+using CodeLlmWiki.Contracts.Identity;
+
+namespace CodeLlmWiki.Query.ProjectStructure;
+
+public sealed record PackageMethodBodyExternalTypeUsageNode(
+    EntityId ExternalTypeId,
+    string ExternalTypeDisplayName,
+    int UsageCount,
+    IReadOnlyList<PackageMethodBodyInternalMethodUsageNode> InternalMethods);

--- a/src/CodeLlmWiki.Query/ProjectStructure/PackageMethodBodyInternalMethodUsageNode.cs
+++ b/src/CodeLlmWiki.Query/ProjectStructure/PackageMethodBodyInternalMethodUsageNode.cs
@@ -1,0 +1,8 @@
+using CodeLlmWiki.Contracts.Identity;
+
+namespace CodeLlmWiki.Query.ProjectStructure;
+
+public sealed record PackageMethodBodyInternalMethodUsageNode(
+    EntityId InternalMethodId,
+    string InternalMethodDisplayName,
+    int UsageCount);

--- a/src/CodeLlmWiki.Query/ProjectStructure/PackageNode.cs
+++ b/src/CodeLlmWiki.Query/ProjectStructure/PackageNode.cs
@@ -13,4 +13,5 @@ public sealed record PackageNode(
     public PackageDeclarationDependencyUsageCatalog DeclarationDependencyUsage { get; init; } = PackageDeclarationDependencyUsageCatalog.Empty;
     public PackageDeclarationDependencyTargetFirstCatalog DeclarationDependencyTargetFirst { get; init; } = PackageDeclarationDependencyTargetFirstCatalog.Empty;
     public PackageMethodBodyDependencyUsageCatalog MethodBodyDependencyUsage { get; init; } = PackageMethodBodyDependencyUsageCatalog.Empty;
+    public PackageMethodBodyDependencyTargetFirstCatalog MethodBodyDependencyTargetFirst { get; init; } = PackageMethodBodyDependencyTargetFirstCatalog.Empty;
 }

--- a/src/CodeLlmWiki.Query/ProjectStructure/ProjectStructureQueryService.cs
+++ b/src/CodeLlmWiki.Query/ProjectStructure/ProjectStructureQueryService.cs
@@ -233,6 +233,15 @@ public sealed class ProjectStructureQueryService : IProjectStructureQueryService
                 declarations.Namespaces,
                 declarations.Types,
                 declarations.Methods.Declarations));
+        var methodBodyDependencyTargetFirstByPackageId = new MethodBodyDependencyTargetFirstProjector().Project(
+            new MethodBodyDependencyUsageProjectionRequest(
+                _triples,
+                projects,
+                packages,
+                files,
+                declarations.Namespaces,
+                declarations.Types,
+                declarations.Methods.Declarations));
         var declarationUnknownDependencyUsage = new UnknownDependencyUsageProjector().Project(
             new UnknownDependencyUsageProjectionRequest(
                 CorePredicates.DependsOnTypeDeclaration,
@@ -265,6 +274,9 @@ public sealed class ProjectStructureQueryService : IProjectStructureQueryService
                 MethodBodyDependencyUsage = methodBodyDependencyUsageByPackageId.TryGetValue(package.Id, out var methodBodyUsage)
                     ? methodBodyUsage
                     : PackageMethodBodyDependencyUsageCatalog.Empty,
+                MethodBodyDependencyTargetFirst = methodBodyDependencyTargetFirstByPackageId.TryGetValue(package.Id, out var methodBodyTargetFirstUsage)
+                    ? methodBodyTargetFirstUsage
+                    : PackageMethodBodyDependencyTargetFirstCatalog.Empty,
             })
             .ToArray();
         var typeDependencyRollupsByTypeId = BuildTypeDependencyRollupsByTypeId(

--- a/src/CodeLlmWiki.Wiki/ProjectStructure/ProjectStructureWikiRenderer.cs
+++ b/src/CodeLlmWiki.Wiki/ProjectStructure/ProjectStructureWikiRenderer.cs
@@ -215,7 +215,6 @@ public sealed class ProjectStructureWikiRenderer : IProjectStructureWikiRenderer
             RenderPackagePage(
                 model.Repository.Id.Value,
                 package,
-                methodById,
                 externalCallTargetsByPackageId,
                 resolver)));
         if (model.DependencyAttribution.DeclarationUnknown.UsageCount > 0
@@ -416,7 +415,6 @@ public sealed class ProjectStructureWikiRenderer : IProjectStructureWikiRenderer
     private static WikiPage RenderPackagePage(
         string repositoryId,
         PackageNode package,
-        IReadOnlyDictionary<EntityId, MethodDeclarationNode> methodById,
         IReadOnlyDictionary<EntityId, IReadOnlyList<string>> externalCallTargetsByPackageId,
         WikiPathResolver resolver)
     {
@@ -450,6 +448,8 @@ public sealed class ProjectStructureWikiRenderer : IProjectStructureWikiRenderer
                 $"| {resolver.ToMarkdownLink(membership.ProjectId, membership.ProjectName)} | `{membership.ProjectPath}` | `{declaredVersion}` | `{resolvedVersion}` |");
         }
 
+        var emittedAnchorIds = new HashSet<string>(StringComparer.Ordinal);
+
         if (package.DeclarationDependencyTargetFirst.UsageCount > 0)
         {
             sb.AppendLine();
@@ -458,7 +458,10 @@ public sealed class ProjectStructureWikiRenderer : IProjectStructureWikiRenderer
             foreach (var externalType in package.DeclarationDependencyTargetFirst.ExternalTypes)
             {
                 var anchor = WikiPathResolver.BuildPackageExternalTypeAnchor(package.CanonicalKey, externalType.ExternalTypeDisplayName);
-                sb.AppendLine($"<a id=\"{anchor}\"></a>");
+                if (emittedAnchorIds.Add(anchor))
+                {
+                    sb.AppendLine($"<a id=\"{anchor}\"></a>");
+                }
                 sb.AppendLine($"- `{externalType.ExternalTypeDisplayName}` ({externalType.UsageCount})");
 
                 foreach (var internalType in externalType.InternalTypes)
@@ -469,44 +472,50 @@ public sealed class ProjectStructureWikiRenderer : IProjectStructureWikiRenderer
             }
         }
 
-        if (package.MethodBodyDependencyUsage.UsageCount > 0)
+        if (package.MethodBodyDependencyTargetFirst.UsageCount > 0)
         {
             sb.AppendLine();
-            sb.AppendLine("## Method Body Dependency Usage");
+            sb.AppendLine("## Method Body Dependencies (External Type -> Internal Method)");
 
-            foreach (var namespaceUsage in package.MethodBodyDependencyUsage.Namespaces)
+            foreach (var externalType in package.MethodBodyDependencyTargetFirst.ExternalTypes)
             {
-                var namespaceDisplay = namespaceUsage.NamespaceId is { } namespaceId
-                    ? resolver.ToWikiLink(namespaceId, namespaceUsage.NamespaceName)
-                    : namespaceUsage.NamespaceName;
-                sb.AppendLine($"- {namespaceDisplay} ({namespaceUsage.UsageCount})");
-
-                foreach (var typeUsage in namespaceUsage.Types)
+                var anchor = WikiPathResolver.BuildPackageExternalTypeAnchor(package.CanonicalKey, externalType.ExternalTypeDisplayName);
+                if (emittedAnchorIds.Add(anchor))
                 {
-                    var typeDisplay = resolver.ToWikiLink(typeUsage.TypeId, typeUsage.TypeName);
-                    sb.AppendLine($"  - {typeDisplay} ({typeUsage.UsageCount})");
+                    sb.AppendLine($"<a id=\"{anchor}\"></a>");
+                }
 
-                    foreach (var methodUsage in typeUsage.Methods)
-                    {
-                        var methodAlias = methodById.TryGetValue(methodUsage.MethodId, out var method)
-                            ? FormatMethodLinkAlias(method)
-                            : methodUsage.MethodSignature;
-                        var methodDisplay = resolver.ToWikiLink(methodUsage.MethodId, methodAlias);
-                        sb.AppendLine($"    - {methodDisplay} ({methodUsage.UsageCount})");
-                    }
+                sb.AppendLine($"- `{externalType.ExternalTypeDisplayName}` ({externalType.UsageCount})");
+
+                foreach (var internalMethod in externalType.InternalMethods)
+                {
+                    var methodDisplay = resolver.ToWikiLink(internalMethod.InternalMethodId, internalMethod.InternalMethodDisplayName);
+                    sb.AppendLine($"  - {methodDisplay} ({internalMethod.UsageCount})");
                 }
             }
         }
 
         if (externalCallTargetsByPackageId.TryGetValue(package.Id, out var externalCallTargets) && externalCallTargets.Count > 0)
         {
-            sb.AppendLine();
-            sb.AppendLine("## External Type Anchors");
-            foreach (var externalCallTarget in externalCallTargets)
+            var additionalTargets = externalCallTargets
+                .Select(target => new
+                {
+                    Target = target,
+                    Anchor = WikiPathResolver.BuildPackageExternalTypeAnchor(package.CanonicalKey, target),
+                })
+                .Where(x => !emittedAnchorIds.Contains(x.Anchor))
+                .OrderBy(x => x.Target, StringComparer.Ordinal)
+                .ToArray();
+
+            if (additionalTargets.Length > 0)
             {
-                var anchor = WikiPathResolver.BuildPackageExternalTypeAnchor(package.CanonicalKey, externalCallTarget);
-                sb.AppendLine($"<a id=\"{anchor}\"></a>");
-                sb.AppendLine($"- `{externalCallTarget}`");
+                sb.AppendLine();
+                sb.AppendLine("## External Type Anchors");
+                foreach (var additionalTarget in additionalTargets)
+                {
+                    sb.AppendLine($"<a id=\"{additionalTarget.Anchor}\"></a>");
+                    sb.AppendLine($"- `{additionalTarget.Target}`");
+                }
             }
         }
 

--- a/tests/CodeLlmWiki.Ingestion.Tests/PackageDependencyVerticalSliceTests.cs
+++ b/tests/CodeLlmWiki.Ingestion.Tests/PackageDependencyVerticalSliceTests.cs
@@ -193,7 +193,25 @@ public sealed class PackageDependencyVerticalSliceTests
     }
 
     [Fact]
-    public async Task Render_PackagePage_IncludesMethodBodyDependencyUsageSection_WhenUsageExists()
+    public async Task Query_ProjectsTargetFirstMethodBodyDependencies_ByExternalTypeAndInternalMethod()
+    {
+        var fixture = await PackageDependencyFixture.CreateAsync();
+        var analyzer = new ProjectStructureAnalyzer(new StableIdGenerator());
+        var analysis = await analyzer.AnalyzeAsync(fixture.RepositoryPath, CancellationToken.None);
+        var model = new ProjectStructureQueryService(analysis.Triples).GetModel(analysis.RepositoryId);
+
+        var package = model.Packages.Single(x => x.Name == "Newtonsoft.Json");
+        Assert.True(package.MethodBodyDependencyTargetFirst.UsageCount > 0);
+        Assert.NotEmpty(package.MethodBodyDependencyTargetFirst.ExternalTypes);
+
+        var jToken = package.MethodBodyDependencyTargetFirst.ExternalTypes
+            .Single(x => x.ExternalTypeDisplayName == "Newtonsoft.Json.Linq.JToken");
+        Assert.Contains(jToken.InternalMethods, x => x.InternalMethodDisplayName.Contains("BodyUsageFacade", StringComparison.Ordinal));
+        Assert.DoesNotContain(jToken.InternalMethods, x => x.InternalMethodDisplayName.Contains("TokenName(", StringComparison.Ordinal));
+    }
+
+    [Fact]
+    public async Task Render_PackagePage_UsesTargetFirstMethodBodyDependencySection_WhenUsageExists()
     {
         var fixture = await PackageDependencyFixture.CreateAsync();
         var analyzer = new ProjectStructureAnalyzer(new StableIdGenerator());
@@ -204,7 +222,9 @@ public sealed class PackageDependencyVerticalSliceTests
         var packagePage = pages.Single(page => page.RelativePath.StartsWith("packages/", StringComparison.Ordinal)
             && page.Markdown.Contains("# Package: Newtonsoft.Json", StringComparison.Ordinal));
 
-        Assert.Contains("## Method Body Dependency Usage", packagePage.Markdown, StringComparison.Ordinal);
+        Assert.Contains("## Method Body Dependencies (External Type -> Internal Method)", packagePage.Markdown, StringComparison.Ordinal);
+        Assert.DoesNotContain("## Method Body Dependency Usage", packagePage.Markdown, StringComparison.Ordinal);
+        Assert.Contains("Newtonsoft.Json.Linq.JToken", packagePage.Markdown, StringComparison.Ordinal);
         Assert.Contains("BodyUsageFacade", packagePage.Markdown, StringComparison.Ordinal);
         Assert.Contains("- [[methods/", packagePage.Markdown, StringComparison.Ordinal);
         Assert.Contains("Serialize(", packagePage.Markdown, StringComparison.Ordinal);


### PR DESCRIPTION
## Summary
- add target-first method-body dependency projection grouped as external type -> internal method
- render package method-body section as target-first and remove caller-first method-body section from package pages
- preserve deterministic ordering and use unambiguous method display labels based on method signatures
- keep deep-anchor publication stable and deduplicated across package dependency sections
- add query/render regression tests for target-first method-body behavior

## Testing
- dotnet test CodeLlmWiki.slnx

Closes #75