### PR TITLE
test: determinism and publication hardening for PRD 006 (issue #78)

### DIFF
--- a/tests/CodeLlmWiki.Ingestion.Tests/PackageDependencyVerticalSliceTests.cs
+++ b/tests/CodeLlmWiki.Ingestion.Tests/PackageDependencyVerticalSliceTests.cs
@@ -382,6 +382,33 @@ public sealed class PackageDependencyVerticalSliceTests
     }
 
     [Fact]
+    public async Task Render_TargetFirstPackageDependencySections_AreDeterministicAcrossRuns()
+    {
+        var fixture = await PackageDependencyFixture.CreateAsync(
+            includeUnresolvedSignatureInNoAssets: true,
+            includePackageInheritanceInWithAssets: true);
+        var analyzer = new ProjectStructureAnalyzer(new StableIdGenerator());
+
+        var first = await analyzer.AnalyzeAsync(fixture.RepositoryPath, CancellationToken.None);
+        var firstModel = new ProjectStructureQueryService(first.Triples).GetModel(first.RepositoryId);
+        var firstPage = new ProjectStructureWikiRenderer()
+            .Render(firstModel)
+            .Single(page => page.RelativePath == "packages/Newtonsoft.Json.md");
+
+        var second = await analyzer.AnalyzeAsync(fixture.RepositoryPath, CancellationToken.None);
+        var secondModel = new ProjectStructureQueryService(second.Triples).GetModel(second.RepositoryId);
+        var secondPage = new ProjectStructureWikiRenderer()
+            .Render(secondModel)
+            .Single(page => page.RelativePath == "packages/Newtonsoft.Json.md");
+
+        Assert.Equal(firstPage.Markdown, secondPage.Markdown);
+
+        var jObjectIndex = firstPage.Markdown.IndexOf("Newtonsoft.Json.Linq.JObject", StringComparison.Ordinal);
+        var jTokenIndex = firstPage.Markdown.IndexOf("Newtonsoft.Json.Linq.JToken", StringComparison.Ordinal);
+        Assert.True(jObjectIndex >= 0 && jTokenIndex >= 0 && jObjectIndex < jTokenIndex);
+    }
+
+    [Fact]
     public async Task Render_PackagePage_RendersInheritedPackageTypes_OnlyWhenEvidenceExists()
     {
         var analyzer = new ProjectStructureAnalyzer(new StableIdGenerator());

--- a/tests/CodeLlmWiki.Ingestion.Tests/TypeSymbolVerticalSliceTests.cs
+++ b/tests/CodeLlmWiki.Ingestion.Tests/TypeSymbolVerticalSliceTests.cs
@@ -153,6 +153,29 @@ public sealed class TypeSymbolVerticalSliceTests
             obj.Id == sharedInterface.Id);
     }
 
+    [Fact]
+    public async Task Render_TypeRelationshipSections_AreDeterministicAcrossRuns()
+    {
+        var fixture = await TypeFixture.CreateAsync();
+        var analyzer = new ProjectStructureAnalyzer(new StableIdGenerator());
+
+        var first = await analyzer.AnalyzeAsync(fixture.RepositoryPath, CancellationToken.None);
+        var firstModel = new ProjectStructureQueryService(first.Triples).GetModel(first.RepositoryId);
+        var firstPages = new ProjectStructureWikiRenderer().Render(firstModel);
+
+        var second = await analyzer.AnalyzeAsync(fixture.RepositoryPath, CancellationToken.None);
+        var secondModel = new ProjectStructureQueryService(second.Triples).GetModel(second.RepositoryId);
+        var secondPages = new ProjectStructureWikiRenderer().Render(secondModel);
+
+        var firstBasePage = firstPages.Single(x => x.RelativePath == "types/Acme/Workers/BaseWorker.md");
+        var secondBasePage = secondPages.Single(x => x.RelativePath == "types/Acme/Workers/BaseWorker.md");
+        Assert.Equal(firstBasePage.Markdown, secondBasePage.Markdown);
+
+        var derivedIndex = firstBasePage.Markdown.IndexOf("DerivedWorker", StringComparison.Ordinal);
+        var innerIndex = firstBasePage.Markdown.IndexOf("Inner", StringComparison.Ordinal);
+        Assert.True(derivedIndex >= 0 && innerIndex >= 0 && derivedIndex < innerIndex);
+    }
+
     private sealed class TypeFixture
     {
         private TypeFixture(string repositoryPath)


### PR DESCRIPTION
## Summary
- add deterministic run-to-run assertions for target-first package dependency sections
- add deterministic ordering assertions for new reverse type relationship sections
- keep scope constrained to PRD 006 navigation surfaces (no query/MCP expansion)

## Testing
- dotnet test CodeLlmWiki.slnx

Closes #78