### PR TITLE
PRD 007 #089: Hotspot ranking and severity engine

### DIFF
--- a/src/CodeLlmWiki.Query/ProjectStructure/HotspotCompositeRankingNode.cs
+++ b/src/CodeLlmWiki.Query/ProjectStructure/HotspotCompositeRankingNode.cs
@@ -1,0 +1,5 @@
+namespace CodeLlmWiki.Query.ProjectStructure;
+
+public sealed record HotspotCompositeRankingNode(
+    HotspotTargetKind TargetKind,
+    IReadOnlyList<HotspotCompositeRankingRow> Rows);

--- a/src/CodeLlmWiki.Query/ProjectStructure/HotspotCompositeRankingRow.cs
+++ b/src/CodeLlmWiki.Query/ProjectStructure/HotspotCompositeRankingRow.cs
@@ -1,0 +1,11 @@
+using CodeLlmWiki.Contracts.Identity;
+
+namespace CodeLlmWiki.Query.ProjectStructure;
+
+public sealed record HotspotCompositeRankingRow(
+    EntityId EntityId,
+    string DisplayName,
+    string Path,
+    double CompositeScore,
+    HotspotSeverityBand Severity,
+    int Rank);

--- a/src/CodeLlmWiki.Query/ProjectStructure/HotspotMetricKind.cs
+++ b/src/CodeLlmWiki.Query/ProjectStructure/HotspotMetricKind.cs
@@ -1,0 +1,17 @@
+namespace CodeLlmWiki.Query.ProjectStructure;
+
+public enum HotspotMetricKind
+{
+    MethodCyclomaticComplexity = 0,
+    MethodCognitiveComplexity = 1,
+    MethodHalsteadVolume = 2,
+    MethodMaintainabilityIndex = 3,
+    TypeCboDeclaration = 4,
+    TypeCboMethodBody = 5,
+    TypeCboTotal = 6,
+    ScopeAverageCyclomaticComplexity = 7,
+    ScopeAverageCognitiveComplexity = 8,
+    ScopeAverageMaintainabilityIndex = 9,
+    ScopeAverageCboTotal = 10,
+    Composite = 11,
+}

--- a/src/CodeLlmWiki.Query/ProjectStructure/HotspotMetricRankingNode.cs
+++ b/src/CodeLlmWiki.Query/ProjectStructure/HotspotMetricRankingNode.cs
@@ -1,0 +1,6 @@
+namespace CodeLlmWiki.Query.ProjectStructure;
+
+public sealed record HotspotMetricRankingNode(
+    HotspotTargetKind TargetKind,
+    HotspotMetricKind MetricKind,
+    IReadOnlyList<HotspotRankingRow> Rows);

--- a/src/CodeLlmWiki.Query/ProjectStructure/HotspotRankingCatalog.cs
+++ b/src/CodeLlmWiki.Query/ProjectStructure/HotspotRankingCatalog.cs
@@ -1,0 +1,16 @@
+namespace CodeLlmWiki.Query.ProjectStructure;
+
+public sealed record HotspotRankingCatalog(
+    HotspotRankingEffectiveConfig EffectiveConfig,
+    IReadOnlyList<HotspotMetricRankingNode> PrimaryRankings,
+    IReadOnlyList<HotspotCompositeRankingNode> CompositeRankings)
+{
+    public static HotspotRankingCatalog Empty { get; } = new(
+        new HotspotRankingEffectiveConfig(
+            EffectiveTopN: 25,
+            Unbounded: false,
+            CompositeWeights: new Dictionary<HotspotMetricKind, double>(),
+            Thresholds: new Dictionary<HotspotMetricKind, HotspotSeverityThresholds>()),
+        [],
+        []);
+}

--- a/src/CodeLlmWiki.Query/ProjectStructure/HotspotRankingEffectiveConfig.cs
+++ b/src/CodeLlmWiki.Query/ProjectStructure/HotspotRankingEffectiveConfig.cs
@@ -1,0 +1,7 @@
+namespace CodeLlmWiki.Query.ProjectStructure;
+
+public sealed record HotspotRankingEffectiveConfig(
+    int EffectiveTopN,
+    bool Unbounded,
+    IReadOnlyDictionary<HotspotMetricKind, double> CompositeWeights,
+    IReadOnlyDictionary<HotspotMetricKind, HotspotSeverityThresholds> Thresholds);

--- a/src/CodeLlmWiki.Query/ProjectStructure/HotspotRankingOptions.cs
+++ b/src/CodeLlmWiki.Query/ProjectStructure/HotspotRankingOptions.cs
@@ -1,0 +1,16 @@
+namespace CodeLlmWiki.Query.ProjectStructure;
+
+public sealed record HotspotRankingOptions
+{
+    public static HotspotRankingOptions Default { get; } = new();
+
+    public int? TopN { get; init; } = 25;
+
+    public bool Unbounded { get; init; }
+
+    public IReadOnlyDictionary<HotspotMetricKind, double> CompositeWeightOverrides { get; init; } =
+        new Dictionary<HotspotMetricKind, double>();
+
+    public IReadOnlyDictionary<HotspotMetricKind, HotspotSeverityThresholds> ThresholdOverrides { get; init; } =
+        new Dictionary<HotspotMetricKind, HotspotSeverityThresholds>();
+}

--- a/src/CodeLlmWiki.Query/ProjectStructure/HotspotRankingProjectionRequest.cs
+++ b/src/CodeLlmWiki.Query/ProjectStructure/HotspotRankingProjectionRequest.cs
@@ -1,0 +1,9 @@
+using CodeLlmWiki.Contracts.Graph;
+
+namespace CodeLlmWiki.Query.ProjectStructure;
+
+public sealed record HotspotRankingProjectionRequest(
+    IReadOnlyList<SemanticTriple> Triples,
+    DeclarationCatalog Declarations,
+    StructuralMetricRollupCatalog StructuralMetrics,
+    HotspotRankingOptions Options);

--- a/src/CodeLlmWiki.Query/ProjectStructure/HotspotRankingProjector.cs
+++ b/src/CodeLlmWiki.Query/ProjectStructure/HotspotRankingProjector.cs
@@ -1,0 +1,532 @@
+using System.Globalization;
+using CodeLlmWiki.Contracts.Graph;
+using CodeLlmWiki.Contracts.Identity;
+
+namespace CodeLlmWiki.Query.ProjectStructure;
+
+public sealed class HotspotRankingProjector : IHotspotRankingProjector
+{
+    private static readonly IReadOnlyDictionary<HotspotMetricKind, double> DefaultCompositeWeights =
+        new Dictionary<HotspotMetricKind, double>
+        {
+            [HotspotMetricKind.MethodCyclomaticComplexity] = 1d,
+            [HotspotMetricKind.MethodCognitiveComplexity] = 1d,
+            [HotspotMetricKind.MethodHalsteadVolume] = 0.7d,
+            [HotspotMetricKind.MethodMaintainabilityIndex] = 1.2d,
+            [HotspotMetricKind.TypeCboDeclaration] = 0.8d,
+            [HotspotMetricKind.TypeCboMethodBody] = 0.8d,
+            [HotspotMetricKind.TypeCboTotal] = 1d,
+            [HotspotMetricKind.ScopeAverageCyclomaticComplexity] = 0.8d,
+            [HotspotMetricKind.ScopeAverageCognitiveComplexity] = 0.8d,
+            [HotspotMetricKind.ScopeAverageMaintainabilityIndex] = 1d,
+            [HotspotMetricKind.ScopeAverageCboTotal] = 0.8d,
+            [HotspotMetricKind.Composite] = 1d,
+        };
+
+    private static readonly IReadOnlyDictionary<HotspotMetricKind, HotspotSeverityThresholds> DefaultThresholds =
+        Enum.GetValues<HotspotMetricKind>().ToDictionary(
+            key => key,
+            _ => new HotspotSeverityThresholds(
+                Low: 0.25d,
+                Medium: 0.50d,
+                High: 0.75d,
+                Critical: 0.90d));
+
+    public HotspotRankingCatalog Project(HotspotRankingProjectionRequest request)
+    {
+        var effectiveTopN = NormalizeTopN(request.Options.TopN);
+        var effectiveWeights = ResolveWeights(request.Options.CompositeWeightOverrides);
+        var effectiveThresholds = ResolveThresholds(request.Options.ThresholdOverrides);
+        var subjectsByKind = BuildSubjectsByKind(request.Triples, request.Declarations, request.StructuralMetrics);
+
+        var primaryRankings = new List<HotspotMetricRankingNode>();
+        var compositeRankings = new List<HotspotCompositeRankingNode>();
+
+        foreach (var targetGroup in subjectsByKind.OrderBy(x => x.Key))
+        {
+            var targetKind = targetGroup.Key;
+            var subjects = targetGroup.Value;
+            if (subjects.Count == 0)
+            {
+                continue;
+            }
+
+            var metricKinds = subjects
+                .SelectMany(subject => subject.Metrics.Keys)
+                .Distinct()
+                .OrderBy(x => x)
+                .ToArray();
+            if (metricKinds.Length == 0)
+            {
+                continue;
+            }
+
+            var normalizedByMetricByEntityId = new Dictionary<HotspotMetricKind, IReadOnlyDictionary<EntityId, double>>();
+            foreach (var metricKind in metricKinds)
+            {
+                var rows = BuildMetricRows(
+                    subjects,
+                    metricKind,
+                    effectiveThresholds[metricKind],
+                    effectiveTopN,
+                    request.Options.Unbounded,
+                    out var normalizedByEntityId);
+
+                normalizedByMetricByEntityId[metricKind] = normalizedByEntityId;
+                primaryRankings.Add(new HotspotMetricRankingNode(targetKind, metricKind, rows));
+            }
+
+            var compositeRows = BuildCompositeRows(
+                subjects,
+                metricKinds,
+                normalizedByMetricByEntityId,
+                effectiveWeights,
+                effectiveThresholds[HotspotMetricKind.Composite],
+                effectiveTopN,
+                request.Options.Unbounded);
+            compositeRankings.Add(new HotspotCompositeRankingNode(targetKind, compositeRows));
+        }
+
+        return new HotspotRankingCatalog(
+            new HotspotRankingEffectiveConfig(
+                EffectiveTopN: effectiveTopN,
+                Unbounded: request.Options.Unbounded,
+                CompositeWeights: effectiveWeights,
+                Thresholds: effectiveThresholds),
+            primaryRankings
+                .OrderBy(x => x.TargetKind)
+                .ThenBy(x => x.MetricKind)
+                .ToArray(),
+            compositeRankings
+                .OrderBy(x => x.TargetKind)
+                .ToArray());
+    }
+
+    private static IReadOnlyList<HotspotRankingRow> BuildMetricRows(
+        IReadOnlyList<HotspotSubject> subjects,
+        HotspotMetricKind metricKind,
+        HotspotSeverityThresholds thresholds,
+        int effectiveTopN,
+        bool unbounded,
+        out IReadOnlyDictionary<EntityId, double> normalizedByEntityId)
+    {
+        var subjectsWithMetric = subjects
+            .Where(subject => subject.Metrics.ContainsKey(metricKind))
+            .ToArray();
+        if (subjectsWithMetric.Length == 0)
+        {
+            normalizedByEntityId = new Dictionary<EntityId, double>();
+            return [];
+        }
+
+        var values = subjectsWithMetric.Select(subject => subject.Metrics[metricKind]).ToArray();
+        var min = values.Min();
+        var max = values.Max();
+        var direction = GetDirection(metricKind);
+
+        var normalizedRows = subjectsWithMetric
+            .Select(subject =>
+            {
+                var rawValue = subject.Metrics[metricKind];
+                var normalized = Normalize(rawValue, min, max, direction);
+                return new
+                {
+                    Subject = subject,
+                    RawValue = rawValue,
+                    Normalized = normalized,
+                    Severity = GetSeverity(normalized, thresholds),
+                };
+            })
+            .OrderByDescending(x => x.Normalized)
+            .ThenByDescending(x => (int)x.Severity)
+            .ThenBy(x => x.Subject.Path, StringComparer.Ordinal)
+            .ThenBy(x => x.Subject.DisplayName, StringComparer.Ordinal)
+            .ThenBy(x => x.Subject.Id.Value, StringComparer.Ordinal)
+            .ToArray();
+
+        normalizedByEntityId = normalizedRows.ToDictionary(x => x.Subject.Id, x => x.Normalized);
+
+        var rows = normalizedRows
+            .Select((row, index) => new HotspotRankingRow(
+                row.Subject.Id,
+                row.Subject.DisplayName,
+                row.Subject.Path,
+                row.RawValue,
+                row.Normalized,
+                row.Severity,
+                Rank: index + 1))
+            .ToArray();
+
+        return ApplyBudget(rows, effectiveTopN, unbounded);
+    }
+
+    private static IReadOnlyList<HotspotCompositeRankingRow> BuildCompositeRows(
+        IReadOnlyList<HotspotSubject> subjects,
+        IReadOnlyList<HotspotMetricKind> metricKinds,
+        IReadOnlyDictionary<HotspotMetricKind, IReadOnlyDictionary<EntityId, double>> normalizedByMetricByEntityId,
+        IReadOnlyDictionary<HotspotMetricKind, double> effectiveWeights,
+        HotspotSeverityThresholds compositeThresholds,
+        int effectiveTopN,
+        bool unbounded)
+    {
+        var scored = new List<(HotspotSubject Subject, double Score, HotspotSeverityBand Severity)>();
+        foreach (var subject in subjects)
+        {
+            var weightedSum = 0d;
+            var totalWeight = 0d;
+            foreach (var metricKind in metricKinds)
+            {
+                if (!normalizedByMetricByEntityId.TryGetValue(metricKind, out var normalizedByEntity))
+                {
+                    continue;
+                }
+
+                if (!normalizedByEntity.TryGetValue(subject.Id, out var normalized))
+                {
+                    continue;
+                }
+
+                if (!effectiveWeights.TryGetValue(metricKind, out var weight) || weight <= 0d)
+                {
+                    continue;
+                }
+
+                weightedSum += normalized * weight;
+                totalWeight += weight;
+            }
+
+            if (totalWeight <= 0d)
+            {
+                continue;
+            }
+
+            var score = weightedSum / totalWeight;
+            scored.Add((subject, score, GetSeverity(score, compositeThresholds)));
+        }
+
+        var ordered = scored
+            .OrderByDescending(x => x.Score)
+            .ThenByDescending(x => (int)x.Severity)
+            .ThenBy(x => x.Subject.Path, StringComparer.Ordinal)
+            .ThenBy(x => x.Subject.DisplayName, StringComparer.Ordinal)
+            .ThenBy(x => x.Subject.Id.Value, StringComparer.Ordinal)
+            .Select((x, index) => new HotspotCompositeRankingRow(
+                x.Subject.Id,
+                x.Subject.DisplayName,
+                x.Subject.Path,
+                x.Score,
+                x.Severity,
+                Rank: index + 1))
+            .ToArray();
+
+        return ApplyBudget(ordered, effectiveTopN, unbounded);
+    }
+
+    private static IReadOnlyList<T> ApplyBudget<T>(IReadOnlyList<T> rows, int effectiveTopN, bool unbounded)
+    {
+        return unbounded
+            ? rows
+            : rows.Take(effectiveTopN).ToArray();
+    }
+
+    private static HotspotSeverityBand GetSeverity(double normalizedScore, HotspotSeverityThresholds thresholds)
+    {
+        if (normalizedScore >= thresholds.Critical)
+        {
+            return HotspotSeverityBand.Critical;
+        }
+
+        if (normalizedScore >= thresholds.High)
+        {
+            return HotspotSeverityBand.High;
+        }
+
+        if (normalizedScore >= thresholds.Medium)
+        {
+            return HotspotSeverityBand.Medium;
+        }
+
+        if (normalizedScore >= thresholds.Low)
+        {
+            return HotspotSeverityBand.Low;
+        }
+
+        return HotspotSeverityBand.None;
+    }
+
+    private static double Normalize(double rawValue, double min, double max, MetricDirection direction)
+    {
+        if (Math.Abs(max - min) < 0.000000001d)
+        {
+            return Math.Abs(rawValue) < 0.000000001d ? 0d : 1d;
+        }
+
+        var normalized = direction == MetricDirection.HigherIsWorse
+            ? (rawValue - min) / (max - min)
+            : (max - rawValue) / (max - min);
+
+        return Math.Clamp(normalized, 0d, 1d);
+    }
+
+    private static MetricDirection GetDirection(HotspotMetricKind metricKind)
+    {
+        return metricKind switch
+        {
+            HotspotMetricKind.MethodMaintainabilityIndex => MetricDirection.LowerIsWorse,
+            HotspotMetricKind.ScopeAverageMaintainabilityIndex => MetricDirection.LowerIsWorse,
+            _ => MetricDirection.HigherIsWorse,
+        };
+    }
+
+    private static int NormalizeTopN(int? configuredTopN)
+    {
+        if (!configuredTopN.HasValue || configuredTopN.Value <= 0)
+        {
+            return 25;
+        }
+
+        return configuredTopN.Value;
+    }
+
+    private static IReadOnlyDictionary<HotspotMetricKind, double> ResolveWeights(
+        IReadOnlyDictionary<HotspotMetricKind, double> overrides)
+    {
+        var resolved = DefaultCompositeWeights.ToDictionary(x => x.Key, x => x.Value);
+        foreach (var item in overrides.OrderBy(x => x.Key))
+        {
+            resolved[item.Key] = item.Value;
+        }
+
+        return resolved;
+    }
+
+    private static IReadOnlyDictionary<HotspotMetricKind, HotspotSeverityThresholds> ResolveThresholds(
+        IReadOnlyDictionary<HotspotMetricKind, HotspotSeverityThresholds> overrides)
+    {
+        var resolved = DefaultThresholds.ToDictionary(x => x.Key, x => x.Value);
+        foreach (var item in overrides.OrderBy(x => x.Key))
+        {
+            resolved[item.Key] = item.Value;
+        }
+
+        return resolved;
+    }
+
+    private static IReadOnlyDictionary<HotspotTargetKind, IReadOnlyList<HotspotSubject>> BuildSubjectsByKind(
+        IReadOnlyList<SemanticTriple> triples,
+        DeclarationCatalog declarations,
+        StructuralMetricRollupCatalog structuralMetrics)
+    {
+        var methodCoverageById = BuildStringMetricMap(triples, CorePredicates.MetricCoverageStatus);
+        var cyclomaticById = BuildIntMetricMap(triples, CorePredicates.CyclomaticComplexity);
+        var cognitiveById = BuildIntMetricMap(triples, CorePredicates.CognitiveComplexity);
+        var halsteadVolumeById = BuildDoubleMetricMap(triples, CorePredicates.HalsteadVolume);
+        var miById = BuildDoubleMetricMap(triples, CorePredicates.MaintainabilityIndex);
+        var cboDeclarationByTypeId = BuildIntMetricMap(triples, CorePredicates.CboDeclaration);
+        var cboMethodBodyByTypeId = BuildIntMetricMap(triples, CorePredicates.CboMethodBody);
+        var cboTotalByTypeId = BuildIntMetricMap(triples, CorePredicates.CboTotal);
+
+        var byKind = new Dictionary<HotspotTargetKind, IReadOnlyList<HotspotSubject>>();
+
+        var methodSubjects = declarations.Methods.Declarations
+            .Where(method => methodCoverageById.TryGetValue(method.Id, out var coverage)
+                && coverage.Equals("analyzable", StringComparison.OrdinalIgnoreCase))
+            .Select(method =>
+            {
+                var metrics = new Dictionary<HotspotMetricKind, double>();
+                if (cyclomaticById.TryGetValue(method.Id, out var cyclomatic))
+                {
+                    metrics[HotspotMetricKind.MethodCyclomaticComplexity] = cyclomatic;
+                }
+
+                if (cognitiveById.TryGetValue(method.Id, out var cognitive))
+                {
+                    metrics[HotspotMetricKind.MethodCognitiveComplexity] = cognitive;
+                }
+
+                if (halsteadVolumeById.TryGetValue(method.Id, out var halsteadVolume))
+                {
+                    metrics[HotspotMetricKind.MethodHalsteadVolume] = halsteadVolume;
+                }
+
+                if (miById.TryGetValue(method.Id, out var maintainabilityIndex))
+                {
+                    metrics[HotspotMetricKind.MethodMaintainabilityIndex] = maintainabilityIndex;
+                }
+
+                return new HotspotSubject(
+                    method.Id,
+                    method.Signature,
+                    method.Signature,
+                    metrics);
+            })
+            .Where(subject => subject.Metrics.Count > 0)
+            .OrderBy(subject => subject.Path, StringComparer.Ordinal)
+            .ThenBy(subject => subject.Id.Value, StringComparer.Ordinal)
+            .ToArray();
+        byKind[HotspotTargetKind.Method] = methodSubjects;
+
+        var typeSubjects = declarations.Types
+            .Select(type =>
+            {
+                var metrics = new Dictionary<HotspotMetricKind, double>();
+                if (cboDeclarationByTypeId.TryGetValue(type.Id, out var cboDeclaration))
+                {
+                    metrics[HotspotMetricKind.TypeCboDeclaration] = cboDeclaration;
+                }
+
+                if (cboMethodBodyByTypeId.TryGetValue(type.Id, out var cboMethodBody))
+                {
+                    metrics[HotspotMetricKind.TypeCboMethodBody] = cboMethodBody;
+                }
+
+                if (cboTotalByTypeId.TryGetValue(type.Id, out var cboTotal))
+                {
+                    metrics[HotspotMetricKind.TypeCboTotal] = cboTotal;
+                }
+
+                return new HotspotSubject(type.Id, type.DisplayName, type.Path, metrics);
+            })
+            .Where(subject => subject.Metrics.Count > 0)
+            .OrderBy(subject => subject.Path, StringComparer.Ordinal)
+            .ThenBy(subject => subject.Id.Value, StringComparer.Ordinal)
+            .ToArray();
+        byKind[HotspotTargetKind.Type] = typeSubjects;
+
+        byKind[HotspotTargetKind.File] = structuralMetrics.Files
+            .Where(file => file.Rollup.IncludedInRanking)
+            .Select(file => new HotspotSubject(
+                file.FileId,
+                file.Name,
+                file.Path,
+                BuildScopeMetrics(file.Rollup)))
+            .Where(subject => subject.Metrics.Count > 0)
+            .OrderBy(subject => subject.Path, StringComparer.Ordinal)
+            .ThenBy(subject => subject.Id.Value, StringComparer.Ordinal)
+            .ToArray();
+
+        byKind[HotspotTargetKind.Namespace] = structuralMetrics.Namespaces
+            .Where(@namespace => @namespace.Recursive.IncludedInRanking)
+            .Select(@namespace => new HotspotSubject(
+                @namespace.NamespaceId,
+                @namespace.Name,
+                @namespace.Path,
+                BuildScopeMetrics(@namespace.Recursive)))
+            .Where(subject => subject.Metrics.Count > 0)
+            .OrderBy(subject => subject.Path, StringComparer.Ordinal)
+            .ThenBy(subject => subject.Id.Value, StringComparer.Ordinal)
+            .ToArray();
+
+        byKind[HotspotTargetKind.Project] = structuralMetrics.Projects
+            .Where(project => project.Rollup.IncludedInRanking)
+            .Select(project => new HotspotSubject(
+                project.ProjectId,
+                project.Name,
+                project.Path,
+                BuildScopeMetrics(project.Rollup)))
+            .Where(subject => subject.Metrics.Count > 0)
+            .OrderBy(subject => subject.Path, StringComparer.Ordinal)
+            .ThenBy(subject => subject.Id.Value, StringComparer.Ordinal)
+            .ToArray();
+
+        var repositorySubjects = new List<HotspotSubject>();
+        if (structuralMetrics.Repository.Rollup.IncludedInRanking)
+        {
+            var repositoryMetrics = BuildScopeMetrics(structuralMetrics.Repository.Rollup);
+            if (repositoryMetrics.Count > 0)
+            {
+                repositorySubjects.Add(new HotspotSubject(
+                    structuralMetrics.Repository.RepositoryId,
+                    "Repository",
+                    ".",
+                    repositoryMetrics));
+            }
+        }
+
+        byKind[HotspotTargetKind.Repository] = repositorySubjects;
+
+        return byKind;
+    }
+
+    private static Dictionary<HotspotMetricKind, double> BuildScopeMetrics(StructuralMetricScopeRollup rollup)
+    {
+        var metrics = new Dictionary<HotspotMetricKind, double>();
+        if (rollup.Metrics.MethodMetricCount > 0)
+        {
+            metrics[HotspotMetricKind.ScopeAverageCyclomaticComplexity] = rollup.Metrics.AverageCyclomaticComplexity;
+            metrics[HotspotMetricKind.ScopeAverageCognitiveComplexity] = rollup.Metrics.AverageCognitiveComplexity;
+            metrics[HotspotMetricKind.ScopeAverageMaintainabilityIndex] = rollup.Metrics.AverageMaintainabilityIndex;
+        }
+
+        if (rollup.Metrics.TypeMetricCount > 0)
+        {
+            metrics[HotspotMetricKind.ScopeAverageCboTotal] = rollup.Metrics.AverageCboTotal;
+        }
+
+        return metrics;
+    }
+
+    private static Dictionary<EntityId, string> BuildStringMetricMap(
+        IReadOnlyList<SemanticTriple> triples,
+        PredicateId predicate)
+    {
+        return triples
+            .Where(triple => triple.Predicate == predicate)
+            .Where(triple => triple.Subject is EntityNode && triple.Object is LiteralNode)
+            .Select(triple => (
+                SubjectId: ((EntityNode)triple.Subject).Id,
+                Value: ((LiteralNode)triple.Object).Value?.ToString() ?? string.Empty))
+            .GroupBy(item => item.SubjectId)
+            .ToDictionary(
+                group => group.Key,
+                group => group.Select(x => x.Value).OrderBy(x => x, StringComparer.Ordinal).First());
+    }
+
+    private static Dictionary<EntityId, int> BuildIntMetricMap(IReadOnlyList<SemanticTriple> triples, PredicateId predicate)
+    {
+        return triples
+            .Where(triple => triple.Predicate == predicate)
+            .Where(triple => triple.Subject is EntityNode && triple.Object is LiteralNode)
+            .Select(triple =>
+            {
+                var subjectId = ((EntityNode)triple.Subject).Id;
+                var literalValue = ((LiteralNode)triple.Object).Value?.ToString() ?? string.Empty;
+                return (SubjectId: subjectId, Value: int.TryParse(literalValue, NumberStyles.Integer, CultureInfo.InvariantCulture, out var parsed) ? parsed : (int?)null);
+            })
+            .Where(item => item.Value.HasValue)
+            .GroupBy(item => item.SubjectId)
+            .ToDictionary(
+                group => group.Key,
+                group => group.Select(x => x.Value!.Value).OrderBy(x => x).First());
+    }
+
+    private static Dictionary<EntityId, double> BuildDoubleMetricMap(IReadOnlyList<SemanticTriple> triples, PredicateId predicate)
+    {
+        return triples
+            .Where(triple => triple.Predicate == predicate)
+            .Where(triple => triple.Subject is EntityNode && triple.Object is LiteralNode)
+            .Select(triple =>
+            {
+                var subjectId = ((EntityNode)triple.Subject).Id;
+                var literalValue = ((LiteralNode)triple.Object).Value?.ToString() ?? string.Empty;
+                return (SubjectId: subjectId, Value: double.TryParse(literalValue, NumberStyles.Float, CultureInfo.InvariantCulture, out var parsed) ? parsed : (double?)null);
+            })
+            .Where(item => item.Value.HasValue)
+            .GroupBy(item => item.SubjectId)
+            .ToDictionary(
+                group => group.Key,
+                group => group.Select(x => x.Value!.Value).OrderBy(x => x).First());
+    }
+
+    private sealed record HotspotSubject(
+        EntityId Id,
+        string DisplayName,
+        string Path,
+        IReadOnlyDictionary<HotspotMetricKind, double> Metrics);
+
+    private enum MetricDirection
+    {
+        HigherIsWorse = 0,
+        LowerIsWorse = 1,
+    }
+}

--- a/src/CodeLlmWiki.Query/ProjectStructure/HotspotRankingRow.cs
+++ b/src/CodeLlmWiki.Query/ProjectStructure/HotspotRankingRow.cs
@@ -1,0 +1,12 @@
+using CodeLlmWiki.Contracts.Identity;
+
+namespace CodeLlmWiki.Query.ProjectStructure;
+
+public sealed record HotspotRankingRow(
+    EntityId EntityId,
+    string DisplayName,
+    string Path,
+    double RawValue,
+    double NormalizedScore,
+    HotspotSeverityBand Severity,
+    int Rank);

--- a/src/CodeLlmWiki.Query/ProjectStructure/HotspotSeverityBand.cs
+++ b/src/CodeLlmWiki.Query/ProjectStructure/HotspotSeverityBand.cs
@@ -1,0 +1,10 @@
+namespace CodeLlmWiki.Query.ProjectStructure;
+
+public enum HotspotSeverityBand
+{
+    None = 0,
+    Low = 1,
+    Medium = 2,
+    High = 3,
+    Critical = 4,
+}

--- a/src/CodeLlmWiki.Query/ProjectStructure/HotspotSeverityThresholds.cs
+++ b/src/CodeLlmWiki.Query/ProjectStructure/HotspotSeverityThresholds.cs
@@ -1,0 +1,7 @@
+namespace CodeLlmWiki.Query.ProjectStructure;
+
+public sealed record HotspotSeverityThresholds(
+    double Low,
+    double Medium,
+    double High,
+    double Critical);

--- a/src/CodeLlmWiki.Query/ProjectStructure/HotspotTargetKind.cs
+++ b/src/CodeLlmWiki.Query/ProjectStructure/HotspotTargetKind.cs
@@ -1,0 +1,11 @@
+namespace CodeLlmWiki.Query.ProjectStructure;
+
+public enum HotspotTargetKind
+{
+    Method = 0,
+    Type = 1,
+    File = 2,
+    Namespace = 3,
+    Project = 4,
+    Repository = 5,
+}

--- a/src/CodeLlmWiki.Query/ProjectStructure/IHotspotRankingProjector.cs
+++ b/src/CodeLlmWiki.Query/ProjectStructure/IHotspotRankingProjector.cs
@@ -1,0 +1,8 @@
+using CodeLlmWiki.Contracts.Graph;
+
+namespace CodeLlmWiki.Query.ProjectStructure;
+
+public interface IHotspotRankingProjector
+{
+    HotspotRankingCatalog Project(HotspotRankingProjectionRequest request);
+}

--- a/src/CodeLlmWiki.Query/ProjectStructure/ProjectStructureQueryOptions.cs
+++ b/src/CodeLlmWiki.Query/ProjectStructure/ProjectStructureQueryOptions.cs
@@ -5,4 +5,6 @@ public sealed record ProjectStructureQueryOptions
     public static ProjectStructureQueryOptions Default { get; } = new();
 
     public StructuralMetricScopeFilter MetricScopeFilter { get; init; } = StructuralMetricScopeFilter.ProductionDefault;
+
+    public HotspotRankingOptions HotspotRanking { get; init; } = HotspotRankingOptions.Default;
 }

--- a/src/CodeLlmWiki.Query/ProjectStructure/ProjectStructureQueryService.cs
+++ b/src/CodeLlmWiki.Query/ProjectStructure/ProjectStructureQueryService.cs
@@ -314,6 +314,12 @@ public sealed class ProjectStructureQueryService : IProjectStructureQueryService
                 files,
                 declarations,
                 options.MetricScopeFilter));
+        var hotspots = new HotspotRankingProjector().Project(
+            new HotspotRankingProjectionRequest(
+                _triples,
+                declarations,
+                structuralMetrics,
+                options.HotspotRanking));
 
         return new ProjectStructureWikiModel(repository, solutions, projects, packages, files, submodules)
         {
@@ -322,6 +328,7 @@ public sealed class ProjectStructureQueryService : IProjectStructureQueryService
                 declarationUnknownDependencyUsage,
                 methodBodyUnknownDependencyUsage),
             StructuralMetrics = structuralMetrics,
+            Hotspots = hotspots,
         };
     }
 

--- a/src/CodeLlmWiki.Query/ProjectStructure/ProjectStructureWikiModel.cs
+++ b/src/CodeLlmWiki.Query/ProjectStructure/ProjectStructureWikiModel.cs
@@ -11,4 +11,5 @@ public sealed record ProjectStructureWikiModel(
     public DeclarationCatalog Declarations { get; init; } = DeclarationCatalog.Empty;
     public DependencyAttributionCatalog DependencyAttribution { get; init; } = DependencyAttributionCatalog.Empty;
     public StructuralMetricRollupCatalog StructuralMetrics { get; init; } = StructuralMetricRollupCatalog.Empty;
+    public HotspotRankingCatalog Hotspots { get; init; } = HotspotRankingCatalog.Empty;
 }

--- a/tests/CodeLlmWiki.Ingestion.Tests/HotspotRankingVerticalSliceTests.cs
+++ b/tests/CodeLlmWiki.Ingestion.Tests/HotspotRankingVerticalSliceTests.cs
@@ -103,6 +103,39 @@ public sealed class HotspotRankingVerticalSliceTests
         Assert.Contains(unbounded.Hotspots.CompositeRankings, x => x.Rows.Count > 1);
     }
 
+    [Fact]
+    public async Task Query_UsesDefaultTopNFallback_WhenTopNIsNotConfigured()
+    {
+        var fixture = await HotspotRankingFixture.CreateAsync();
+        var analyzer = new ProjectStructureAnalyzer(new StableIdGenerator());
+        var analysis = await analyzer.AnalyzeAsync(fixture.RepositoryPath, CancellationToken.None);
+        var query = new ProjectStructureQueryService(analysis.Triples);
+
+        var nullTopN = query.GetModel(
+            analysis.RepositoryId,
+            new ProjectStructureQueryOptions
+            {
+                MetricScopeFilter = StructuralMetricScopeFilter.AllCodeKinds,
+                HotspotRanking = new HotspotRankingOptions
+                {
+                    TopN = null,
+                },
+            });
+        Assert.Equal(25, nullTopN.Hotspots.EffectiveConfig.EffectiveTopN);
+
+        var zeroTopN = query.GetModel(
+            analysis.RepositoryId,
+            new ProjectStructureQueryOptions
+            {
+                MetricScopeFilter = StructuralMetricScopeFilter.AllCodeKinds,
+                HotspotRanking = new HotspotRankingOptions
+                {
+                    TopN = 0,
+                },
+            });
+        Assert.Equal(25, zeroTopN.Hotspots.EffectiveConfig.EffectiveTopN);
+    }
+
     private static string BuildFingerprint(HotspotRankingCatalog catalog)
     {
         var primary = catalog.PrimaryRankings

--- a/tests/CodeLlmWiki.Ingestion.Tests/HotspotRankingVerticalSliceTests.cs
+++ b/tests/CodeLlmWiki.Ingestion.Tests/HotspotRankingVerticalSliceTests.cs
@@ -1,0 +1,242 @@
+using System.Diagnostics;
+using CodeLlmWiki.Contracts.Identity;
+using CodeLlmWiki.Ingestion.ProjectStructure;
+using CodeLlmWiki.Query.ProjectStructure;
+
+namespace CodeLlmWiki.Ingestion.Tests;
+
+public sealed class HotspotRankingVerticalSliceTests
+{
+    [Fact]
+    public async Task Query_ProducesDeterministicPrimaryAndCompositeRankings()
+    {
+        var fixture = await HotspotRankingFixture.CreateAsync();
+        var analyzer = new ProjectStructureAnalyzer(new StableIdGenerator());
+        var analysis = await analyzer.AnalyzeAsync(fixture.RepositoryPath, CancellationToken.None);
+        var query = new ProjectStructureQueryService(analysis.Triples);
+
+        var options = new ProjectStructureQueryOptions
+        {
+            MetricScopeFilter = StructuralMetricScopeFilter.AllCodeKinds,
+        };
+
+        var first = query.GetModel(analysis.RepositoryId, options);
+        var second = query.GetModel(analysis.RepositoryId, options);
+
+        Assert.NotEmpty(first.Hotspots.PrimaryRankings);
+        Assert.NotEmpty(first.Hotspots.CompositeRankings);
+        Assert.Contains(first.Hotspots.PrimaryRankings, x => x.TargetKind == HotspotTargetKind.Method);
+        Assert.Contains(first.Hotspots.PrimaryRankings, x => x.TargetKind == HotspotTargetKind.Type);
+
+        Assert.Equal(BuildFingerprint(first.Hotspots), BuildFingerprint(second.Hotspots));
+    }
+
+    [Fact]
+    public async Task Query_ExposesEffectiveThresholdsAndWeights_WithOverrideSupport()
+    {
+        var fixture = await HotspotRankingFixture.CreateAsync();
+        var analyzer = new ProjectStructureAnalyzer(new StableIdGenerator());
+        var analysis = await analyzer.AnalyzeAsync(fixture.RepositoryPath, CancellationToken.None);
+        var query = new ProjectStructureQueryService(analysis.Triples);
+
+        var model = query.GetModel(
+            analysis.RepositoryId,
+            new ProjectStructureQueryOptions
+            {
+                MetricScopeFilter = StructuralMetricScopeFilter.AllCodeKinds,
+                HotspotRanking = new HotspotRankingOptions
+                {
+                    TopN = 4,
+                    CompositeWeightOverrides = new Dictionary<HotspotMetricKind, double>
+                    {
+                        [HotspotMetricKind.MethodCognitiveComplexity] = 5d,
+                    },
+                    ThresholdOverrides = new Dictionary<HotspotMetricKind, HotspotSeverityThresholds>
+                    {
+                        [HotspotMetricKind.MethodCyclomaticComplexity] = new HotspotSeverityThresholds(0.10d, 0.20d, 0.30d, 0.40d),
+                    },
+                },
+            });
+
+        var config = model.Hotspots.EffectiveConfig;
+        Assert.Equal(5d, config.CompositeWeights[HotspotMetricKind.MethodCognitiveComplexity]);
+        Assert.Equal(0.10d, config.Thresholds[HotspotMetricKind.MethodCyclomaticComplexity].Low);
+        Assert.Equal(4, config.EffectiveTopN);
+    }
+
+    [Fact]
+    public async Task Query_AppliesTopNByDefault_AndSupportsExplicitUnboundedOverride()
+    {
+        var fixture = await HotspotRankingFixture.CreateAsync();
+        var analyzer = new ProjectStructureAnalyzer(new StableIdGenerator());
+        var analysis = await analyzer.AnalyzeAsync(fixture.RepositoryPath, CancellationToken.None);
+        var query = new ProjectStructureQueryService(analysis.Triples);
+
+        var bounded = query.GetModel(
+            analysis.RepositoryId,
+            new ProjectStructureQueryOptions
+            {
+                MetricScopeFilter = StructuralMetricScopeFilter.AllCodeKinds,
+                HotspotRanking = new HotspotRankingOptions
+                {
+                    TopN = 1,
+                    Unbounded = false,
+                },
+            });
+
+        Assert.All(bounded.Hotspots.PrimaryRankings, x => Assert.True(x.Rows.Count <= 1));
+        Assert.All(bounded.Hotspots.CompositeRankings, x => Assert.True(x.Rows.Count <= 1));
+
+        var unbounded = query.GetModel(
+            analysis.RepositoryId,
+            new ProjectStructureQueryOptions
+            {
+                MetricScopeFilter = StructuralMetricScopeFilter.AllCodeKinds,
+                HotspotRanking = new HotspotRankingOptions
+                {
+                    TopN = 1,
+                    Unbounded = true,
+                },
+            });
+
+        Assert.Contains(unbounded.Hotspots.PrimaryRankings, x => x.Rows.Count > 1);
+        Assert.Contains(unbounded.Hotspots.CompositeRankings, x => x.Rows.Count > 1);
+    }
+
+    private static string BuildFingerprint(HotspotRankingCatalog catalog)
+    {
+        var primary = catalog.PrimaryRankings
+            .SelectMany(ranking => ranking.Rows.Select(row => $"P:{ranking.TargetKind}:{ranking.MetricKind}:{row.EntityId.Value}:{row.Rank}:{row.NormalizedScore:F8}:{row.Severity}"));
+        var composite = catalog.CompositeRankings
+            .SelectMany(ranking => ranking.Rows.Select(row => $"C:{ranking.TargetKind}:{row.EntityId.Value}:{row.Rank}:{row.CompositeScore:F8}:{row.Severity}"));
+
+        return string.Join("\n", primary.Concat(composite));
+    }
+
+    private sealed class HotspotRankingFixture
+    {
+        private HotspotRankingFixture(string repositoryPath)
+        {
+            RepositoryPath = repositoryPath;
+        }
+
+        public string RepositoryPath { get; }
+
+        public static async Task<HotspotRankingFixture> CreateAsync()
+        {
+            var root = Path.Combine(Path.GetTempPath(), $"codellmwiki-hotspot-ranking-{Guid.NewGuid():N}", "metric-repo");
+            Directory.CreateDirectory(root);
+
+            await File.WriteAllTextAsync(Path.Combine(root, "Sample.slnx"),
+                """
+                <Solution>
+                  <Project Path="src/App/App.csproj" />
+                </Solution>
+                """);
+
+            var appDir = Path.Combine(root, "src", "App");
+            Directory.CreateDirectory(appDir);
+            await File.WriteAllTextAsync(Path.Combine(appDir, "App.csproj"),
+                """
+                <Project Sdk="Microsoft.NET.Sdk">
+                  <PropertyGroup>
+                    <TargetFramework>net10.0</TargetFramework>
+                    <AssemblyName>Acme.Hotspots</AssemblyName>
+                  </PropertyGroup>
+                </Project>
+                """);
+
+            await File.WriteAllTextAsync(Path.Combine(appDir, "Hotspots.cs"),
+                """
+                namespace Acme.Hotspots;
+
+                public class DependencyA { }
+                public class DependencyB { }
+                public class DependencyC { }
+
+                public class TypeAlpha
+                {
+                    public int Simple(int x)
+                    {
+                        return x + 1;
+                    }
+
+                    public int Branchy(int x)
+                    {
+                        if (x > 10)
+                        {
+                            return x;
+                        }
+
+                        if (x % 2 == 0)
+                        {
+                            return x * 2;
+                        }
+
+                        return x + 3;
+                    }
+
+                    public int Looping(int x)
+                    {
+                        for (var i = 0; i < 3; i++)
+                        {
+                            x += i;
+                        }
+
+                        return x;
+                    }
+                }
+
+                public class TypeBeta
+                {
+                    private System.Collections.Generic.Dictionary<DependencyA, DependencyB> _map = new();
+
+                    public int Compute(DependencyC dep, int value)
+                    {
+                        _ = dep;
+                        if (value > 0 && value < 10)
+                        {
+                            return _map.Count + value;
+                        }
+
+                        return value;
+                    }
+                }
+                """);
+
+            RunGit(root, "init", "-b", "main");
+            RunGit(root, "config", "user.email", "test@example.com");
+            RunGit(root, "config", "user.name", "Test User");
+            RunGit(root, "add", ".");
+            RunGit(root, "commit", "-m", "initial");
+
+            return new HotspotRankingFixture(root);
+        }
+    }
+
+    private static void RunGit(string workingDirectory, params string[] arguments)
+    {
+        var info = new ProcessStartInfo("git")
+        {
+            WorkingDirectory = workingDirectory,
+            RedirectStandardOutput = true,
+            RedirectStandardError = true,
+            UseShellExecute = false,
+        };
+
+        foreach (var argument in arguments)
+        {
+            info.ArgumentList.Add(argument);
+        }
+
+        using var process = Process.Start(info) ?? throw new InvalidOperationException("Failed to start git process.");
+        var standardOutput = process.StandardOutput.ReadToEnd();
+        var standardError = process.StandardError.ReadToEnd();
+        process.WaitForExit();
+
+        if (process.ExitCode != 0)
+        {
+            throw new InvalidOperationException($"git {string.Join(' ', arguments)} failed with exit code {process.ExitCode}.{Environment.NewLine}{standardOutput}{Environment.NewLine}{standardError}");
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- add a query-layer hotspot ranking projector with deterministic per-metric primary rankings and composite secondary rankings
- implement repository-relative normalization and threshold-based severity bands
- support configurable weight/threshold overrides with effective config publication for auditability
- implement top-N row budgeting with explicit unbounded override
- project hotspot rankings into `ProjectStructureWikiModel` as additive data
- add vertical-slice tests for determinism, config override behavior, and budget semantics

## Verification
- `dotnet test tests/CodeLlmWiki.Ingestion.Tests/CodeLlmWiki.Ingestion.Tests.csproj --filter "FullyQualifiedName~HotspotRankingVerticalSliceTests"`
- `dotnet test CodeLlmWiki.slnx`

Closes #89
