### PR TITLE
PRD 007 #091: Determinism, parallelism, and performance hardening

### DIFF
--- a/src/CodeLlmWiki.Cli/CliApplication.cs
+++ b/src/CodeLlmWiki.Cli/CliApplication.cs
@@ -55,6 +55,8 @@ public sealed class CliApplication
 
         var maxMergeEntriesPerFile = options.MaxMergeEntriesPerFile
             ?? config.MaxMergeEntriesPerFile;
+        var metricComputationMdop = options.MetricComputationMaxDegreeOfParallelism
+            ?? config.MetricComputationMaxDegreeOfParallelism;
 
         var request = new IngestionRunRequest(
             RepositoryPath: options.RepositoryPath,
@@ -73,7 +75,8 @@ public sealed class CliApplication
                 StartedAtUtc: startedAtUtc,
                 CompletedAtUtc: completedAtUtc,
                 RunResult: result,
-                MaxMergeEntriesPerFile: maxMergeEntriesPerFile),
+                MaxMergeEntriesPerFile: maxMergeEntriesPerFile,
+                MetricComputationMaxDegreeOfParallelism: metricComputationMdop),
             cancellationToken);
 
         if (!publication.Succeeded)

--- a/src/CodeLlmWiki.Cli/Commands/IngestOptions.cs
+++ b/src/CodeLlmWiki.Cli/Commands/IngestOptions.cs
@@ -22,4 +22,7 @@ public sealed class IngestOptions
 
     [Option('m', "max-merge-entries-per-file", Required = false, HelpText = "Caps merge-to-mainline entries per file in wiki output.")]
     public int? MaxMergeEntriesPerFile { get; init; }
+
+    [Option('d', "metric-mdop", Required = false, HelpText = "Max degree of parallelism for metric/rollup computation.")]
+    public int? MetricComputationMaxDegreeOfParallelism { get; init; }
 }

--- a/src/CodeLlmWiki.Cli/Config/IngestionCliConfig.cs
+++ b/src/CodeLlmWiki.Cli/Config/IngestionCliConfig.cs
@@ -6,7 +6,8 @@ public sealed record IngestionCliConfig(
     string? OntologyPath,
     bool? AllowPartialSuccess,
     string? OutputRoot,
-    [property: JsonPropertyName("max_merge_entries_per_file")] int? MaxMergeEntriesPerFile)
+    [property: JsonPropertyName("max_merge_entries_per_file")] int? MaxMergeEntriesPerFile,
+    [property: JsonPropertyName("metric_computation_max_degree_of_parallelism")] int? MetricComputationMaxDegreeOfParallelism)
 {
-    public static readonly IngestionCliConfig Empty = new(null, null, null, null);
+    public static readonly IngestionCliConfig Empty = new(null, null, null, null, null);
 }

--- a/src/CodeLlmWiki.Cli/Features/Ingest/IngestionArtifactPublishRequest.cs
+++ b/src/CodeLlmWiki.Cli/Features/Ingest/IngestionArtifactPublishRequest.cs
@@ -8,4 +8,5 @@ public sealed record IngestionArtifactPublishRequest(
     DateTimeOffset StartedAtUtc,
     DateTimeOffset CompletedAtUtc,
     IngestionRunResult RunResult,
-    int? MaxMergeEntriesPerFile = null);
+    int? MaxMergeEntriesPerFile = null,
+    int? MetricComputationMaxDegreeOfParallelism = null);

--- a/src/CodeLlmWiki.Cli/Features/Ingest/IngestionArtifactPublisher.cs
+++ b/src/CodeLlmWiki.Cli/Features/Ingest/IngestionArtifactPublisher.cs
@@ -47,7 +47,13 @@ public sealed class IngestionArtifactPublisher : IIngestionArtifactPublisher
             if (request.RunResult.RepositoryId != default && request.RunResult.Triples.Count > 0)
             {
                 var query = new ProjectStructureQueryService(request.RunResult.Triples);
-                var model = query.GetModel(request.RunResult.RepositoryId);
+                var queryOptions = request.MetricComputationMaxDegreeOfParallelism is { } maxDegreeOfParallelism
+                    ? ProjectStructureQueryOptions.Default with
+                    {
+                        MetricComputationMaxDegreeOfParallelism = maxDegreeOfParallelism,
+                    }
+                    : ProjectStructureQueryOptions.Default;
+                var model = query.GetModel(request.RunResult.RepositoryId, queryOptions);
                 metricsSummary = BuildMetricsSummary(model);
                 var renderer = new ProjectStructureWikiRenderer();
                 var pages = renderer.Render(model, request.MaxMergeEntriesPerFile)

--- a/src/CodeLlmWiki.Query/ProjectStructure/HotspotRankingProjectionRequest.cs
+++ b/src/CodeLlmWiki.Query/ProjectStructure/HotspotRankingProjectionRequest.cs
@@ -6,4 +6,5 @@ public sealed record HotspotRankingProjectionRequest(
     IReadOnlyList<SemanticTriple> Triples,
     DeclarationCatalog Declarations,
     StructuralMetricRollupCatalog StructuralMetrics,
-    HotspotRankingOptions Options);
+    HotspotRankingOptions Options,
+    int MaxDegreeOfParallelism);

--- a/src/CodeLlmWiki.Query/ProjectStructure/HotspotRankingProjector.cs
+++ b/src/CodeLlmWiki.Query/ProjectStructure/HotspotRankingProjector.cs
@@ -38,54 +38,26 @@ public sealed class HotspotRankingProjector : IHotspotRankingProjector
         var effectiveWeights = ResolveWeights(request.Options.CompositeWeightOverrides);
         var effectiveThresholds = ResolveThresholds(request.Options.ThresholdOverrides);
         var subjectsByKind = BuildSubjectsByKind(request.Triples, request.Declarations, request.StructuralMetrics);
-
-        var primaryRankings = new List<HotspotMetricRankingNode>();
-        var compositeRankings = new List<HotspotCompositeRankingNode>();
-
-        foreach (var targetGroup in subjectsByKind.OrderBy(x => x.Key))
-        {
-            var targetKind = targetGroup.Key;
-            var subjects = targetGroup.Value;
-            if (subjects.Count == 0)
-            {
-                continue;
-            }
-
-            var metricKinds = subjects
-                .SelectMany(subject => subject.Metrics.Keys)
-                .Distinct()
-                .OrderBy(x => x)
-                .ToArray();
-            if (metricKinds.Length == 0)
-            {
-                continue;
-            }
-
-            var normalizedByMetricByEntityId = new Dictionary<HotspotMetricKind, IReadOnlyDictionary<EntityId, double>>();
-            foreach (var metricKind in metricKinds)
-            {
-                var rows = BuildMetricRows(
-                    subjects,
-                    metricKind,
-                    effectiveThresholds[metricKind],
-                    effectiveTopN,
-                    request.Options.Unbounded,
-                    out var normalizedByEntityId);
-
-                normalizedByMetricByEntityId[metricKind] = normalizedByEntityId;
-                primaryRankings.Add(new HotspotMetricRankingNode(targetKind, metricKind, rows));
-            }
-
-            var compositeRows = BuildCompositeRows(
-                subjects,
-                metricKinds,
-                normalizedByMetricByEntityId,
-                effectiveWeights,
-                effectiveThresholds[HotspotMetricKind.Composite],
+        var maxDegreeOfParallelism = NormalizeMaxDegreeOfParallelism(request.MaxDegreeOfParallelism);
+        var targetGroups = subjectsByKind
+            .OrderBy(x => x.Key)
+            .ToArray();
+        var rankingResults = BuildInParallel(
+            targetGroups,
+            maxDegreeOfParallelism,
+            targetGroup => BuildTargetRankingResult(
+                targetGroup,
+                effectiveThresholds,
                 effectiveTopN,
-                request.Options.Unbounded);
-            compositeRankings.Add(new HotspotCompositeRankingNode(targetKind, compositeRows));
-        }
+                request.Options.Unbounded,
+                effectiveWeights));
+
+        var primaryRankings = rankingResults
+            .SelectMany(x => x.PrimaryRankings)
+            .ToArray();
+        var compositeRankings = rankingResults
+            .SelectMany(x => x.CompositeRankings)
+            .ToArray();
 
         return new HotspotRankingCatalog(
             new HotspotRankingEffectiveConfig(
@@ -100,6 +72,59 @@ public sealed class HotspotRankingProjector : IHotspotRankingProjector
             compositeRankings
                 .OrderBy(x => x.TargetKind)
                 .ToArray());
+    }
+
+    private static TargetRankingResult BuildTargetRankingResult(
+        KeyValuePair<HotspotTargetKind, IReadOnlyList<HotspotSubject>> targetGroup,
+        IReadOnlyDictionary<HotspotMetricKind, HotspotSeverityThresholds> effectiveThresholds,
+        int effectiveTopN,
+        bool unbounded,
+        IReadOnlyDictionary<HotspotMetricKind, double> effectiveWeights)
+    {
+        var targetKind = targetGroup.Key;
+        var subjects = targetGroup.Value;
+        if (subjects.Count == 0)
+        {
+            return TargetRankingResult.Empty;
+        }
+
+        var metricKinds = subjects
+            .SelectMany(subject => subject.Metrics.Keys)
+            .Distinct()
+            .OrderBy(x => x)
+            .ToArray();
+        if (metricKinds.Length == 0)
+        {
+            return TargetRankingResult.Empty;
+        }
+
+        var primaryRankings = new List<HotspotMetricRankingNode>(metricKinds.Length);
+        var normalizedByMetricByEntityId = new Dictionary<HotspotMetricKind, IReadOnlyDictionary<EntityId, double>>();
+        foreach (var metricKind in metricKinds)
+        {
+            var rows = BuildMetricRows(
+                subjects,
+                metricKind,
+                effectiveThresholds[metricKind],
+                effectiveTopN,
+                unbounded,
+                out var normalizedByEntityId);
+
+            normalizedByMetricByEntityId[metricKind] = normalizedByEntityId;
+            primaryRankings.Add(new HotspotMetricRankingNode(targetKind, metricKind, rows));
+        }
+
+        var compositeRows = BuildCompositeRows(
+            subjects,
+            metricKinds,
+            normalizedByMetricByEntityId,
+            effectiveWeights,
+            effectiveThresholds[HotspotMetricKind.Composite],
+            effectiveTopN,
+            unbounded);
+        var compositeRanking = new HotspotCompositeRankingNode(targetKind, compositeRows);
+
+        return new TargetRankingResult(primaryRankings, [compositeRanking]);
     }
 
     private static IReadOnlyList<HotspotRankingRow> BuildMetricRows(
@@ -286,6 +311,40 @@ public sealed class HotspotRankingProjector : IHotspotRankingProjector
         }
 
         return configuredTopN.Value;
+    }
+
+    private static TOut[] BuildInParallel<TIn, TOut>(
+        IReadOnlyList<TIn> source,
+        int maxDegreeOfParallelism,
+        Func<TIn, TOut> projector)
+    {
+        if (source.Count == 0)
+        {
+            return [];
+        }
+
+        if (maxDegreeOfParallelism <= 1 || source.Count == 1)
+        {
+            return source.Select(projector).ToArray();
+        }
+
+        var output = new TOut[source.Count];
+        Parallel.For(
+            0,
+            source.Count,
+            new ParallelOptions { MaxDegreeOfParallelism = maxDegreeOfParallelism },
+            index => output[index] = projector(source[index]));
+        return output;
+    }
+
+    private static int NormalizeMaxDegreeOfParallelism(int configured)
+    {
+        if (configured <= 0)
+        {
+            return Environment.ProcessorCount;
+        }
+
+        return configured;
     }
 
     private static IReadOnlyDictionary<HotspotMetricKind, double> ResolveWeights(
@@ -523,6 +582,13 @@ public sealed class HotspotRankingProjector : IHotspotRankingProjector
         string DisplayName,
         string Path,
         IReadOnlyDictionary<HotspotMetricKind, double> Metrics);
+
+    private sealed record TargetRankingResult(
+        IReadOnlyList<HotspotMetricRankingNode> PrimaryRankings,
+        IReadOnlyList<HotspotCompositeRankingNode> CompositeRankings)
+    {
+        public static TargetRankingResult Empty { get; } = new([], []);
+    }
 
     private enum MetricDirection
     {

--- a/src/CodeLlmWiki.Query/ProjectStructure/ProjectStructureQueryOptions.cs
+++ b/src/CodeLlmWiki.Query/ProjectStructure/ProjectStructureQueryOptions.cs
@@ -7,4 +7,6 @@ public sealed record ProjectStructureQueryOptions
     public StructuralMetricScopeFilter MetricScopeFilter { get; init; } = StructuralMetricScopeFilter.ProductionDefault;
 
     public HotspotRankingOptions HotspotRanking { get; init; } = HotspotRankingOptions.Default;
+
+    public int MetricComputationMaxDegreeOfParallelism { get; init; } = 1;
 }

--- a/src/CodeLlmWiki.Query/ProjectStructure/ProjectStructureQueryService.cs
+++ b/src/CodeLlmWiki.Query/ProjectStructure/ProjectStructureQueryService.cs
@@ -313,13 +313,15 @@ public sealed class ProjectStructureQueryService : IProjectStructureQueryService
                 projects,
                 files,
                 declarations,
-                options.MetricScopeFilter));
+                options.MetricScopeFilter,
+                options.MetricComputationMaxDegreeOfParallelism));
         var hotspots = new HotspotRankingProjector().Project(
             new HotspotRankingProjectionRequest(
                 _triples,
                 declarations,
                 structuralMetrics,
-                options.HotspotRanking));
+                options.HotspotRanking,
+                options.MetricComputationMaxDegreeOfParallelism));
 
         return new ProjectStructureWikiModel(repository, solutions, projects, packages, files, submodules)
         {

--- a/src/CodeLlmWiki.Query/ProjectStructure/StructuralMetricRollupProjectionRequest.cs
+++ b/src/CodeLlmWiki.Query/ProjectStructure/StructuralMetricRollupProjectionRequest.cs
@@ -9,4 +9,5 @@ public sealed record StructuralMetricRollupProjectionRequest(
     IReadOnlyList<ProjectNode> Projects,
     IReadOnlyList<FileNode> Files,
     DeclarationCatalog Declarations,
-    StructuralMetricScopeFilter ScopeFilter);
+    StructuralMetricScopeFilter ScopeFilter,
+    int MaxDegreeOfParallelism);

--- a/src/CodeLlmWiki.Query/ProjectStructure/StructuralMetricRollupProjector.cs
+++ b/src/CodeLlmWiki.Query/ProjectStructure/StructuralMetricRollupProjector.cs
@@ -84,11 +84,16 @@ public sealed class StructuralMetricRollupProjector : IStructuralMetricRollupPro
                     .DistinctBy(v => v.Id)
                     .ToArray());
 
+        var maxDegreeOfParallelism = NormalizeMaxDegreeOfParallelism(request.MaxDegreeOfParallelism);
         var namespaceDescendants = BuildNamespaceDescendants(request.Declarations.Namespaces);
-        var files = request.Files
+        var orderedFiles = request.Files
             .OrderBy(x => x.Path, StringComparer.Ordinal)
             .ThenBy(x => x.Id.Value, StringComparer.Ordinal)
-            .Select(file =>
+            .ToArray();
+        var files = BuildInParallel(
+            orderedFiles,
+            maxDegreeOfParallelism,
+            file =>
             {
                 var methods = methodsByFileId.TryGetValue(file.Id, out var fileMethods)
                     ? fileMethods
@@ -108,13 +113,16 @@ public sealed class StructuralMetricRollupProjector : IStructuralMetricRollupPro
                     file.Path,
                     fileCodeKinds[file.Id],
                     rollup);
-            })
-            .ToArray();
+            });
 
-        var projects = request.Projects
+        var orderedProjects = request.Projects
             .OrderBy(x => x.Path, StringComparer.Ordinal)
             .ThenBy(x => x.Id.Value, StringComparer.Ordinal)
-            .Select(project =>
+            .ToArray();
+        var projects = BuildInParallel(
+            orderedProjects,
+            maxDegreeOfParallelism,
+            project =>
             {
                 var methods = methodsByProjectId.TryGetValue(project.Id, out var projectMethods)
                     ? projectMethods
@@ -134,13 +142,16 @@ public sealed class StructuralMetricRollupProjector : IStructuralMetricRollupPro
                     project.Path,
                     projectCodeKinds[project.Id],
                     rollup);
-            })
-            .ToArray();
+            });
 
-        var namespaces = request.Declarations.Namespaces
+        var orderedNamespaces = request.Declarations.Namespaces
             .OrderBy(x => x.Path, StringComparer.Ordinal)
             .ThenBy(x => x.Id.Value, StringComparer.Ordinal)
-            .Select(namespaceNode =>
+            .ToArray();
+        var namespaces = BuildInParallel(
+            orderedNamespaces,
+            maxDegreeOfParallelism,
+            namespaceNode =>
             {
                 var directMethods = methodsByNamespaceId.TryGetValue(namespaceNode.Id, out var directMethodSet)
                     ? directMethodSet
@@ -176,8 +187,7 @@ public sealed class StructuralMetricRollupProjector : IStructuralMetricRollupPro
                     namespaceNode.ParentNamespaceId,
                     direct,
                     recursive);
-            })
-            .ToArray();
+            });
 
         var repositoryMethods = ApplyScopeFilter(methodContexts, request.ScopeFilter);
         var repositoryTypes = ApplyScopeFilter(typeContexts, request.ScopeFilter);
@@ -188,6 +198,40 @@ public sealed class StructuralMetricRollupProjector : IStructuralMetricRollupPro
             repositoryRaw with { IncludedInRanking = repositoryIncluded });
 
         return new StructuralMetricRollupCatalog(repository, projects, namespaces, files, request.ScopeFilter);
+    }
+
+    private static TOut[] BuildInParallel<TIn, TOut>(
+        IReadOnlyList<TIn> source,
+        int maxDegreeOfParallelism,
+        Func<TIn, TOut> projector)
+    {
+        if (source.Count == 0)
+        {
+            return [];
+        }
+
+        if (maxDegreeOfParallelism <= 1 || source.Count == 1)
+        {
+            return source.Select(projector).ToArray();
+        }
+
+        var output = new TOut[source.Count];
+        Parallel.For(
+            0,
+            source.Count,
+            new ParallelOptions { MaxDegreeOfParallelism = maxDegreeOfParallelism },
+            index => output[index] = projector(source[index]));
+        return output;
+    }
+
+    private static int NormalizeMaxDegreeOfParallelism(int configured)
+    {
+        if (configured <= 0)
+        {
+            return Environment.ProcessorCount;
+        }
+
+        return configured;
     }
 
     private static IReadOnlyList<MethodMetricContext> ApplyScopeFilter(

--- a/tests/CodeLlmWiki.Cli.Tests/CliApplicationTests.cs
+++ b/tests/CodeLlmWiki.Cli.Tests/CliApplicationTests.cs
@@ -93,7 +93,8 @@ public sealed class CliApplicationTests
             """
             {
               "ontologyPath": "./ontology/ontology.v1.yaml",
-              "max_merge_entries_per_file": 7
+              "max_merge_entries_per_file": 7,
+              "metric_computation_max_degree_of_parallelism": 5
             }
             """);
 
@@ -107,12 +108,14 @@ public sealed class CliApplicationTests
                 "--path", ".",
                 "--config", configPath,
                 "--max-merge-entries-per-file", "3",
+                "--metric-mdop", "4",
             ],
             CancellationToken.None);
 
         Assert.Equal(0, exitCode);
         Assert.NotNull(publisher.LastRequest);
         Assert.Equal(3, publisher.LastRequest!.MaxMergeEntriesPerFile);
+        Assert.Equal(4, publisher.LastRequest.MetricComputationMaxDegreeOfParallelism);
     }
 
     private static string WriteTempFile(string content)

--- a/tests/CodeLlmWiki.Ingestion.Tests/HotspotRankingVerticalSliceTests.cs
+++ b/tests/CodeLlmWiki.Ingestion.Tests/HotspotRankingVerticalSliceTests.cs
@@ -172,6 +172,35 @@ public sealed class HotspotRankingVerticalSliceTests
         Assert.Contains("(hotspots/repository.md)", repositoryPage.Markdown, StringComparison.Ordinal);
     }
 
+    [Fact]
+    public async Task Query_HotspotRankingsRemainDeterministic_AcrossConfiguredConcurrencyLevels()
+    {
+        var fixture = await HotspotRankingFixture.CreateAsync();
+        var analyzer = new ProjectStructureAnalyzer(new StableIdGenerator());
+        var analysis = await analyzer.AnalyzeAsync(fixture.RepositoryPath, CancellationToken.None);
+        var query = new ProjectStructureQueryService(analysis.Triples);
+
+        var serialModel = query.GetModel(
+            analysis.RepositoryId,
+            new ProjectStructureQueryOptions
+            {
+                MetricScopeFilter = StructuralMetricScopeFilter.AllCodeKinds,
+                MetricComputationMaxDegreeOfParallelism = 1,
+            });
+
+        var parallelModel = query.GetModel(
+            analysis.RepositoryId,
+            new ProjectStructureQueryOptions
+            {
+                MetricScopeFilter = StructuralMetricScopeFilter.AllCodeKinds,
+                MetricComputationMaxDegreeOfParallelism = 4,
+            });
+
+        Assert.Equal(
+            BuildFingerprint(serialModel.Hotspots),
+            BuildFingerprint(parallelModel.Hotspots));
+    }
+
     private static string BuildFingerprint(HotspotRankingCatalog catalog)
     {
         var primary = catalog.PrimaryRankings

--- a/tests/CodeLlmWiki.Ingestion.Tests/HotspotRankingVerticalSliceTests.cs
+++ b/tests/CodeLlmWiki.Ingestion.Tests/HotspotRankingVerticalSliceTests.cs
@@ -195,10 +195,20 @@ public sealed class HotspotRankingVerticalSliceTests
                 MetricScopeFilter = StructuralMetricScopeFilter.AllCodeKinds,
                 MetricComputationMaxDegreeOfParallelism = 4,
             });
+        var secondParallelModel = query.GetModel(
+            analysis.RepositoryId,
+            new ProjectStructureQueryOptions
+            {
+                MetricScopeFilter = StructuralMetricScopeFilter.AllCodeKinds,
+                MetricComputationMaxDegreeOfParallelism = 4,
+            });
 
         Assert.Equal(
             BuildFingerprint(serialModel.Hotspots),
             BuildFingerprint(parallelModel.Hotspots));
+        Assert.Equal(
+            BuildFingerprint(parallelModel.Hotspots),
+            BuildFingerprint(secondParallelModel.Hotspots));
     }
 
     private static string BuildFingerprint(HotspotRankingCatalog catalog)

--- a/tests/CodeLlmWiki.Ingestion.Tests/MetricEngineVersionPinningTests.cs
+++ b/tests/CodeLlmWiki.Ingestion.Tests/MetricEngineVersionPinningTests.cs
@@ -1,0 +1,60 @@
+using System.Xml.Linq;
+
+namespace CodeLlmWiki.Ingestion.Tests;
+
+public sealed class MetricEngineVersionPinningTests
+{
+    [Fact]
+    public void PackageReferences_ArePinnedToExplicitVersions()
+    {
+        var repositoryRoot = ResolveRepositoryRoot();
+        var projectFiles = Directory
+            .EnumerateFiles(Path.Combine(repositoryRoot, "src"), "*.csproj", SearchOption.AllDirectories)
+            .OrderBy(path => path, StringComparer.Ordinal)
+            .ToArray();
+
+        Assert.NotEmpty(projectFiles);
+
+        foreach (var projectFile in projectFiles)
+        {
+            var document = XDocument.Load(projectFile);
+            var packageReferences = document
+                .Descendants("PackageReference")
+                .Select(element => new
+                {
+                    Include = element.Attribute("Include")?.Value ?? string.Empty,
+                    Version = element.Attribute("Version")?.Value
+                        ?? element.Element("Version")?.Value
+                        ?? string.Empty,
+                })
+                .ToArray();
+
+            foreach (var packageReference in packageReferences)
+            {
+                Assert.False(string.IsNullOrWhiteSpace(packageReference.Version), $"Package '{packageReference.Include}' in '{projectFile}' must specify an explicit version.");
+                Assert.DoesNotContain("*", packageReference.Version);
+                Assert.DoesNotContain("[", packageReference.Version);
+                Assert.DoesNotContain("]", packageReference.Version);
+                Assert.DoesNotContain(",", packageReference.Version);
+                Assert.Matches(@"^\d+\.\d+\.\d+([\-+][0-9A-Za-z\.-]+)?$", packageReference.Version);
+            }
+        }
+    }
+
+    private static string ResolveRepositoryRoot()
+    {
+        var current = new DirectoryInfo(AppContext.BaseDirectory);
+        while (current is not null)
+        {
+            if (Directory.Exists(Path.Combine(current.FullName, "src"))
+                && Directory.Exists(Path.Combine(current.FullName, "tests")))
+            {
+                return current.FullName;
+            }
+
+            current = current.Parent;
+        }
+
+        throw new InvalidOperationException("Repository root could not be resolved.");
+    }
+}

--- a/tests/CodeLlmWiki.Ingestion.Tests/MetricPerformanceBudgetValidationTests.cs
+++ b/tests/CodeLlmWiki.Ingestion.Tests/MetricPerformanceBudgetValidationTests.cs
@@ -1,0 +1,154 @@
+using System.Diagnostics;
+using CodeLlmWiki.Contracts.Identity;
+using CodeLlmWiki.Ingestion.ProjectStructure;
+using CodeLlmWiki.Query.ProjectStructure;
+
+namespace CodeLlmWiki.Ingestion.Tests;
+
+public sealed class MetricPerformanceBudgetValidationTests
+{
+    [Fact]
+    public async Task QueryPipeline_StaysWithinPerformanceBudget_OnRepresentativeFixture()
+    {
+        var fixture = await PerformanceFixture.CreateAsync();
+        var analyzer = new ProjectStructureAnalyzer(new StableIdGenerator());
+        var analysis = await analyzer.AnalyzeAsync(fixture.RepositoryPath, CancellationToken.None);
+        var query = new ProjectStructureQueryService(analysis.Triples);
+
+        var serialWatch = Stopwatch.StartNew();
+        var serialModel = query.GetModel(
+            analysis.RepositoryId,
+            new ProjectStructureQueryOptions
+            {
+                MetricScopeFilter = StructuralMetricScopeFilter.AllCodeKinds,
+                MetricComputationMaxDegreeOfParallelism = 1,
+            });
+        serialWatch.Stop();
+
+        var parallelWatch = Stopwatch.StartNew();
+        var parallelModel = query.GetModel(
+            analysis.RepositoryId,
+            new ProjectStructureQueryOptions
+            {
+                MetricScopeFilter = StructuralMetricScopeFilter.AllCodeKinds,
+                MetricComputationMaxDegreeOfParallelism = 4,
+            });
+        parallelWatch.Stop();
+
+        Assert.NotEmpty(serialModel.Hotspots.PrimaryRankings);
+        Assert.NotEmpty(parallelModel.Hotspots.PrimaryRankings);
+
+        Assert.True(serialWatch.ElapsedMilliseconds < 15_000, $"Serial query exceeded budget: {serialWatch.ElapsedMilliseconds}ms");
+        Assert.True(parallelWatch.ElapsedMilliseconds < 15_000, $"Parallel query exceeded budget: {parallelWatch.ElapsedMilliseconds}ms");
+        Assert.True(parallelWatch.ElapsedMilliseconds <= (serialWatch.ElapsedMilliseconds * 3) + 500,
+            $"Parallel query overhead exceeded tolerance. serial={serialWatch.ElapsedMilliseconds}ms parallel={parallelWatch.ElapsedMilliseconds}ms");
+    }
+
+    private sealed class PerformanceFixture
+    {
+        private PerformanceFixture(string repositoryPath)
+        {
+            RepositoryPath = repositoryPath;
+        }
+
+        public string RepositoryPath { get; }
+
+        public static async Task<PerformanceFixture> CreateAsync()
+        {
+            var root = Path.Combine(Path.GetTempPath(), $"codellmwiki-performance-{Guid.NewGuid():N}", "perf-repo");
+            Directory.CreateDirectory(root);
+
+            await File.WriteAllTextAsync(Path.Combine(root, "Perf.slnx"),
+                """
+                <Solution>
+                  <Project Path="src/App/App.csproj" />
+                </Solution>
+                """);
+
+            var appDir = Path.Combine(root, "src", "App");
+            Directory.CreateDirectory(appDir);
+            await File.WriteAllTextAsync(Path.Combine(appDir, "App.csproj"),
+                """
+                <Project Sdk="Microsoft.NET.Sdk">
+                  <PropertyGroup>
+                    <TargetFramework>net10.0</TargetFramework>
+                    <AssemblyName>Acme.Performance</AssemblyName>
+                  </PropertyGroup>
+                </Project>
+                """);
+
+            var source = BuildSourceText();
+            await File.WriteAllTextAsync(Path.Combine(appDir, "GeneratedWorkload.cs"), source);
+
+            RunGit(root, "init", "-b", "main");
+            RunGit(root, "config", "user.email", "test@example.com");
+            RunGit(root, "config", "user.name", "Test User");
+            RunGit(root, "add", ".");
+            RunGit(root, "commit", "-m", "initial");
+
+            return new PerformanceFixture(root);
+        }
+
+        private static string BuildSourceText()
+        {
+            var sb = new System.Text.StringBuilder();
+            sb.AppendLine("namespace Acme.Performance;");
+            sb.AppendLine();
+            sb.AppendLine("public class SharedDependency { }");
+            sb.AppendLine();
+
+            for (var i = 0; i < 60; i++)
+            {
+                sb.AppendLine($"public class Worker{i:000}");
+                sb.AppendLine("{");
+                sb.AppendLine("    private readonly SharedDependency _dependency = new();");
+                sb.AppendLine();
+                sb.AppendLine("    public int Execute(int input)");
+                sb.AppendLine("    {");
+                sb.AppendLine("        var value = input;");
+                sb.AppendLine("        if (value > 10)");
+                sb.AppendLine("        {");
+                sb.AppendLine("            value += 2;");
+                sb.AppendLine("        }");
+                sb.AppendLine();
+                sb.AppendLine("        for (var i = 0; i < 3; i++)");
+                sb.AppendLine("        {");
+                sb.AppendLine("            value += i;");
+                sb.AppendLine("        }");
+                sb.AppendLine();
+                sb.AppendLine("        return value;");
+                sb.AppendLine("    }");
+                sb.AppendLine("}");
+                sb.AppendLine();
+            }
+
+            return sb.ToString();
+        }
+    }
+
+    private static void RunGit(string workingDirectory, params string[] arguments)
+    {
+        var info = new ProcessStartInfo("git")
+        {
+            WorkingDirectory = workingDirectory,
+            RedirectStandardOutput = true,
+            RedirectStandardError = true,
+            UseShellExecute = false,
+        };
+
+        foreach (var argument in arguments)
+        {
+            info.ArgumentList.Add(argument);
+        }
+
+        using var process = Process.Start(info) ?? throw new InvalidOperationException("Failed to start git process.");
+        var standardOutput = process.StandardOutput.ReadToEnd();
+        var standardError = process.StandardError.ReadToEnd();
+        process.WaitForExit();
+
+        if (process.ExitCode != 0)
+        {
+            throw new InvalidOperationException($"git {string.Join(' ', arguments)} failed with exit code {process.ExitCode}.{Environment.NewLine}{standardOutput}{Environment.NewLine}{standardError}");
+        }
+    }
+}

--- a/tests/CodeLlmWiki.Ingestion.Tests/StructuralMetricRollupVerticalSliceTests.cs
+++ b/tests/CodeLlmWiki.Ingestion.Tests/StructuralMetricRollupVerticalSliceTests.cs
@@ -122,10 +122,19 @@ public sealed class StructuralMetricRollupVerticalSliceTests
             {
                 MetricComputationMaxDegreeOfParallelism = 4,
             });
+        var secondParallelModel = query.GetModel(
+            analysis.RepositoryId,
+            new ProjectStructureQueryOptions
+            {
+                MetricComputationMaxDegreeOfParallelism = 4,
+            });
 
         Assert.Equal(
             BuildFingerprint(serialModel.StructuralMetrics),
             BuildFingerprint(parallelModel.StructuralMetrics));
+        Assert.Equal(
+            BuildFingerprint(parallelModel.StructuralMetrics),
+            BuildFingerprint(secondParallelModel.StructuralMetrics));
     }
 
     private static string BuildFingerprint(StructuralMetricRollupCatalog catalog)

--- a/tests/CodeLlmWiki.Ingestion.Tests/StructuralMetricRollupVerticalSliceTests.cs
+++ b/tests/CodeLlmWiki.Ingestion.Tests/StructuralMetricRollupVerticalSliceTests.cs
@@ -101,6 +101,33 @@ public sealed class StructuralMetricRollupVerticalSliceTests
         Assert.False(contractsNamespace.Direct.IncludedInRanking);
     }
 
+    [Fact]
+    public async Task Query_RollupsRemainDeterministic_AcrossConfiguredConcurrencyLevels()
+    {
+        var fixture = await StructuralMetricFixture.CreateAsync();
+        var analyzer = new ProjectStructureAnalyzer(new StableIdGenerator());
+        var analysis = await analyzer.AnalyzeAsync(fixture.RepositoryPath, CancellationToken.None);
+        var query = new ProjectStructureQueryService(analysis.Triples);
+
+        var serialModel = query.GetModel(
+            analysis.RepositoryId,
+            new ProjectStructureQueryOptions
+            {
+                MetricComputationMaxDegreeOfParallelism = 1,
+            });
+
+        var parallelModel = query.GetModel(
+            analysis.RepositoryId,
+            new ProjectStructureQueryOptions
+            {
+                MetricComputationMaxDegreeOfParallelism = 4,
+            });
+
+        Assert.Equal(
+            BuildFingerprint(serialModel.StructuralMetrics),
+            BuildFingerprint(parallelModel.StructuralMetrics));
+    }
+
     private static string BuildFingerprint(StructuralMetricRollupCatalog catalog)
     {
         static string SerializeRollup(StructuralMetricScopeRollup rollup)


### PR DESCRIPTION
## Summary
- add configurable bounded parallel metric computation (`MetricComputationMaxDegreeOfParallelism`) in structural rollup and hotspot ranking projectors
- preserve deterministic post-merge ordering by index-stable parallel projection and deterministic final ordering
- add deterministic concurrency regression tests for structural rollups and hotspot rankings (`mdop=1` vs `mdop=4`)
- add package-version pinning regression test to prevent floating/range package versions in `src/*.csproj`
- add performance budget validation test on a representative synthetic repository fixture

## Verification
- `dotnet test tests/CodeLlmWiki.Ingestion.Tests/CodeLlmWiki.Ingestion.Tests.csproj --filter "FullyQualifiedName~StructuralMetricRollupVerticalSliceTests|FullyQualifiedName~HotspotRankingVerticalSliceTests|FullyQualifiedName~MetricEngineVersionPinningTests|FullyQualifiedName~MetricPerformanceBudgetValidationTests"`
- `dotnet test CodeLlmWiki.slnx`

Closes #91
