### PR TITLE
PRD 007 #088: Structural rollups and scope filters

### DIFF
--- a/src/CodeLlmWiki.Query/ProjectStructure/FileStructuralMetricRollupNode.cs
+++ b/src/CodeLlmWiki.Query/ProjectStructure/FileStructuralMetricRollupNode.cs
@@ -1,0 +1,10 @@
+using CodeLlmWiki.Contracts.Identity;
+
+namespace CodeLlmWiki.Query.ProjectStructure;
+
+public sealed record FileStructuralMetricRollupNode(
+    EntityId FileId,
+    string Name,
+    string Path,
+    StructuralMetricCodeKind CodeKind,
+    StructuralMetricScopeRollup Rollup);

--- a/src/CodeLlmWiki.Query/ProjectStructure/IProjectStructureQueryService.cs
+++ b/src/CodeLlmWiki.Query/ProjectStructure/IProjectStructureQueryService.cs
@@ -5,4 +5,5 @@ namespace CodeLlmWiki.Query.ProjectStructure;
 public interface IProjectStructureQueryService
 {
     ProjectStructureWikiModel GetModel(EntityId repositoryId);
+    ProjectStructureWikiModel GetModel(EntityId repositoryId, ProjectStructureQueryOptions options);
 }

--- a/src/CodeLlmWiki.Query/ProjectStructure/IStructuralMetricRollupProjector.cs
+++ b/src/CodeLlmWiki.Query/ProjectStructure/IStructuralMetricRollupProjector.cs
@@ -1,0 +1,6 @@
+namespace CodeLlmWiki.Query.ProjectStructure;
+
+public interface IStructuralMetricRollupProjector
+{
+    StructuralMetricRollupCatalog Project(StructuralMetricRollupProjectionRequest request);
+}

--- a/src/CodeLlmWiki.Query/ProjectStructure/NamespaceStructuralMetricRollupNode.cs
+++ b/src/CodeLlmWiki.Query/ProjectStructure/NamespaceStructuralMetricRollupNode.cs
@@ -1,0 +1,12 @@
+using CodeLlmWiki.Contracts.Identity;
+
+namespace CodeLlmWiki.Query.ProjectStructure;
+
+public sealed record NamespaceStructuralMetricRollupNode(
+    EntityId NamespaceId,
+    string Name,
+    string Path,
+    bool IsGlobalNamespace,
+    EntityId? ParentNamespaceId,
+    StructuralMetricScopeRollup Direct,
+    StructuralMetricScopeRollup Recursive);

--- a/src/CodeLlmWiki.Query/ProjectStructure/ProjectStructuralMetricRollupNode.cs
+++ b/src/CodeLlmWiki.Query/ProjectStructure/ProjectStructuralMetricRollupNode.cs
@@ -1,0 +1,10 @@
+using CodeLlmWiki.Contracts.Identity;
+
+namespace CodeLlmWiki.Query.ProjectStructure;
+
+public sealed record ProjectStructuralMetricRollupNode(
+    EntityId ProjectId,
+    string Name,
+    string Path,
+    StructuralMetricCodeKind CodeKind,
+    StructuralMetricScopeRollup Rollup);

--- a/src/CodeLlmWiki.Query/ProjectStructure/ProjectStructureQueryOptions.cs
+++ b/src/CodeLlmWiki.Query/ProjectStructure/ProjectStructureQueryOptions.cs
@@ -1,0 +1,8 @@
+namespace CodeLlmWiki.Query.ProjectStructure;
+
+public sealed record ProjectStructureQueryOptions
+{
+    public static ProjectStructureQueryOptions Default { get; } = new();
+
+    public StructuralMetricScopeFilter MetricScopeFilter { get; init; } = StructuralMetricScopeFilter.ProductionDefault;
+}

--- a/src/CodeLlmWiki.Query/ProjectStructure/ProjectStructureQueryService.cs
+++ b/src/CodeLlmWiki.Query/ProjectStructure/ProjectStructureQueryService.cs
@@ -14,6 +14,11 @@ public sealed class ProjectStructureQueryService : IProjectStructureQueryService
 
     public ProjectStructureWikiModel GetModel(EntityId repositoryId)
     {
+        return GetModel(repositoryId, ProjectStructureQueryOptions.Default);
+    }
+
+    public ProjectStructureWikiModel GetModel(EntityId repositoryId, ProjectStructureQueryOptions options)
+    {
         var metadataById = BuildEntityMetadata(_triples);
         var contains = BuildContainsEdges(_triples);
         var packageReferences = BuildPackageReferences(_triples, metadataById);
@@ -301,6 +306,14 @@ public sealed class ProjectStructureQueryService : IProjectStructureQueryService
             repoMeta.Path,
             repoMeta.HeadBranch,
             repoMeta.MainlineBranch);
+        var structuralMetrics = new StructuralMetricRollupProjector().Project(
+            new StructuralMetricRollupProjectionRequest(
+                repositoryId,
+                _triples,
+                projects,
+                files,
+                declarations,
+                options.MetricScopeFilter));
 
         return new ProjectStructureWikiModel(repository, solutions, projects, packages, files, submodules)
         {
@@ -308,6 +321,7 @@ public sealed class ProjectStructureQueryService : IProjectStructureQueryService
             DependencyAttribution = new DependencyAttributionCatalog(
                 declarationUnknownDependencyUsage,
                 methodBodyUnknownDependencyUsage),
+            StructuralMetrics = structuralMetrics,
         };
     }
 

--- a/src/CodeLlmWiki.Query/ProjectStructure/ProjectStructureWikiModel.cs
+++ b/src/CodeLlmWiki.Query/ProjectStructure/ProjectStructureWikiModel.cs
@@ -10,4 +10,5 @@ public sealed record ProjectStructureWikiModel(
 {
     public DeclarationCatalog Declarations { get; init; } = DeclarationCatalog.Empty;
     public DependencyAttributionCatalog DependencyAttribution { get; init; } = DependencyAttributionCatalog.Empty;
+    public StructuralMetricRollupCatalog StructuralMetrics { get; init; } = StructuralMetricRollupCatalog.Empty;
 }

--- a/src/CodeLlmWiki.Query/ProjectStructure/RepositoryStructuralMetricRollupNode.cs
+++ b/src/CodeLlmWiki.Query/ProjectStructure/RepositoryStructuralMetricRollupNode.cs
@@ -1,0 +1,7 @@
+using CodeLlmWiki.Contracts.Identity;
+
+namespace CodeLlmWiki.Query.ProjectStructure;
+
+public sealed record RepositoryStructuralMetricRollupNode(
+    EntityId RepositoryId,
+    StructuralMetricScopeRollup Rollup);

--- a/src/CodeLlmWiki.Query/ProjectStructure/StructuralMetricCodeKind.cs
+++ b/src/CodeLlmWiki.Query/ProjectStructure/StructuralMetricCodeKind.cs
@@ -1,0 +1,8 @@
+namespace CodeLlmWiki.Query.ProjectStructure;
+
+public enum StructuralMetricCodeKind
+{
+    Production = 0,
+    Test = 1,
+    Generated = 2,
+}

--- a/src/CodeLlmWiki.Query/ProjectStructure/StructuralMetricCoverage.cs
+++ b/src/CodeLlmWiki.Query/ProjectStructure/StructuralMetricCoverage.cs
@@ -1,0 +1,8 @@
+namespace CodeLlmWiki.Query.ProjectStructure;
+
+public sealed record StructuralMetricCoverage(
+    int TotalMethods,
+    int AnalyzableMethods,
+    int NonAnalyzableMethods,
+    int TotalTypes,
+    int TypesWithCbo);

--- a/src/CodeLlmWiki.Query/ProjectStructure/StructuralMetricRollupCatalog.cs
+++ b/src/CodeLlmWiki.Query/ProjectStructure/StructuralMetricRollupCatalog.cs
@@ -1,0 +1,22 @@
+namespace CodeLlmWiki.Query.ProjectStructure;
+
+public sealed record StructuralMetricRollupCatalog(
+    RepositoryStructuralMetricRollupNode Repository,
+    IReadOnlyList<ProjectStructuralMetricRollupNode> Projects,
+    IReadOnlyList<NamespaceStructuralMetricRollupNode> Namespaces,
+    IReadOnlyList<FileStructuralMetricRollupNode> Files,
+    StructuralMetricScopeFilter EffectiveFilter)
+{
+    public static StructuralMetricRollupCatalog Empty { get; } = new(
+        new RepositoryStructuralMetricRollupNode(
+            default,
+            new StructuralMetricScopeRollup(
+                new StructuralMetricCoverage(0, 0, 0, 0, 0),
+                new StructuralMetricStatistics(0, 0d, 0d, 0d, 0d, 0, 0d, 0d, 0d),
+                StructuralMetricSeverity.None,
+                IncludedInRanking: false)),
+        [],
+        [],
+        [],
+        StructuralMetricScopeFilter.ProductionDefault);
+}

--- a/src/CodeLlmWiki.Query/ProjectStructure/StructuralMetricRollupProjectionRequest.cs
+++ b/src/CodeLlmWiki.Query/ProjectStructure/StructuralMetricRollupProjectionRequest.cs
@@ -1,0 +1,12 @@
+using CodeLlmWiki.Contracts.Graph;
+using CodeLlmWiki.Contracts.Identity;
+
+namespace CodeLlmWiki.Query.ProjectStructure;
+
+public sealed record StructuralMetricRollupProjectionRequest(
+    EntityId RepositoryId,
+    IReadOnlyList<SemanticTriple> Triples,
+    IReadOnlyList<ProjectNode> Projects,
+    IReadOnlyList<FileNode> Files,
+    DeclarationCatalog Declarations,
+    StructuralMetricScopeFilter ScopeFilter);

--- a/src/CodeLlmWiki.Query/ProjectStructure/StructuralMetricRollupProjector.cs
+++ b/src/CodeLlmWiki.Query/ProjectStructure/StructuralMetricRollupProjector.cs
@@ -1,0 +1,634 @@
+using System.Globalization;
+using CodeLlmWiki.Contracts.Graph;
+using CodeLlmWiki.Contracts.Identity;
+
+namespace CodeLlmWiki.Query.ProjectStructure;
+
+public sealed class StructuralMetricRollupProjector : IStructuralMetricRollupProjector
+{
+    public StructuralMetricRollupCatalog Project(StructuralMetricRollupProjectionRequest request)
+    {
+        var methodMetricsById = BuildMethodMetricsById(request.Triples);
+        var typeMetricsById = BuildTypeMetricsById(request.Triples);
+        var methodsById = request.Declarations.Methods.Declarations.ToDictionary(x => x.Id, x => x);
+        var typesById = request.Declarations.Types.ToDictionary(x => x.Id, x => x);
+        var filesById = request.Files.ToDictionary(x => x.Id, x => x);
+
+        var fileProjectMap = BuildFileProjectMap(request.Files, request.Projects);
+        var projectCodeKinds = request.Projects.ToDictionary(
+            project => project.Id,
+            project => ClassifyProjectCodeKind(project.Name, project.Path));
+        var fileCodeKinds = request.Files.ToDictionary(
+            file => file.Id,
+            file =>
+            {
+                fileProjectMap.TryGetValue(file.Id, out var projectId);
+                return ClassifyFileCodeKind(
+                    file.Path,
+                    projectId is { } mappedProjectId && projectCodeKinds.TryGetValue(mappedProjectId, out var projectKind)
+                        ? projectKind
+                        : StructuralMetricCodeKind.Production);
+            });
+
+        var methodContexts = BuildMethodContexts(methodsById, typesById, filesById, fileProjectMap, fileCodeKinds, methodMetricsById);
+        var typeContexts = BuildTypeContexts(typesById, filesById, fileProjectMap, fileCodeKinds, typeMetricsById);
+
+        var methodsByFileId = methodContexts
+            .SelectMany(method => method.DeclarationFileIds.Select(fileId => (fileId, method)))
+            .GroupBy(x => x.fileId)
+            .ToDictionary(
+                x => x.Key,
+                x => (IReadOnlyList<MethodMetricContext>)x
+                    .Select(v => v.method)
+                    .DistinctBy(v => v.Id)
+                    .ToArray());
+        var typesByFileId = typeContexts
+            .SelectMany(type => type.DeclarationFileIds.Select(fileId => (fileId, type)))
+            .GroupBy(x => x.fileId)
+            .ToDictionary(
+                x => x.Key,
+                x => (IReadOnlyList<TypeMetricContext>)x
+                    .Select(v => v.type)
+                    .DistinctBy(v => v.Id)
+                    .ToArray());
+        var methodsByProjectId = methodContexts
+            .Where(x => x.ProjectId is not null)
+            .GroupBy(x => x.ProjectId!.Value)
+            .ToDictionary(
+                x => x.Key,
+                x => (IReadOnlyList<MethodMetricContext>)x
+                    .DistinctBy(v => v.Id)
+                    .ToArray());
+        var typesByProjectId = typeContexts
+            .Where(x => x.ProjectId is not null)
+            .GroupBy(x => x.ProjectId!.Value)
+            .ToDictionary(
+                x => x.Key,
+                x => (IReadOnlyList<TypeMetricContext>)x
+                    .DistinctBy(v => v.Id)
+                    .ToArray());
+        var methodsByNamespaceId = methodContexts
+            .Where(x => x.NamespaceId is not null)
+            .GroupBy(x => x.NamespaceId!.Value)
+            .ToDictionary(
+                x => x.Key,
+                x => (IReadOnlyList<MethodMetricContext>)x
+                    .DistinctBy(v => v.Id)
+                    .ToArray());
+        var typesByNamespaceId = typeContexts
+            .Where(x => x.NamespaceId is not null)
+            .GroupBy(x => x.NamespaceId!.Value)
+            .ToDictionary(
+                x => x.Key,
+                x => (IReadOnlyList<TypeMetricContext>)x
+                    .DistinctBy(v => v.Id)
+                    .ToArray());
+
+        var namespaceDescendants = BuildNamespaceDescendants(request.Declarations.Namespaces);
+        var files = request.Files
+            .OrderBy(x => x.Path, StringComparer.Ordinal)
+            .ThenBy(x => x.Id.Value, StringComparer.Ordinal)
+            .Select(file =>
+            {
+                var methods = methodsByFileId.TryGetValue(file.Id, out var fileMethods)
+                    ? fileMethods
+                    : [];
+                var types = typesByFileId.TryGetValue(file.Id, out var fileTypes)
+                    ? fileTypes
+                    : [];
+                var rawRollup = BuildRawRollup(methods, types);
+                var included = IsIncludedInRanking(rawRollup, methods, types, request.ScopeFilter);
+                var rollup = rawRollup with { IncludedInRanking = included };
+
+                return new FileStructuralMetricRollupNode(
+                    file.Id,
+                    file.Name,
+                    file.Path,
+                    fileCodeKinds[file.Id],
+                    rollup);
+            })
+            .ToArray();
+
+        var projects = request.Projects
+            .OrderBy(x => x.Path, StringComparer.Ordinal)
+            .ThenBy(x => x.Id.Value, StringComparer.Ordinal)
+            .Select(project =>
+            {
+                var methods = methodsByProjectId.TryGetValue(project.Id, out var projectMethods)
+                    ? projectMethods
+                    : [];
+                var types = typesByProjectId.TryGetValue(project.Id, out var projectTypes)
+                    ? projectTypes
+                    : [];
+                var rawRollup = BuildRawRollup(methods, types);
+                var included = IsIncludedInRanking(rawRollup, methods, types, request.ScopeFilter);
+                var rollup = rawRollup with { IncludedInRanking = included };
+
+                return new ProjectStructuralMetricRollupNode(
+                    project.Id,
+                    project.Name,
+                    project.Path,
+                    projectCodeKinds[project.Id],
+                    rollup);
+            })
+            .ToArray();
+
+        var namespaces = request.Declarations.Namespaces
+            .OrderBy(x => x.Path, StringComparer.Ordinal)
+            .ThenBy(x => x.Id.Value, StringComparer.Ordinal)
+            .Select(namespaceNode =>
+            {
+                var directMethods = methodsByNamespaceId.TryGetValue(namespaceNode.Id, out var directMethodSet)
+                    ? directMethodSet
+                    : [];
+                var directTypes = typesByNamespaceId.TryGetValue(namespaceNode.Id, out var directTypeSet)
+                    ? directTypeSet
+                    : [];
+                var directRaw = BuildRawRollup(directMethods, directTypes);
+                var directIncluded = IsIncludedInRanking(directRaw, directMethods, directTypes, request.ScopeFilter);
+                var direct = directRaw with { IncludedInRanking = directIncluded };
+
+                var recursiveMethodSet = namespaceDescendants[namespaceNode.Id]
+                    .SelectMany(descendantId => methodsByNamespaceId.TryGetValue(descendantId, out var recursiveMethods) ? recursiveMethods : [])
+                    .DistinctBy(x => x.Id)
+                    .ToArray();
+                var recursiveTypeSet = namespaceDescendants[namespaceNode.Id]
+                    .SelectMany(descendantId => typesByNamespaceId.TryGetValue(descendantId, out var recursiveTypes) ? recursiveTypes : [])
+                    .DistinctBy(x => x.Id)
+                    .ToArray();
+                var recursiveRaw = BuildRawRollup(recursiveMethodSet, recursiveTypeSet);
+                var recursiveIncluded = IsIncludedInRanking(recursiveRaw, recursiveMethodSet, recursiveTypeSet, request.ScopeFilter);
+                var recursive = recursiveRaw with { IncludedInRanking = recursiveIncluded };
+
+                return new NamespaceStructuralMetricRollupNode(
+                    namespaceNode.Id,
+                    namespaceNode.Name.Equals("<global>", StringComparison.Ordinal) ? "(global)" : namespaceNode.Name,
+                    namespaceNode.Path,
+                    namespaceNode.Name.Equals("<global>", StringComparison.Ordinal),
+                    namespaceNode.ParentNamespaceId,
+                    direct,
+                    recursive);
+            })
+            .ToArray();
+
+        var repositoryRaw = BuildRawRollup(methodContexts, typeContexts);
+        var repositoryIncluded = IsIncludedInRanking(repositoryRaw, methodContexts, typeContexts, request.ScopeFilter);
+        var repository = new RepositoryStructuralMetricRollupNode(
+            request.RepositoryId,
+            repositoryRaw with { IncludedInRanking = repositoryIncluded });
+
+        return new StructuralMetricRollupCatalog(repository, projects, namespaces, files, request.ScopeFilter);
+    }
+
+    private static bool IsIncludedInRanking(
+        StructuralMetricScopeRollup rollup,
+        IReadOnlyList<MethodMetricContext> methods,
+        IReadOnlyList<TypeMetricContext> types,
+        StructuralMetricScopeFilter filter)
+    {
+        if (filter.ExcludeInsufficientDataFromRanking && rollup.Severity == StructuralMetricSeverity.None)
+        {
+            return false;
+        }
+
+        var eligibleMethods = methods.Count(method => method.IsAnalyzable && filter.IncludesCodeKind(method.CodeKind));
+        if (eligibleMethods > 0)
+        {
+            return true;
+        }
+
+        var eligibleTypes = types.Count(type => type.HasCbo && filter.IncludesCodeKind(type.CodeKind));
+        return eligibleTypes > 0;
+    }
+
+    private static StructuralMetricScopeRollup BuildRawRollup(
+        IReadOnlyList<MethodMetricContext> methods,
+        IReadOnlyList<TypeMetricContext> types)
+    {
+        var totalMethods = methods.Count;
+        var analyzableMethods = methods.Count(x => x.IsAnalyzable);
+        var nonAnalyzableMethods = totalMethods - analyzableMethods;
+
+        var methodMetricCount = methods.Count(x => x.IsAnalyzable && x.CyclomaticComplexity.HasValue);
+        var avgCyclomatic = methodMetricCount == 0
+            ? 0d
+            : methods.Where(x => x.IsAnalyzable && x.CyclomaticComplexity.HasValue).Average(x => x.CyclomaticComplexity!.Value);
+        var avgCognitive = methodMetricCount == 0
+            ? 0d
+            : methods.Where(x => x.IsAnalyzable && x.CognitiveComplexity.HasValue).Average(x => x.CognitiveComplexity!.Value);
+        var avgHalsteadVolume = methodMetricCount == 0
+            ? 0d
+            : methods.Where(x => x.IsAnalyzable && x.HalsteadVolume.HasValue).Average(x => x.HalsteadVolume!.Value);
+        var avgMaintainability = methodMetricCount == 0
+            ? 0d
+            : methods.Where(x => x.IsAnalyzable && x.MaintainabilityIndex.HasValue).Average(x => x.MaintainabilityIndex!.Value);
+
+        var totalTypes = types.Count;
+        var typeMetricCount = types.Count(x => x.HasCbo);
+        var avgCboDeclaration = typeMetricCount == 0
+            ? 0d
+            : types.Where(x => x.HasCbo).Average(x => x.CboDeclaration);
+        var avgCboMethodBody = typeMetricCount == 0
+            ? 0d
+            : types.Where(x => x.HasCbo).Average(x => x.CboMethodBody);
+        var avgCboTotal = typeMetricCount == 0
+            ? 0d
+            : types.Where(x => x.HasCbo).Average(x => x.CboTotal);
+
+        var severity = analyzableMethods == 0
+            ? StructuralMetricSeverity.None
+            : StructuralMetricSeverity.Unknown;
+
+        return new StructuralMetricScopeRollup(
+            new StructuralMetricCoverage(
+                TotalMethods: totalMethods,
+                AnalyzableMethods: analyzableMethods,
+                NonAnalyzableMethods: nonAnalyzableMethods,
+                TotalTypes: totalTypes,
+                TypesWithCbo: typeMetricCount),
+            new StructuralMetricStatistics(
+                MethodMetricCount: methodMetricCount,
+                AverageCyclomaticComplexity: avgCyclomatic,
+                AverageCognitiveComplexity: avgCognitive,
+                AverageHalsteadVolume: avgHalsteadVolume,
+                AverageMaintainabilityIndex: avgMaintainability,
+                TypeMetricCount: typeMetricCount,
+                AverageCboDeclaration: avgCboDeclaration,
+                AverageCboMethodBody: avgCboMethodBody,
+                AverageCboTotal: avgCboTotal),
+            severity,
+            IncludedInRanking: false);
+    }
+
+    private static IReadOnlyDictionary<EntityId, IReadOnlySet<EntityId>> BuildNamespaceDescendants(
+        IReadOnlyList<NamespaceDeclarationNode> namespaces)
+    {
+        var childrenByParent = namespaces.ToDictionary(
+            x => x.Id,
+            x => (IReadOnlyList<EntityId>)x.ChildNamespaceIds
+                .OrderBy(id => id.Value, StringComparer.Ordinal)
+                .ToArray());
+
+        var descendantsByNamespace = new Dictionary<EntityId, IReadOnlySet<EntityId>>();
+        foreach (var namespaceNode in namespaces.OrderBy(x => x.Path, StringComparer.Ordinal).ThenBy(x => x.Id.Value, StringComparer.Ordinal))
+        {
+            descendantsByNamespace[namespaceNode.Id] = CollectDescendants(namespaceNode.Id, childrenByParent);
+        }
+
+        return descendantsByNamespace;
+    }
+
+    private static IReadOnlySet<EntityId> CollectDescendants(
+        EntityId root,
+        IReadOnlyDictionary<EntityId, IReadOnlyList<EntityId>> childrenByParent)
+    {
+        var collected = new HashSet<EntityId> { root };
+        var pending = new Queue<EntityId>();
+        pending.Enqueue(root);
+
+        while (pending.Count > 0)
+        {
+            var next = pending.Dequeue();
+            if (!childrenByParent.TryGetValue(next, out var children))
+            {
+                continue;
+            }
+
+            foreach (var child in children)
+            {
+                if (!collected.Add(child))
+                {
+                    continue;
+                }
+
+                pending.Enqueue(child);
+            }
+        }
+
+        return collected;
+    }
+
+    private static IReadOnlyDictionary<EntityId, EntityId> BuildFileProjectMap(
+        IReadOnlyList<FileNode> files,
+        IReadOnlyList<ProjectNode> projects)
+    {
+        var projectDirectories = projects
+            .Select(project => new
+            {
+                project.Id,
+                Directory = NormalizePath(Path.GetDirectoryName(project.Path)?.Replace('\\', '/') ?? string.Empty),
+            })
+            .OrderByDescending(x => x.Directory.Length)
+            .ThenBy(x => x.Directory, StringComparer.Ordinal)
+            .ThenBy(x => x.Id.Value, StringComparer.Ordinal)
+            .ToArray();
+
+        var fileProjectMap = new Dictionary<EntityId, EntityId>();
+        foreach (var file in files)
+        {
+            var normalizedPath = NormalizePath(file.Path);
+            foreach (var projectDirectory in projectDirectories)
+            {
+                if (PathMatchesProjectDirectory(normalizedPath, projectDirectory.Directory))
+                {
+                    fileProjectMap[file.Id] = projectDirectory.Id;
+                    break;
+                }
+            }
+        }
+
+        return fileProjectMap;
+    }
+
+    private static bool PathMatchesProjectDirectory(string filePath, string projectDirectory)
+    {
+        if (string.IsNullOrEmpty(projectDirectory))
+        {
+            return true;
+        }
+
+        if (filePath.Equals(projectDirectory, StringComparison.OrdinalIgnoreCase))
+        {
+            return true;
+        }
+
+        return filePath.StartsWith(projectDirectory + "/", StringComparison.OrdinalIgnoreCase);
+    }
+
+    private static string NormalizePath(string path)
+    {
+        return path.Trim().TrimStart('.').Trim('/').Replace('\\', '/');
+    }
+
+    private static StructuralMetricCodeKind ClassifyProjectCodeKind(string projectName, string projectPath)
+    {
+        var loweredName = projectName.ToLowerInvariant();
+        var loweredPath = projectPath.Replace('\\', '/').ToLowerInvariant();
+        var isTest = loweredName.Contains("test", StringComparison.Ordinal)
+                     || loweredPath.Contains("/test/", StringComparison.Ordinal)
+                     || loweredPath.Contains("/tests/", StringComparison.Ordinal)
+                     || loweredPath.Contains(".test", StringComparison.Ordinal)
+                     || loweredPath.Contains(".tests", StringComparison.Ordinal);
+
+        return isTest
+            ? StructuralMetricCodeKind.Test
+            : StructuralMetricCodeKind.Production;
+    }
+
+    private static StructuralMetricCodeKind ClassifyFileCodeKind(string filePath, StructuralMetricCodeKind projectCodeKind)
+    {
+        var normalizedPath = filePath.Replace('\\', '/');
+        var loweredPath = normalizedPath.ToLowerInvariant();
+
+        var isGenerated = loweredPath.EndsWith(".g.cs", StringComparison.Ordinal)
+                          || loweredPath.EndsWith(".g.i.cs", StringComparison.Ordinal)
+                          || loweredPath.EndsWith(".generated.cs", StringComparison.Ordinal)
+                          || loweredPath.EndsWith(".designer.cs", StringComparison.Ordinal)
+                          || loweredPath.Contains("/generated/", StringComparison.Ordinal)
+                          || loweredPath.Contains("/obj/", StringComparison.Ordinal);
+        if (isGenerated)
+        {
+            return StructuralMetricCodeKind.Generated;
+        }
+
+        var isTestFile = loweredPath.Contains("/test/", StringComparison.Ordinal)
+                         || loweredPath.Contains("/tests/", StringComparison.Ordinal)
+                         || loweredPath.EndsWith("tests.cs", StringComparison.Ordinal);
+        if (isTestFile || projectCodeKind == StructuralMetricCodeKind.Test)
+        {
+            return StructuralMetricCodeKind.Test;
+        }
+
+        return StructuralMetricCodeKind.Production;
+    }
+
+    private static IReadOnlyList<MethodMetricContext> BuildMethodContexts(
+        IReadOnlyDictionary<EntityId, MethodDeclarationNode> methodsById,
+        IReadOnlyDictionary<EntityId, TypeDeclarationNode> typesById,
+        IReadOnlyDictionary<EntityId, FileNode> filesById,
+        IReadOnlyDictionary<EntityId, EntityId> fileProjectMap,
+        IReadOnlyDictionary<EntityId, StructuralMetricCodeKind> fileCodeKinds,
+        IReadOnlyDictionary<EntityId, MethodMetricSnapshot> methodMetricsById)
+    {
+        var contexts = new List<MethodMetricContext>(methodsById.Count);
+        foreach (var method in methodsById.Values)
+        {
+            if (!typesById.TryGetValue(method.DeclaringTypeId, out var declaringType))
+            {
+                continue;
+            }
+
+            var declarationFileIds = method.DeclarationFileIds
+                .Where(filesById.ContainsKey)
+                .Distinct()
+                .OrderBy(id => filesById[id].Path, StringComparer.Ordinal)
+                .ThenBy(id => id.Value, StringComparer.Ordinal)
+                .ToArray();
+            if (declarationFileIds.Length == 0)
+            {
+                continue;
+            }
+
+            var primaryFileId = declarationFileIds[0];
+            var projectId = fileProjectMap.TryGetValue(primaryFileId, out var mappedProjectId)
+                ? mappedProjectId
+                : (EntityId?)null;
+            var codeKind = fileCodeKinds.TryGetValue(primaryFileId, out var mappedCodeKind)
+                ? mappedCodeKind
+                : StructuralMetricCodeKind.Production;
+            var metrics = methodMetricsById.TryGetValue(method.Id, out var methodMetricSnapshot)
+                ? methodMetricSnapshot
+                : MethodMetricSnapshot.Empty;
+
+            contexts.Add(new MethodMetricContext(
+                method.Id,
+                declarationFileIds,
+                declaringType.NamespaceId,
+                projectId,
+                codeKind,
+                metrics.CoverageStatus.Equals("analyzable", StringComparison.OrdinalIgnoreCase),
+                metrics.CyclomaticComplexity,
+                metrics.CognitiveComplexity,
+                metrics.HalsteadVolume,
+                metrics.MaintainabilityIndex));
+        }
+
+        return contexts;
+    }
+
+    private static IReadOnlyList<TypeMetricContext> BuildTypeContexts(
+        IReadOnlyDictionary<EntityId, TypeDeclarationNode> typesById,
+        IReadOnlyDictionary<EntityId, FileNode> filesById,
+        IReadOnlyDictionary<EntityId, EntityId> fileProjectMap,
+        IReadOnlyDictionary<EntityId, StructuralMetricCodeKind> fileCodeKinds,
+        IReadOnlyDictionary<EntityId, TypeMetricSnapshot> typeMetricsById)
+    {
+        var contexts = new List<TypeMetricContext>(typesById.Count);
+        foreach (var type in typesById.Values)
+        {
+            var declarationFileIds = type.DeclarationFileIds
+                .Where(filesById.ContainsKey)
+                .Distinct()
+                .OrderBy(id => filesById[id].Path, StringComparer.Ordinal)
+                .ThenBy(id => id.Value, StringComparer.Ordinal)
+                .ToArray();
+            if (declarationFileIds.Length == 0)
+            {
+                continue;
+            }
+
+            var primaryFileId = declarationFileIds[0];
+            var projectId = fileProjectMap.TryGetValue(primaryFileId, out var mappedProjectId)
+                ? mappedProjectId
+                : (EntityId?)null;
+            var codeKind = fileCodeKinds.TryGetValue(primaryFileId, out var mappedCodeKind)
+                ? mappedCodeKind
+                : StructuralMetricCodeKind.Production;
+
+            var metrics = typeMetricsById.TryGetValue(type.Id, out var snapshot)
+                ? snapshot
+                : TypeMetricSnapshot.Empty;
+            contexts.Add(new TypeMetricContext(
+                type.Id,
+                declarationFileIds,
+                type.NamespaceId,
+                projectId,
+                codeKind,
+                metrics.HasCbo,
+                metrics.CboDeclaration,
+                metrics.CboMethodBody,
+                metrics.CboTotal));
+        }
+
+        return contexts;
+    }
+
+    private static IReadOnlyDictionary<EntityId, MethodMetricSnapshot> BuildMethodMetricsById(IReadOnlyList<SemanticTriple> triples)
+    {
+        var coverageByMethodId = triples
+            .Where(triple => triple.Predicate == CorePredicates.MetricCoverageStatus)
+            .Where(triple => triple.Subject is EntityNode && triple.Object is LiteralNode)
+            .ToDictionary(
+                triple => ((EntityNode)triple.Subject).Id,
+                triple => (((LiteralNode)triple.Object).Value?.ToString() ?? string.Empty),
+                EqualityComparer<EntityId>.Default);
+        var cyclomaticByMethodId = BuildIntMetricMap(triples, CorePredicates.CyclomaticComplexity);
+        var cognitiveByMethodId = BuildIntMetricMap(triples, CorePredicates.CognitiveComplexity);
+        var halsteadByMethodId = BuildDoubleMetricMap(triples, CorePredicates.HalsteadVolume);
+        var maintainabilityByMethodId = BuildDoubleMetricMap(triples, CorePredicates.MaintainabilityIndex);
+
+        var methodIds = coverageByMethodId.Keys
+            .Concat(cyclomaticByMethodId.Keys)
+            .Concat(cognitiveByMethodId.Keys)
+            .Concat(halsteadByMethodId.Keys)
+            .Concat(maintainabilityByMethodId.Keys)
+            .Distinct()
+            .OrderBy(id => id.Value, StringComparer.Ordinal)
+            .ToArray();
+
+        return methodIds.ToDictionary(
+            methodId => methodId,
+            methodId => new MethodMetricSnapshot(
+                coverageByMethodId.TryGetValue(methodId, out var coverage) ? coverage : string.Empty,
+                cyclomaticByMethodId.TryGetValue(methodId, out var cyclomatic) ? cyclomatic : null,
+                cognitiveByMethodId.TryGetValue(methodId, out var cognitive) ? cognitive : null,
+                halsteadByMethodId.TryGetValue(methodId, out var halstead) ? halstead : null,
+                maintainabilityByMethodId.TryGetValue(methodId, out var maintainability) ? maintainability : null));
+    }
+
+    private static IReadOnlyDictionary<EntityId, TypeMetricSnapshot> BuildTypeMetricsById(IReadOnlyList<SemanticTriple> triples)
+    {
+        var cboDeclaration = BuildIntMetricMap(triples, CorePredicates.CboDeclaration);
+        var cboMethodBody = BuildIntMetricMap(triples, CorePredicates.CboMethodBody);
+        var cboTotal = BuildIntMetricMap(triples, CorePredicates.CboTotal);
+
+        var typeIds = cboDeclaration.Keys
+            .Concat(cboMethodBody.Keys)
+            .Concat(cboTotal.Keys)
+            .Distinct()
+            .OrderBy(id => id.Value, StringComparer.Ordinal)
+            .ToArray();
+
+        return typeIds.ToDictionary(
+            typeId => typeId,
+            typeId => new TypeMetricSnapshot(
+                cboDeclaration.TryGetValue(typeId, out var declarationValue) ? declarationValue : 0,
+                cboMethodBody.TryGetValue(typeId, out var methodBodyValue) ? methodBodyValue : 0,
+                cboTotal.TryGetValue(typeId, out var totalValue) ? totalValue : 0,
+                cboDeclaration.ContainsKey(typeId) || cboMethodBody.ContainsKey(typeId) || cboTotal.ContainsKey(typeId)));
+    }
+
+    private static Dictionary<EntityId, int> BuildIntMetricMap(IReadOnlyList<SemanticTriple> triples, PredicateId predicate)
+    {
+        return triples
+            .Where(triple => triple.Predicate == predicate)
+            .Where(triple => triple.Subject is EntityNode && triple.Object is LiteralNode)
+            .Select(triple =>
+            {
+                var subjectId = ((EntityNode)triple.Subject).Id;
+                var literalValue = ((LiteralNode)triple.Object).Value?.ToString() ?? string.Empty;
+                return (SubjectId: subjectId, Value: int.TryParse(literalValue, NumberStyles.Integer, CultureInfo.InvariantCulture, out var parsed) ? parsed : (int?)null);
+            })
+            .Where(item => item.Value.HasValue)
+            .GroupBy(item => item.SubjectId)
+            .ToDictionary(group => group.Key, group => group.First().Value!.Value);
+    }
+
+    private static Dictionary<EntityId, double> BuildDoubleMetricMap(IReadOnlyList<SemanticTriple> triples, PredicateId predicate)
+    {
+        return triples
+            .Where(triple => triple.Predicate == predicate)
+            .Where(triple => triple.Subject is EntityNode && triple.Object is LiteralNode)
+            .Select(triple =>
+            {
+                var subjectId = ((EntityNode)triple.Subject).Id;
+                var literalValue = ((LiteralNode)triple.Object).Value?.ToString() ?? string.Empty;
+                return (SubjectId: subjectId, Value: double.TryParse(literalValue, NumberStyles.Float, CultureInfo.InvariantCulture, out var parsed) ? parsed : (double?)null);
+            })
+            .Where(item => item.Value.HasValue)
+            .GroupBy(item => item.SubjectId)
+            .ToDictionary(group => group.Key, group => group.First().Value!.Value);
+    }
+
+    private sealed record MethodMetricSnapshot(
+        string CoverageStatus,
+        int? CyclomaticComplexity,
+        int? CognitiveComplexity,
+        double? HalsteadVolume,
+        double? MaintainabilityIndex)
+    {
+        public static MethodMetricSnapshot Empty { get; } = new(string.Empty, null, null, null, null);
+    }
+
+    private sealed record TypeMetricSnapshot(
+        int CboDeclaration,
+        int CboMethodBody,
+        int CboTotal,
+        bool HasCbo)
+    {
+        public static TypeMetricSnapshot Empty { get; } = new(0, 0, 0, false);
+    }
+
+    private sealed record MethodMetricContext(
+        EntityId Id,
+        IReadOnlyList<EntityId> DeclarationFileIds,
+        EntityId? NamespaceId,
+        EntityId? ProjectId,
+        StructuralMetricCodeKind CodeKind,
+        bool IsAnalyzable,
+        int? CyclomaticComplexity,
+        int? CognitiveComplexity,
+        double? HalsteadVolume,
+        double? MaintainabilityIndex);
+
+    private sealed record TypeMetricContext(
+        EntityId Id,
+        IReadOnlyList<EntityId> DeclarationFileIds,
+        EntityId? NamespaceId,
+        EntityId? ProjectId,
+        StructuralMetricCodeKind CodeKind,
+        bool HasCbo,
+        int CboDeclaration,
+        int CboMethodBody,
+        int CboTotal);
+}

--- a/src/CodeLlmWiki.Query/ProjectStructure/StructuralMetricRollupProjector.cs
+++ b/src/CodeLlmWiki.Query/ProjectStructure/StructuralMetricRollupProjector.cs
@@ -96,8 +96,10 @@ public sealed class StructuralMetricRollupProjector : IStructuralMetricRollupPro
                 var types = typesByFileId.TryGetValue(file.Id, out var fileTypes)
                     ? fileTypes
                     : [];
-                var rawRollup = BuildRawRollup(methods, types);
-                var included = IsIncludedInRanking(rawRollup, methods, types, request.ScopeFilter);
+                var filteredMethods = ApplyScopeFilter(methods, request.ScopeFilter);
+                var filteredTypes = ApplyScopeFilter(types, request.ScopeFilter);
+                var rawRollup = BuildRawRollup(filteredMethods, filteredTypes);
+                var included = IsIncludedInRanking(rawRollup, request.ScopeFilter);
                 var rollup = rawRollup with { IncludedInRanking = included };
 
                 return new FileStructuralMetricRollupNode(
@@ -120,8 +122,10 @@ public sealed class StructuralMetricRollupProjector : IStructuralMetricRollupPro
                 var types = typesByProjectId.TryGetValue(project.Id, out var projectTypes)
                     ? projectTypes
                     : [];
-                var rawRollup = BuildRawRollup(methods, types);
-                var included = IsIncludedInRanking(rawRollup, methods, types, request.ScopeFilter);
+                var filteredMethods = ApplyScopeFilter(methods, request.ScopeFilter);
+                var filteredTypes = ApplyScopeFilter(types, request.ScopeFilter);
+                var rawRollup = BuildRawRollup(filteredMethods, filteredTypes);
+                var included = IsIncludedInRanking(rawRollup, request.ScopeFilter);
                 var rollup = rawRollup with { IncludedInRanking = included };
 
                 return new ProjectStructuralMetricRollupNode(
@@ -144,8 +148,10 @@ public sealed class StructuralMetricRollupProjector : IStructuralMetricRollupPro
                 var directTypes = typesByNamespaceId.TryGetValue(namespaceNode.Id, out var directTypeSet)
                     ? directTypeSet
                     : [];
-                var directRaw = BuildRawRollup(directMethods, directTypes);
-                var directIncluded = IsIncludedInRanking(directRaw, directMethods, directTypes, request.ScopeFilter);
+                var filteredDirectMethods = ApplyScopeFilter(directMethods, request.ScopeFilter);
+                var filteredDirectTypes = ApplyScopeFilter(directTypes, request.ScopeFilter);
+                var directRaw = BuildRawRollup(filteredDirectMethods, filteredDirectTypes);
+                var directIncluded = IsIncludedInRanking(directRaw, request.ScopeFilter);
                 var direct = directRaw with { IncludedInRanking = directIncluded };
 
                 var recursiveMethodSet = namespaceDescendants[namespaceNode.Id]
@@ -156,8 +162,10 @@ public sealed class StructuralMetricRollupProjector : IStructuralMetricRollupPro
                     .SelectMany(descendantId => typesByNamespaceId.TryGetValue(descendantId, out var recursiveTypes) ? recursiveTypes : [])
                     .DistinctBy(x => x.Id)
                     .ToArray();
-                var recursiveRaw = BuildRawRollup(recursiveMethodSet, recursiveTypeSet);
-                var recursiveIncluded = IsIncludedInRanking(recursiveRaw, recursiveMethodSet, recursiveTypeSet, request.ScopeFilter);
+                var filteredRecursiveMethods = ApplyScopeFilter(recursiveMethodSet, request.ScopeFilter);
+                var filteredRecursiveTypes = ApplyScopeFilter(recursiveTypeSet, request.ScopeFilter);
+                var recursiveRaw = BuildRawRollup(filteredRecursiveMethods, filteredRecursiveTypes);
+                var recursiveIncluded = IsIncludedInRanking(recursiveRaw, request.ScopeFilter);
                 var recursive = recursiveRaw with { IncludedInRanking = recursiveIncluded };
 
                 return new NamespaceStructuralMetricRollupNode(
@@ -171,8 +179,10 @@ public sealed class StructuralMetricRollupProjector : IStructuralMetricRollupPro
             })
             .ToArray();
 
-        var repositoryRaw = BuildRawRollup(methodContexts, typeContexts);
-        var repositoryIncluded = IsIncludedInRanking(repositoryRaw, methodContexts, typeContexts, request.ScopeFilter);
+        var repositoryMethods = ApplyScopeFilter(methodContexts, request.ScopeFilter);
+        var repositoryTypes = ApplyScopeFilter(typeContexts, request.ScopeFilter);
+        var repositoryRaw = BuildRawRollup(repositoryMethods, repositoryTypes);
+        var repositoryIncluded = IsIncludedInRanking(repositoryRaw, request.ScopeFilter);
         var repository = new RepositoryStructuralMetricRollupNode(
             request.RepositoryId,
             repositoryRaw with { IncludedInRanking = repositoryIncluded });
@@ -180,10 +190,26 @@ public sealed class StructuralMetricRollupProjector : IStructuralMetricRollupPro
         return new StructuralMetricRollupCatalog(repository, projects, namespaces, files, request.ScopeFilter);
     }
 
+    private static IReadOnlyList<MethodMetricContext> ApplyScopeFilter(
+        IReadOnlyList<MethodMetricContext> methods,
+        StructuralMetricScopeFilter filter)
+    {
+        return methods
+            .Where(method => filter.IncludesCodeKind(method.CodeKind))
+            .ToArray();
+    }
+
+    private static IReadOnlyList<TypeMetricContext> ApplyScopeFilter(
+        IReadOnlyList<TypeMetricContext> types,
+        StructuralMetricScopeFilter filter)
+    {
+        return types
+            .Where(type => filter.IncludesCodeKind(type.CodeKind))
+            .ToArray();
+    }
+
     private static bool IsIncludedInRanking(
         StructuralMetricScopeRollup rollup,
-        IReadOnlyList<MethodMetricContext> methods,
-        IReadOnlyList<TypeMetricContext> types,
         StructuralMetricScopeFilter filter)
     {
         if (filter.ExcludeInsufficientDataFromRanking && rollup.Severity == StructuralMetricSeverity.None)
@@ -191,14 +217,7 @@ public sealed class StructuralMetricRollupProjector : IStructuralMetricRollupPro
             return false;
         }
 
-        var eligibleMethods = methods.Count(method => method.IsAnalyzable && filter.IncludesCodeKind(method.CodeKind));
-        if (eligibleMethods > 0)
-        {
-            return true;
-        }
-
-        var eligibleTypes = types.Count(type => type.HasCbo && filter.IncludesCodeKind(type.CodeKind));
-        return eligibleTypes > 0;
+        return rollup.Coverage.AnalyzableMethods > 0 || rollup.Coverage.TypesWithCbo > 0;
     }
 
     private static StructuralMetricScopeRollup BuildRawRollup(
@@ -362,13 +381,8 @@ public sealed class StructuralMetricRollupProjector : IStructuralMetricRollupPro
 
     private static StructuralMetricCodeKind ClassifyProjectCodeKind(string projectName, string projectPath)
     {
-        var loweredName = projectName.ToLowerInvariant();
-        var loweredPath = projectPath.Replace('\\', '/').ToLowerInvariant();
-        var isTest = loweredName.Contains("test", StringComparison.Ordinal)
-                     || loweredPath.Contains("/test/", StringComparison.Ordinal)
-                     || loweredPath.Contains("/tests/", StringComparison.Ordinal)
-                     || loweredPath.Contains(".test", StringComparison.Ordinal)
-                     || loweredPath.Contains(".tests", StringComparison.Ordinal);
+        var isTest = ContainsTestToken(projectName)
+                     || ContainsTestToken(projectPath.Replace('\\', '/'));
 
         return isTest
             ? StructuralMetricCodeKind.Test
@@ -393,7 +407,7 @@ public sealed class StructuralMetricRollupProjector : IStructuralMetricRollupPro
 
         var isTestFile = loweredPath.Contains("/test/", StringComparison.Ordinal)
                          || loweredPath.Contains("/tests/", StringComparison.Ordinal)
-                         || loweredPath.EndsWith("tests.cs", StringComparison.Ordinal);
+                         || ContainsTestToken(loweredPath);
         if (isTestFile || projectCodeKind == StructuralMetricCodeKind.Test)
         {
             return StructuralMetricCodeKind.Test;
@@ -508,9 +522,16 @@ public sealed class StructuralMetricRollupProjector : IStructuralMetricRollupPro
         var coverageByMethodId = triples
             .Where(triple => triple.Predicate == CorePredicates.MetricCoverageStatus)
             .Where(triple => triple.Subject is EntityNode && triple.Object is LiteralNode)
+            .Select(triple => (
+                MethodId: ((EntityNode)triple.Subject).Id,
+                CoverageStatus: ((LiteralNode)triple.Object).Value?.ToString() ?? string.Empty))
+            .GroupBy(x => x.MethodId)
             .ToDictionary(
-                triple => ((EntityNode)triple.Subject).Id,
-                triple => (((LiteralNode)triple.Object).Value?.ToString() ?? string.Empty),
+                group => group.Key,
+                group => group
+                    .Select(x => x.CoverageStatus)
+                    .OrderBy(x => x, StringComparer.Ordinal)
+                    .First(),
                 EqualityComparer<EntityId>.Default);
         var cyclomaticByMethodId = BuildIntMetricMap(triples, CorePredicates.CyclomaticComplexity);
         var cognitiveByMethodId = BuildIntMetricMap(triples, CorePredicates.CognitiveComplexity);
@@ -571,7 +592,9 @@ public sealed class StructuralMetricRollupProjector : IStructuralMetricRollupPro
             })
             .Where(item => item.Value.HasValue)
             .GroupBy(item => item.SubjectId)
-            .ToDictionary(group => group.Key, group => group.First().Value!.Value);
+            .ToDictionary(
+                group => group.Key,
+                group => group.Select(x => x.Value!.Value).OrderBy(x => x).First());
     }
 
     private static Dictionary<EntityId, double> BuildDoubleMetricMap(IReadOnlyList<SemanticTriple> triples, PredicateId predicate)
@@ -587,7 +610,18 @@ public sealed class StructuralMetricRollupProjector : IStructuralMetricRollupPro
             })
             .Where(item => item.Value.HasValue)
             .GroupBy(item => item.SubjectId)
-            .ToDictionary(group => group.Key, group => group.First().Value!.Value);
+            .ToDictionary(
+                group => group.Key,
+                group => group.Select(x => x.Value!.Value).OrderBy(x => x).First());
+    }
+
+    private static bool ContainsTestToken(string value)
+    {
+        var lowered = value.ToLowerInvariant();
+        var tokens = lowered
+            .Split(['/', '\\', '.', '-', '_', ' '], StringSplitOptions.RemoveEmptyEntries);
+
+        return tokens.Any(token => token is "test" or "tests");
     }
 
     private sealed record MethodMetricSnapshot(

--- a/src/CodeLlmWiki.Query/ProjectStructure/StructuralMetricScopeFilter.cs
+++ b/src/CodeLlmWiki.Query/ProjectStructure/StructuralMetricScopeFilter.cs
@@ -1,0 +1,29 @@
+namespace CodeLlmWiki.Query.ProjectStructure;
+
+public sealed record StructuralMetricScopeFilter(
+    bool IncludeProduction,
+    bool IncludeTest,
+    bool IncludeGenerated,
+    bool ExcludeInsufficientDataFromRanking = true)
+{
+    public static StructuralMetricScopeFilter ProductionDefault { get; } = new(
+        IncludeProduction: true,
+        IncludeTest: false,
+        IncludeGenerated: false);
+
+    public static StructuralMetricScopeFilter AllCodeKinds { get; } = new(
+        IncludeProduction: true,
+        IncludeTest: true,
+        IncludeGenerated: true);
+
+    public bool IncludesCodeKind(StructuralMetricCodeKind codeKind)
+    {
+        return codeKind switch
+        {
+            StructuralMetricCodeKind.Production => IncludeProduction,
+            StructuralMetricCodeKind.Test => IncludeTest,
+            StructuralMetricCodeKind.Generated => IncludeGenerated,
+            _ => false,
+        };
+    }
+}

--- a/src/CodeLlmWiki.Query/ProjectStructure/StructuralMetricScopeRollup.cs
+++ b/src/CodeLlmWiki.Query/ProjectStructure/StructuralMetricScopeRollup.cs
@@ -1,0 +1,7 @@
+namespace CodeLlmWiki.Query.ProjectStructure;
+
+public sealed record StructuralMetricScopeRollup(
+    StructuralMetricCoverage Coverage,
+    StructuralMetricStatistics Metrics,
+    StructuralMetricSeverity Severity,
+    bool IncludedInRanking);

--- a/src/CodeLlmWiki.Query/ProjectStructure/StructuralMetricSeverity.cs
+++ b/src/CodeLlmWiki.Query/ProjectStructure/StructuralMetricSeverity.cs
@@ -1,0 +1,7 @@
+namespace CodeLlmWiki.Query.ProjectStructure;
+
+public enum StructuralMetricSeverity
+{
+    None = 0,
+    Unknown = 1,
+}

--- a/src/CodeLlmWiki.Query/ProjectStructure/StructuralMetricStatistics.cs
+++ b/src/CodeLlmWiki.Query/ProjectStructure/StructuralMetricStatistics.cs
@@ -1,0 +1,12 @@
+namespace CodeLlmWiki.Query.ProjectStructure;
+
+public sealed record StructuralMetricStatistics(
+    int MethodMetricCount,
+    double AverageCyclomaticComplexity,
+    double AverageCognitiveComplexity,
+    double AverageHalsteadVolume,
+    double AverageMaintainabilityIndex,
+    int TypeMetricCount,
+    double AverageCboDeclaration,
+    double AverageCboMethodBody,
+    double AverageCboTotal);

--- a/tests/CodeLlmWiki.Ingestion.Tests/StructuralMetricRollupVerticalSliceTests.cs
+++ b/tests/CodeLlmWiki.Ingestion.Tests/StructuralMetricRollupVerticalSliceTests.cs
@@ -1,0 +1,274 @@
+using System.Diagnostics;
+using CodeLlmWiki.Contracts.Identity;
+using CodeLlmWiki.Ingestion.ProjectStructure;
+using CodeLlmWiki.Query.ProjectStructure;
+
+namespace CodeLlmWiki.Ingestion.Tests;
+
+public sealed class StructuralMetricRollupVerticalSliceTests
+{
+    [Fact]
+    public async Task Query_BuildsDeterministicRollups_ForFileNamespaceProjectAndRepository()
+    {
+        var fixture = await StructuralMetricFixture.CreateAsync();
+        var analyzer = new ProjectStructureAnalyzer(new StableIdGenerator());
+        var analysis = await analyzer.AnalyzeAsync(fixture.RepositoryPath, CancellationToken.None);
+        var query = new ProjectStructureQueryService(analysis.Triples);
+
+        var first = query.GetModel(analysis.RepositoryId);
+        var second = query.GetModel(analysis.RepositoryId);
+
+        Assert.NotNull(first.StructuralMetrics.Repository);
+        Assert.NotEmpty(first.StructuralMetrics.Files);
+        Assert.NotEmpty(first.StructuralMetrics.Namespaces);
+        Assert.NotEmpty(first.StructuralMetrics.Projects);
+
+        var globalNamespace = first.StructuralMetrics.Namespaces.Single(x => x.Name == "(global)");
+        Assert.True(globalNamespace.Direct.Coverage.TotalMethods > 0);
+        Assert.True(globalNamespace.Recursive.Coverage.TotalMethods >= globalNamespace.Direct.Coverage.TotalMethods);
+
+        var servicesNamespace = first.StructuralMetrics.Namespaces.Single(x => x.Name == "Acme.Services");
+        Assert.True(servicesNamespace.Direct.Coverage.AnalyzableMethods > 0);
+        Assert.True(servicesNamespace.Recursive.Coverage.AnalyzableMethods > servicesNamespace.Direct.Coverage.AnalyzableMethods);
+
+        var firstFingerprint = BuildFingerprint(first.StructuralMetrics);
+        var secondFingerprint = BuildFingerprint(second.StructuralMetrics);
+        Assert.Equal(firstFingerprint, secondFingerprint);
+    }
+
+    [Fact]
+    public async Task Query_UsesProductionDefaultRankingScope_AndSupportsFilterOverrides()
+    {
+        var fixture = await StructuralMetricFixture.CreateAsync();
+        var analyzer = new ProjectStructureAnalyzer(new StableIdGenerator());
+        var analysis = await analyzer.AnalyzeAsync(fixture.RepositoryPath, CancellationToken.None);
+        var query = new ProjectStructureQueryService(analysis.Triples);
+
+        var defaultModel = query.GetModel(analysis.RepositoryId);
+        var defaultFiles = defaultModel.StructuralMetrics.Files;
+
+        var productionFile = defaultFiles.Single(x => x.Path == "src/App/Services/Service.cs");
+        var generatedFile = defaultFiles.Single(x => x.Path == "src/App/Generated/Auto.generated.cs");
+        var testFile = defaultFiles.Single(x => x.Path == "tests/App.Tests/ServiceTests.cs");
+
+        Assert.Equal(StructuralMetricCodeKind.Production, productionFile.CodeKind);
+        Assert.Equal(StructuralMetricCodeKind.Generated, generatedFile.CodeKind);
+        Assert.Equal(StructuralMetricCodeKind.Test, testFile.CodeKind);
+
+        Assert.True(productionFile.Rollup.IncludedInRanking);
+        Assert.False(generatedFile.Rollup.IncludedInRanking);
+        Assert.False(testFile.Rollup.IncludedInRanking);
+
+        var includeAllModel = query.GetModel(
+            analysis.RepositoryId,
+            new ProjectStructureQueryOptions
+            {
+                MetricScopeFilter = StructuralMetricScopeFilter.AllCodeKinds,
+            });
+
+        var includeAllFiles = includeAllModel.StructuralMetrics.Files;
+        Assert.True(includeAllFiles.Single(x => x.Path == "src/App/Services/Service.cs").Rollup.IncludedInRanking);
+        Assert.True(includeAllFiles.Single(x => x.Path == "src/App/Generated/Auto.generated.cs").Rollup.IncludedInRanking);
+        Assert.True(includeAllFiles.Single(x => x.Path == "tests/App.Tests/ServiceTests.cs").Rollup.IncludedInRanking);
+    }
+
+    [Fact]
+    public async Task Query_MarksInsufficientScopes_AsSeverityNone_AndExcludesThemFromDefaultRanking()
+    {
+        var fixture = await StructuralMetricFixture.CreateAsync();
+        var analyzer = new ProjectStructureAnalyzer(new StableIdGenerator());
+        var analysis = await analyzer.AnalyzeAsync(fixture.RepositoryPath, CancellationToken.None);
+        var model = new ProjectStructureQueryService(analysis.Triples).GetModel(analysis.RepositoryId);
+
+        var contractsFile = model.StructuralMetrics.Files.Single(x => x.Path == "src/App/Contracts/IContract.cs");
+        Assert.Equal(StructuralMetricSeverity.None, contractsFile.Rollup.Severity);
+        Assert.False(contractsFile.Rollup.IncludedInRanking);
+
+        var contractsNamespace = model.StructuralMetrics.Namespaces.Single(x => x.Name == "Acme.Contracts");
+        Assert.Equal(StructuralMetricSeverity.None, contractsNamespace.Direct.Severity);
+        Assert.False(contractsNamespace.Direct.IncludedInRanking);
+    }
+
+    private static string BuildFingerprint(StructuralMetricRollupCatalog catalog)
+    {
+        static string SerializeRollup(StructuralMetricScopeRollup rollup)
+            => $"{rollup.Coverage.TotalMethods}:{rollup.Coverage.AnalyzableMethods}:{rollup.Severity}:{rollup.IncludedInRanking}";
+
+        var fileRows = catalog.Files
+            .Select(x => $"file:{x.Path}:{x.CodeKind}:{SerializeRollup(x.Rollup)}");
+        var namespaceRows = catalog.Namespaces
+            .Select(x => $"ns:{x.Path}:{SerializeRollup(x.Direct)}:{SerializeRollup(x.Recursive)}");
+        var projectRows = catalog.Projects
+            .Select(x => $"project:{x.Path}:{x.CodeKind}:{SerializeRollup(x.Rollup)}");
+        var repositoryRow = $"repo:{SerializeRollup(catalog.Repository.Rollup)}";
+
+        return string.Join(
+            "\n",
+            fileRows.Concat(namespaceRows).Concat(projectRows).Append(repositoryRow));
+    }
+
+    private sealed class StructuralMetricFixture
+    {
+        private StructuralMetricFixture(string repositoryPath)
+        {
+            RepositoryPath = repositoryPath;
+        }
+
+        public string RepositoryPath { get; }
+
+        public static async Task<StructuralMetricFixture> CreateAsync()
+        {
+            var root = Path.Combine(Path.GetTempPath(), $"codellmwiki-structural-rollups-{Guid.NewGuid():N}", "metric-repo");
+            Directory.CreateDirectory(root);
+
+            await File.WriteAllTextAsync(Path.Combine(root, "Sample.slnx"),
+                """
+                <Solution>
+                  <Project Path="src/App/App.csproj" />
+                  <Project Path="tests/App.Tests/App.Tests.csproj" />
+                </Solution>
+                """);
+
+            var appDir = Path.Combine(root, "src", "App");
+            Directory.CreateDirectory(appDir);
+            await File.WriteAllTextAsync(Path.Combine(appDir, "App.csproj"),
+                """
+                <Project Sdk="Microsoft.NET.Sdk">
+                  <PropertyGroup>
+                    <TargetFramework>net10.0</TargetFramework>
+                    <AssemblyName>Acme.App</AssemblyName>
+                  </PropertyGroup>
+                </Project>
+                """);
+
+            await File.WriteAllTextAsync(Path.Combine(appDir, "GlobalWorker.cs"),
+                """
+                public class GlobalWorker
+                {
+                    public int Execute(int value)
+                    {
+                        return value + 1;
+                    }
+                }
+                """);
+
+            Directory.CreateDirectory(Path.Combine(appDir, "Services"));
+            await File.WriteAllTextAsync(Path.Combine(appDir, "Services", "Service.cs"),
+                """
+                namespace Acme.Services;
+
+                public class Service
+                {
+                    public int Run(int value)
+                    {
+                        if (value > 0)
+                        {
+                            return value;
+                        }
+
+                        return value + 1;
+                    }
+                }
+                """);
+
+            Directory.CreateDirectory(Path.Combine(appDir, "Services", "Internal"));
+            await File.WriteAllTextAsync(Path.Combine(appDir, "Services", "Internal", "NestedService.cs"),
+                """
+                namespace Acme.Services.Internal;
+
+                public class NestedService
+                {
+                    public int Compute(int value)
+                    {
+                        return value * 2;
+                    }
+                }
+                """);
+
+            Directory.CreateDirectory(Path.Combine(appDir, "Contracts"));
+            await File.WriteAllTextAsync(Path.Combine(appDir, "Contracts", "IContract.cs"),
+                """
+                namespace Acme.Contracts;
+
+                public interface IContract
+                {
+                    void Execute();
+                }
+                """);
+
+            Directory.CreateDirectory(Path.Combine(appDir, "Generated"));
+            await File.WriteAllTextAsync(Path.Combine(appDir, "Generated", "Auto.generated.cs"),
+                """
+                namespace Acme.Generated;
+
+                public class AutoGenerated
+                {
+                    public int Value()
+                    {
+                        return 42;
+                    }
+                }
+                """);
+
+            var testsDir = Path.Combine(root, "tests", "App.Tests");
+            Directory.CreateDirectory(testsDir);
+            await File.WriteAllTextAsync(Path.Combine(testsDir, "App.Tests.csproj"),
+                """
+                <Project Sdk="Microsoft.NET.Sdk">
+                  <PropertyGroup>
+                    <TargetFramework>net10.0</TargetFramework>
+                    <AssemblyName>Acme.App.Tests</AssemblyName>
+                  </PropertyGroup>
+                </Project>
+                """);
+
+            await File.WriteAllTextAsync(Path.Combine(testsDir, "ServiceTests.cs"),
+                """
+                namespace Acme.Tests;
+
+                public class ServiceTests
+                {
+                    public int ShouldRun()
+                    {
+                        var service = new Acme.Services.Service();
+                        return service.Run(3);
+                    }
+                }
+                """);
+
+            RunGit(root, "init", "-b", "main");
+            RunGit(root, "config", "user.email", "test@example.com");
+            RunGit(root, "config", "user.name", "Test User");
+            RunGit(root, "add", ".");
+            RunGit(root, "commit", "-m", "initial");
+
+            return new StructuralMetricFixture(root);
+        }
+    }
+
+    private static void RunGit(string workingDirectory, params string[] arguments)
+    {
+        var info = new ProcessStartInfo("git")
+        {
+            WorkingDirectory = workingDirectory,
+            RedirectStandardOutput = true,
+            RedirectStandardError = true,
+            UseShellExecute = false,
+        };
+
+        foreach (var argument in arguments)
+        {
+            info.ArgumentList.Add(argument);
+        }
+
+        using var process = Process.Start(info) ?? throw new InvalidOperationException("Failed to start git process.");
+        var standardOutput = process.StandardOutput.ReadToEnd();
+        var standardError = process.StandardError.ReadToEnd();
+        process.WaitForExit();
+
+        if (process.ExitCode != 0)
+        {
+            throw new InvalidOperationException($"git {string.Join(' ', arguments)} failed with exit code {process.ExitCode}.{Environment.NewLine}{standardOutput}{Environment.NewLine}{standardError}");
+        }
+    }
+}

--- a/tests/CodeLlmWiki.Ingestion.Tests/StructuralMetricRollupVerticalSliceTests.cs
+++ b/tests/CodeLlmWiki.Ingestion.Tests/StructuralMetricRollupVerticalSliceTests.cs
@@ -48,16 +48,23 @@ public sealed class StructuralMetricRollupVerticalSliceTests
         var defaultFiles = defaultModel.StructuralMetrics.Files;
 
         var productionFile = defaultFiles.Single(x => x.Path == "src/App/Services/Service.cs");
+        var contestFile = defaultFiles.Single(x => x.Path == "src/App/Contest.cs");
         var generatedFile = defaultFiles.Single(x => x.Path == "src/App/Generated/Auto.generated.cs");
         var testFile = defaultFiles.Single(x => x.Path == "tests/App.Tests/ServiceTests.cs");
 
         Assert.Equal(StructuralMetricCodeKind.Production, productionFile.CodeKind);
+        Assert.Equal(StructuralMetricCodeKind.Production, contestFile.CodeKind);
         Assert.Equal(StructuralMetricCodeKind.Generated, generatedFile.CodeKind);
         Assert.Equal(StructuralMetricCodeKind.Test, testFile.CodeKind);
 
         Assert.True(productionFile.Rollup.IncludedInRanking);
         Assert.False(generatedFile.Rollup.IncludedInRanking);
         Assert.False(testFile.Rollup.IncludedInRanking);
+        Assert.Equal(3, defaultModel.StructuralMetrics.Repository.Rollup.Coverage.AnalyzableMethods);
+
+        var defaultTestProject = defaultModel.StructuralMetrics.Projects.Single(x => x.Path == "tests/App.Tests/App.Tests.csproj");
+        Assert.Equal(StructuralMetricSeverity.None, defaultTestProject.Rollup.Severity);
+        Assert.False(defaultTestProject.Rollup.IncludedInRanking);
 
         var includeAllModel = query.GetModel(
             analysis.RepositoryId,
@@ -70,6 +77,11 @@ public sealed class StructuralMetricRollupVerticalSliceTests
         Assert.True(includeAllFiles.Single(x => x.Path == "src/App/Services/Service.cs").Rollup.IncludedInRanking);
         Assert.True(includeAllFiles.Single(x => x.Path == "src/App/Generated/Auto.generated.cs").Rollup.IncludedInRanking);
         Assert.True(includeAllFiles.Single(x => x.Path == "tests/App.Tests/ServiceTests.cs").Rollup.IncludedInRanking);
+        Assert.Equal(5, includeAllModel.StructuralMetrics.Repository.Rollup.Coverage.AnalyzableMethods);
+
+        var includeAllTestProject = includeAllModel.StructuralMetrics.Projects.Single(x => x.Path == "tests/App.Tests/App.Tests.csproj");
+        Assert.Equal(1, includeAllTestProject.Rollup.Coverage.AnalyzableMethods);
+        Assert.True(includeAllTestProject.Rollup.IncludedInRanking);
     }
 
     [Fact]
@@ -149,6 +161,15 @@ public sealed class StructuralMetricRollupVerticalSliceTests
                     {
                         return value + 1;
                     }
+                }
+                """);
+
+            await File.WriteAllTextAsync(Path.Combine(appDir, "Contest.cs"),
+                """
+                namespace Acme.Contest;
+
+                public class ContestTag
+                {
                 }
                 """);
 


### PR DESCRIPTION
## Summary
- add additive structural metric rollup model to `ProjectStructureWikiModel`
- project deterministic rollups for files, namespaces (direct + recursive), projects, and repository
- implement production/test/generated scope filtering with production-default ranking semantics
- mark insufficient-data scopes as `severity: none` and exclude them from default ranked inclusion
- add vertical-slice tests for determinism, namespace recursion, scope filtering, and severity handling

## Verification
- `dotnet test tests/CodeLlmWiki.Ingestion.Tests/CodeLlmWiki.Ingestion.Tests.csproj --filter "FullyQualifiedName~StructuralMetricRollupVerticalSliceTests"`
- `dotnet test CodeLlmWiki.slnx`

Closes #88
