### PR TITLE
Implement PRD 010 phase 2 project-scoped semantic call resolution (#121)

### DIFF
--- a/src/CodeLlmWiki.Ingestion/ProjectStructure/CallResolution/IProjectScopedCompilationProvider.cs
+++ b/src/CodeLlmWiki.Ingestion/ProjectStructure/CallResolution/IProjectScopedCompilationProvider.cs
@@ -1,0 +1,6 @@
+namespace CodeLlmWiki.Ingestion.ProjectStructure.CallResolution;
+
+public interface IProjectScopedCompilationProvider
+{
+    IProjectScopedSemanticContext Build(ProjectScopedCompilationRequest request, List<IngestionDiagnostic> diagnostics);
+}

--- a/src/CodeLlmWiki.Ingestion/ProjectStructure/CallResolution/IProjectScopedSemanticContext.cs
+++ b/src/CodeLlmWiki.Ingestion/ProjectStructure/CallResolution/IProjectScopedSemanticContext.cs
@@ -1,0 +1,8 @@
+using Microsoft.CodeAnalysis;
+
+namespace CodeLlmWiki.Ingestion.ProjectStructure.CallResolution;
+
+public interface IProjectScopedSemanticContext
+{
+    bool TryGetSemanticModel(string relativeSourceFilePath, out SemanticModel semanticModel, out SemanticContextInfo contextInfo);
+}

--- a/src/CodeLlmWiki.Ingestion/ProjectStructure/CallResolution/ProjectScopedCompilationProvider.cs
+++ b/src/CodeLlmWiki.Ingestion/ProjectStructure/CallResolution/ProjectScopedCompilationProvider.cs
@@ -1,0 +1,265 @@
+using System.Xml.Linq;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
+
+namespace CodeLlmWiki.Ingestion.ProjectStructure.CallResolution;
+
+public sealed class ProjectScopedCompilationProvider : IProjectScopedCompilationProvider
+{
+    public IProjectScopedSemanticContext Build(ProjectScopedCompilationRequest request, List<IngestionDiagnostic> diagnostics)
+    {
+        var orderedSourceFiles = request.SourceFiles
+            .Distinct(StringComparer.Ordinal)
+            .OrderBy(x => x, StringComparer.Ordinal)
+            .ToArray();
+
+        var syntaxTreeByRelativePath = new Dictionary<string, SyntaxTree>(StringComparer.Ordinal);
+        foreach (var relativePath in orderedSourceFiles)
+        {
+            if (!request.SourceTextByRelativePath.TryGetValue(relativePath, out var sourceText))
+            {
+                var fullPath = Path.Combine(request.RepositoryRoot, relativePath.Replace('/', Path.DirectorySeparatorChar));
+                if (!File.Exists(fullPath))
+                {
+                    continue;
+                }
+
+                sourceText = File.ReadAllText(fullPath);
+            }
+
+            syntaxTreeByRelativePath[relativePath] = CSharpSyntaxTree.ParseText(sourceText, path: relativePath);
+        }
+
+        var allSyntaxTrees = syntaxTreeByRelativePath
+            .OrderBy(x => x.Key, StringComparer.Ordinal)
+            .Select(x => x.Value)
+            .ToArray();
+
+        var fallbackCompilation = CSharpCompilation.Create(
+            assemblyName: "CodeLlmWiki.CallGraph.Fallback",
+            syntaxTrees: allSyntaxTrees,
+            references: request.References,
+            options: new CSharpCompilationOptions(OutputKind.DynamicallyLinkedLibrary));
+
+        var normalizedProjectPaths = request.ProjectPaths
+            .Select(Path.GetFullPath)
+            .Distinct(StringComparer.OrdinalIgnoreCase)
+            .ToArray();
+        var projectDirectoryByPath = normalizedProjectPaths.ToDictionary(
+            x => x,
+            x => Path.GetDirectoryName(x) ?? request.RepositoryRoot,
+            StringComparer.OrdinalIgnoreCase);
+        var orderedProjectPathsByDirectoryDepth = normalizedProjectPaths
+            .OrderByDescending(x => projectDirectoryByPath[x].Length)
+            .ThenBy(x => x, StringComparer.OrdinalIgnoreCase)
+            .ToArray();
+
+        var owningProjectByRelativePath = new Dictionary<string, string>(StringComparer.Ordinal);
+        var sourceFilesByOwningProject = new Dictionary<string, List<string>>(StringComparer.OrdinalIgnoreCase);
+        foreach (var relativePath in orderedSourceFiles)
+        {
+            var owningProjectPath = ResolveOwningProjectPath(
+                request.RepositoryRoot,
+                relativePath,
+                orderedProjectPathsByDirectoryDepth,
+                projectDirectoryByPath);
+            if (owningProjectPath is null)
+            {
+                continue;
+            }
+
+            owningProjectByRelativePath[relativePath] = owningProjectPath;
+            if (!sourceFilesByOwningProject.TryGetValue(owningProjectPath, out var sourceFiles))
+            {
+                sourceFiles = [];
+                sourceFilesByOwningProject[owningProjectPath] = sourceFiles;
+            }
+
+            sourceFiles.Add(relativePath);
+        }
+
+        var projectReferencesByProjectPath = normalizedProjectPaths.ToDictionary(
+            x => x,
+            x => ParseProjectReferences(x, diagnostics),
+            StringComparer.OrdinalIgnoreCase);
+        var projectSourceClosureByProjectPath = new Dictionary<string, IReadOnlyList<string>>(StringComparer.OrdinalIgnoreCase);
+
+        foreach (var projectPath in normalizedProjectPaths.OrderBy(x => x, StringComparer.OrdinalIgnoreCase))
+        {
+            var closureProjects = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+            CollectProjectReferenceClosure(projectPath, projectReferencesByProjectPath, closureProjects, new HashSet<string>(StringComparer.OrdinalIgnoreCase));
+
+            var closureSourceFiles = closureProjects
+                .SelectMany(x => sourceFilesByOwningProject.TryGetValue(x, out var files) ? files : [])
+                .Distinct(StringComparer.Ordinal)
+                .OrderBy(x => x, StringComparer.Ordinal)
+                .ToArray();
+
+            projectSourceClosureByProjectPath[projectPath] = closureSourceFiles;
+        }
+
+        var projectCompilationByPath = new Dictionary<string, CSharpCompilation>(StringComparer.OrdinalIgnoreCase);
+        foreach (var projectPath in normalizedProjectPaths.OrderBy(x => x, StringComparer.OrdinalIgnoreCase))
+        {
+            var closureSourceFiles = projectSourceClosureByProjectPath.TryGetValue(projectPath, out var files)
+                ? files
+                : [];
+            var syntaxTrees = closureSourceFiles
+                .Where(syntaxTreeByRelativePath.ContainsKey)
+                .Select(relativePath => syntaxTreeByRelativePath[relativePath])
+                .ToArray();
+
+            var assemblyName = request.ProjectAssemblyNameByPath.TryGetValue(projectPath, out var configuredAssemblyName)
+                ? configuredAssemblyName
+                : Path.GetFileNameWithoutExtension(projectPath);
+
+            var compilation = CSharpCompilation.Create(
+                assemblyName: string.IsNullOrWhiteSpace(assemblyName) ? "CodeLlmWiki.ProjectScoped" : assemblyName,
+                syntaxTrees: syntaxTrees,
+                references: request.References,
+                options: new CSharpCompilationOptions(OutputKind.DynamicallyLinkedLibrary));
+            projectCompilationByPath[projectPath] = compilation;
+        }
+
+        return new ProjectScopedSemanticContext(
+            syntaxTreeByRelativePath,
+            owningProjectByRelativePath,
+            projectCompilationByPath,
+            request.ProjectAssemblyNameByPath,
+            fallbackCompilation);
+    }
+
+    private static string? ResolveOwningProjectPath(
+        string repositoryRoot,
+        string relativePath,
+        IReadOnlyList<string> orderedProjectPathsByDirectoryDepth,
+        IReadOnlyDictionary<string, string> projectDirectoryByPath)
+    {
+        var fullSourcePath = Path.GetFullPath(Path.Combine(repositoryRoot, relativePath.Replace('/', Path.DirectorySeparatorChar)));
+        foreach (var projectPath in orderedProjectPathsByDirectoryDepth)
+        {
+            var projectDirectory = projectDirectoryByPath[projectPath];
+            if (fullSourcePath.StartsWith(projectDirectory + Path.DirectorySeparatorChar, StringComparison.OrdinalIgnoreCase)
+                || fullSourcePath.Equals(projectDirectory, StringComparison.OrdinalIgnoreCase))
+            {
+                return projectPath;
+            }
+        }
+
+        return null;
+    }
+
+    private static IReadOnlyList<string> ParseProjectReferences(string projectPath, List<IngestionDiagnostic> diagnostics)
+    {
+        try
+        {
+            var projectDirectory = Path.GetDirectoryName(projectPath) ?? ".";
+            var document = XDocument.Load(projectPath);
+
+            var references = document
+                .Descendants()
+                .Where(x => string.Equals(x.Name.LocalName, "ProjectReference", StringComparison.Ordinal))
+                .Select(x => x.Attribute("Include")?.Value)
+                .Where(x => !string.IsNullOrWhiteSpace(x))
+                .Select(x => Path.GetFullPath(Path.Combine(projectDirectory, x!)))
+                .Where(File.Exists)
+                .Distinct(StringComparer.OrdinalIgnoreCase)
+                .OrderBy(x => x, StringComparer.OrdinalIgnoreCase)
+                .ToArray();
+
+            return references;
+        }
+        catch (Exception ex)
+        {
+            diagnostics.Add(new IngestionDiagnostic(
+                "project:references:parse:failed",
+                $"Failed to parse project references for '{projectPath}': {ex.Message}"));
+            return [];
+        }
+    }
+
+    private static void CollectProjectReferenceClosure(
+        string projectPath,
+        IReadOnlyDictionary<string, IReadOnlyList<string>> projectReferencesByProjectPath,
+        HashSet<string> closure,
+        HashSet<string> active)
+    {
+        if (!closure.Add(projectPath))
+        {
+            return;
+        }
+
+        if (!active.Add(projectPath))
+        {
+            return;
+        }
+
+        if (projectReferencesByProjectPath.TryGetValue(projectPath, out var references))
+        {
+            foreach (var reference in references.OrderBy(x => x, StringComparer.OrdinalIgnoreCase))
+            {
+                if (!projectReferencesByProjectPath.ContainsKey(reference))
+                {
+                    continue;
+                }
+
+                CollectProjectReferenceClosure(reference, projectReferencesByProjectPath, closure, active);
+            }
+        }
+
+        active.Remove(projectPath);
+    }
+
+    private sealed class ProjectScopedSemanticContext : IProjectScopedSemanticContext
+    {
+        private readonly IReadOnlyDictionary<string, SyntaxTree> _syntaxTreeByRelativePath;
+        private readonly IReadOnlyDictionary<string, string> _owningProjectByRelativePath;
+        private readonly IReadOnlyDictionary<string, CSharpCompilation> _projectCompilationByPath;
+        private readonly IReadOnlyDictionary<string, string> _projectAssemblyNameByPath;
+        private readonly CSharpCompilation _fallbackCompilation;
+
+        public ProjectScopedSemanticContext(
+            IReadOnlyDictionary<string, SyntaxTree> syntaxTreeByRelativePath,
+            IReadOnlyDictionary<string, string> owningProjectByRelativePath,
+            IReadOnlyDictionary<string, CSharpCompilation> projectCompilationByPath,
+            IReadOnlyDictionary<string, string> projectAssemblyNameByPath,
+            CSharpCompilation fallbackCompilation)
+        {
+            _syntaxTreeByRelativePath = syntaxTreeByRelativePath;
+            _owningProjectByRelativePath = owningProjectByRelativePath;
+            _projectCompilationByPath = projectCompilationByPath;
+            _projectAssemblyNameByPath = projectAssemblyNameByPath;
+            _fallbackCompilation = fallbackCompilation;
+        }
+
+        public bool TryGetSemanticModel(string relativeSourceFilePath, out SemanticModel semanticModel, out SemanticContextInfo contextInfo)
+        {
+            if (!_syntaxTreeByRelativePath.TryGetValue(relativeSourceFilePath, out var syntaxTree))
+            {
+                semanticModel = null!;
+                contextInfo = default;
+                return false;
+            }
+
+            if (_owningProjectByRelativePath.TryGetValue(relativeSourceFilePath, out var owningProjectPath)
+                && _projectCompilationByPath.TryGetValue(owningProjectPath, out var projectCompilation))
+            {
+                semanticModel = projectCompilation.GetSemanticModel(syntaxTree, ignoreAccessibility: true);
+                contextInfo = new SemanticContextInfo(
+                    SemanticContextMode.ProjectScoped,
+                    AssemblyName: _projectAssemblyNameByPath.TryGetValue(owningProjectPath, out var assemblyName)
+                        ? assemblyName
+                        : projectCompilation.AssemblyName ?? "UnknownAssembly",
+                    ProjectPath: owningProjectPath);
+                return true;
+            }
+
+            semanticModel = _fallbackCompilation.GetSemanticModel(syntaxTree, ignoreAccessibility: true);
+            contextInfo = new SemanticContextInfo(
+                SemanticContextMode.GlobalFallback,
+                AssemblyName: _fallbackCompilation.AssemblyName ?? "CodeLlmWiki.CallGraph.Fallback",
+                ProjectPath: null);
+            return true;
+        }
+    }
+}

--- a/src/CodeLlmWiki.Ingestion/ProjectStructure/CallResolution/ProjectScopedCompilationRequest.cs
+++ b/src/CodeLlmWiki.Ingestion/ProjectStructure/CallResolution/ProjectScopedCompilationRequest.cs
@@ -1,0 +1,11 @@
+using Microsoft.CodeAnalysis;
+
+namespace CodeLlmWiki.Ingestion.ProjectStructure.CallResolution;
+
+public sealed record ProjectScopedCompilationRequest(
+    string RepositoryRoot,
+    IReadOnlyList<string> SourceFiles,
+    IReadOnlyDictionary<string, string> SourceTextByRelativePath,
+    IReadOnlyDictionary<string, string> ProjectAssemblyNameByPath,
+    IReadOnlyList<string> ProjectPaths,
+    IReadOnlyList<MetadataReference> References);

--- a/src/CodeLlmWiki.Ingestion/ProjectStructure/CallResolution/SemanticContextInfo.cs
+++ b/src/CodeLlmWiki.Ingestion/ProjectStructure/CallResolution/SemanticContextInfo.cs
@@ -1,0 +1,6 @@
+namespace CodeLlmWiki.Ingestion.ProjectStructure.CallResolution;
+
+public readonly record struct SemanticContextInfo(
+    SemanticContextMode Mode,
+    string AssemblyName,
+    string? ProjectPath);

--- a/src/CodeLlmWiki.Ingestion/ProjectStructure/CallResolution/SemanticContextMode.cs
+++ b/src/CodeLlmWiki.Ingestion/ProjectStructure/CallResolution/SemanticContextMode.cs
@@ -1,0 +1,7 @@
+namespace CodeLlmWiki.Ingestion.ProjectStructure.CallResolution;
+
+public enum SemanticContextMode
+{
+    ProjectScoped,
+    GlobalFallback,
+}

--- a/src/CodeLlmWiki.Ingestion/ProjectStructure/ProjectStructureAnalyzer.cs
+++ b/src/CodeLlmWiki.Ingestion/ProjectStructure/ProjectStructureAnalyzer.cs
@@ -6,6 +6,7 @@ using CodeLlmWiki.Contracts.Graph;
 using CodeLlmWiki.Contracts.Identity;
 using CodeLlmWiki.Ingestion.Diagnostics;
 using CodeLlmWiki.Ingestion.Telemetry;
+using CodeLlmWiki.Ingestion.ProjectStructure.CallResolution;
 using CodeLlmWiki.Query.ProjectStructure;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.Operations;
@@ -23,17 +24,20 @@ public sealed class ProjectStructureAnalyzer : IProjectStructureAnalyzer
     private readonly EndpointRuleCatalog _endpointRuleCatalog;
     private readonly ICallResolutionDiagnosticClassifier _callResolutionDiagnosticClassifier;
     private readonly IIngestionStageTelemetry _stageTelemetry;
+    private readonly IProjectScopedCompilationProvider _projectScopedCompilationProvider;
 
     public ProjectStructureAnalyzer(
         IStableIdGenerator stableIdGenerator,
         EndpointRuleCatalog? endpointRuleCatalog = null,
         ICallResolutionDiagnosticClassifier? callResolutionDiagnosticClassifier = null,
-        IIngestionStageTelemetry? stageTelemetry = null)
+        IIngestionStageTelemetry? stageTelemetry = null,
+        IProjectScopedCompilationProvider? projectScopedCompilationProvider = null)
     {
         _stableIdGenerator = stableIdGenerator;
         _endpointRuleCatalog = endpointRuleCatalog ?? EndpointRuleCatalog.Default;
         _callResolutionDiagnosticClassifier = callResolutionDiagnosticClassifier ?? new CallResolutionDiagnosticClassifier();
         _stageTelemetry = stageTelemetry ?? NoOpIngestionStageTelemetry.Instance;
+        _projectScopedCompilationProvider = projectScopedCompilationProvider ?? new ProjectScopedCompilationProvider();
     }
 
     public Task<ProjectStructureAnalysisResult> AnalyzeAsync(string repositoryPath, CancellationToken cancellationToken)
@@ -1053,6 +1057,7 @@ public sealed class ProjectStructureAnalyzer : IProjectStructureAnalyzer
                 repositoryRoot,
                 sourceFiles,
                 sourceTextByRelativePath,
+                projectAssemblyNameByPath,
                 typeIdByQualifiedName,
                 methodCandidatesByTypeId,
                 declaringTypeIdByMethodId,
@@ -3181,6 +3186,7 @@ public sealed class ProjectStructureAnalyzer : IProjectStructureAnalyzer
         string repositoryRoot,
         IReadOnlyList<string> sourceFiles,
         IReadOnlyDictionary<string, string> sourceTextByRelativePath,
+        IReadOnlyDictionary<string, string> projectAssemblyNameByPath,
         IReadOnlyDictionary<string, EntityId> typeIdByQualifiedName,
         IReadOnlyDictionary<EntityId, List<MethodRelationshipCandidate>> methodCandidatesByTypeId,
         IReadOnlyDictionary<EntityId, EntityId> declaringTypeIdByMethodId,
@@ -3196,44 +3202,29 @@ public sealed class ProjectStructureAnalyzer : IProjectStructureAnalyzer
             return;
         }
 
-        var syntaxTrees = new List<SyntaxTree>(sourceFiles.Count);
-        foreach (var relativePath in sourceFiles.OrderBy(x => x, StringComparer.Ordinal))
-        {
-            if (!sourceTextByRelativePath.TryGetValue(relativePath, out var sourceText))
-            {
-                var fullPath = Path.Combine(repositoryRoot, relativePath.Replace('/', Path.DirectorySeparatorChar));
-                if (!File.Exists(fullPath))
-                {
-                    continue;
-                }
-
-                sourceText = File.ReadAllText(fullPath);
-            }
-
-            var syntaxTree = CSharpSyntaxTree.ParseText(sourceText, path: relativePath);
-            syntaxTrees.Add(syntaxTree);
-        }
-
-        if (syntaxTrees.Count == 0)
-        {
-            return;
-        }
-
         var references = BuildCompilationReferences(diagnostics);
-        var compilation = CSharpCompilation.Create(
-            assemblyName: "CodeLlmWiki.CallGraph",
-            syntaxTrees: syntaxTrees,
-            references: references,
-            options: new CSharpCompilationOptions(OutputKind.DynamicallyLinkedLibrary));
+        var semanticContext = _projectScopedCompilationProvider.Build(
+            new ProjectScopedCompilationRequest(
+                RepositoryRoot: repositoryRoot,
+                SourceFiles: sourceFiles,
+                SourceTextByRelativePath: sourceTextByRelativePath,
+                ProjectAssemblyNameByPath: projectAssemblyNameByPath,
+                ProjectPaths: projectAssemblyNameByPath.Keys.OrderBy(x => x, StringComparer.OrdinalIgnoreCase).ToArray(),
+                References: references),
+            diagnostics);
 
         var declarationDependenciesByTypeId = new Dictionary<EntityId, HashSet<EntityId>>();
         var methodBodyDependenciesByTypeId = new Dictionary<EntityId, HashSet<EntityId>>();
         var emittedMethodMetricIds = new HashSet<EntityId>();
 
-        foreach (var syntaxTree in syntaxTrees)
+        foreach (var relativePath in sourceFiles.OrderBy(x => x, StringComparer.Ordinal))
         {
-            var semanticModel = compilation.GetSemanticModel(syntaxTree, ignoreAccessibility: true);
-            var root = syntaxTree.GetRoot() as CompilationUnitSyntax;
+            if (!semanticContext.TryGetSemanticModel(relativePath, out var semanticModel, out _))
+            {
+                continue;
+            }
+
+            var root = semanticModel.SyntaxTree.GetRoot() as CompilationUnitSyntax;
             if (root is null)
             {
                 continue;

--- a/tests/CodeLlmWiki.Ingestion.Tests/MethodCallsVerticalSliceTests.cs
+++ b/tests/CodeLlmWiki.Ingestion.Tests/MethodCallsVerticalSliceTests.cs
@@ -120,6 +120,24 @@ public sealed class MethodCallsVerticalSliceTests
         Assert.Contains(outgoingCalls, x => x.TargetMethodId == pingMethod.Id);
     }
 
+    [Fact]
+    public async Task Query_ProjectScopedCallResolution_IsDeterministicAcrossRuns()
+    {
+        var fixture = await ProjectScopedMethodCallsFixture.CreateAsync();
+        var analyzer = new ProjectStructureAnalyzer(new StableIdGenerator());
+
+        var first = await analyzer.AnalyzeAsync(fixture.RepositoryPath, CancellationToken.None);
+        var second = await analyzer.AnalyzeAsync(fixture.RepositoryPath, CancellationToken.None);
+
+        var firstModel = new ProjectStructureQueryService(first.Triples).GetModel(first.RepositoryId);
+        var secondModel = new ProjectStructureQueryService(second.Triples).GetModel(second.RepositoryId);
+
+        var firstSnapshot = BuildCallSnapshot(firstModel);
+        var secondSnapshot = BuildCallSnapshot(secondModel);
+
+        Assert.Equal(firstSnapshot, secondSnapshot);
+    }
+
     private sealed class MethodCallsFixture
     {
         private MethodCallsFixture(string repositoryPath)
@@ -347,5 +365,18 @@ public sealed class MethodCallsVerticalSliceTests
             var stdErr = process.StandardError.ReadToEnd();
             throw new InvalidOperationException($"git {string.Join(' ', args)} failed: {stdOut}\n{stdErr}");
         }
+    }
+
+    private static IReadOnlyList<string> BuildCallSnapshot(ProjectStructureWikiModel model)
+    {
+        var callerType = model.Declarations.Types.Single(x => x.Name == "Caller");
+        var callMethod = model.Declarations.Methods.Declarations.Single(x => x.DeclaringTypeId == callerType.Id && x.Name == "Call");
+
+        return model.Declarations.Methods.Relations
+            .Where(x => x.Kind == MethodRelationKind.Calls && x.SourceMethodId == callMethod.Id)
+            .Select(x =>
+                $"{x.SourceMethodId.Value}|{x.TargetMethodId?.Value ?? "-"}|{x.ResolutionStatus}|{x.ResolutionReason ?? "-"}|{x.ExternalTargetType?.DisplayText ?? "-"}")
+            .OrderBy(x => x, StringComparer.Ordinal)
+            .ToArray();
     }
 }

--- a/tests/CodeLlmWiki.Ingestion.Tests/MethodCallsVerticalSliceTests.cs
+++ b/tests/CodeLlmWiki.Ingestion.Tests/MethodCallsVerticalSliceTests.cs
@@ -100,6 +100,26 @@ public sealed class MethodCallsVerticalSliceTests
         Assert.Contains("internal-target-unmatched", callLocalPage.Markdown, StringComparison.Ordinal);
     }
 
+    [Fact]
+    public async Task Query_ResolvesInternalCalls_WithDuplicateUnreferencedProjectTypes()
+    {
+        var fixture = await ProjectScopedMethodCallsFixture.CreateAsync();
+        var analyzer = new ProjectStructureAnalyzer(new StableIdGenerator());
+        var analysis = await analyzer.AnalyzeAsync(fixture.RepositoryPath, CancellationToken.None);
+        var model = new ProjectStructureQueryService(analysis.Triples).GetModel(analysis.RepositoryId);
+
+        var callerType = model.Declarations.Types.Single(x => x.Name == "Caller");
+        var workerType = model.Declarations.Types.Single(x => x.Name == "Worker");
+        var callMethod = model.Declarations.Methods.Declarations.Single(x => x.DeclaringTypeId == callerType.Id && x.Name == "Call");
+        var pingMethod = model.Declarations.Methods.Declarations.Single(x => x.DeclaringTypeId == workerType.Id && x.Name == "Ping");
+
+        var outgoingCalls = model.Declarations.Methods.Relations
+            .Where(x => x.Kind == MethodRelationKind.Calls && x.SourceMethodId == callMethod.Id)
+            .ToArray();
+
+        Assert.Contains(outgoingCalls, x => x.TargetMethodId == pingMethod.Id);
+    }
+
     private sealed class MethodCallsFixture
     {
         private MethodCallsFixture(string repositoryPath)
@@ -187,6 +207,119 @@ public sealed class MethodCallsVerticalSliceTests
             RunGit(root, "commit", "-m", "initial");
 
             return new MethodCallsFixture(root);
+        }
+    }
+
+    private sealed class ProjectScopedMethodCallsFixture
+    {
+        private ProjectScopedMethodCallsFixture(string repositoryPath)
+        {
+            RepositoryPath = repositoryPath;
+        }
+
+        public string RepositoryPath { get; }
+
+        public static async Task<ProjectScopedMethodCallsFixture> CreateAsync()
+        {
+            var root = Path.Combine(Path.GetTempPath(), $"codellmwiki-project-scoped-calls-{Guid.NewGuid():N}", "method-call-repo");
+            Directory.CreateDirectory(root);
+
+            await File.WriteAllTextAsync(Path.Combine(root, "Sample.slnx"),
+                """
+                <Solution>
+                  <Project Path="src/App/App.csproj" />
+                  <Project Path="src/LibA/LibA.csproj" />
+                  <Project Path="src/LibB/LibB.csproj" />
+                </Solution>
+                """);
+
+            var appDir = Path.Combine(root, "src", "App");
+            var libADir = Path.Combine(root, "src", "LibA");
+            var libBDir = Path.Combine(root, "src", "LibB");
+            Directory.CreateDirectory(appDir);
+            Directory.CreateDirectory(libADir);
+            Directory.CreateDirectory(libBDir);
+
+            await File.WriteAllTextAsync(Path.Combine(appDir, "App.csproj"),
+                """
+                <Project Sdk="Microsoft.NET.Sdk">
+                  <PropertyGroup>
+                    <TargetFramework>net10.0</TargetFramework>
+                    <AssemblyName>Acme.ProjectScoped.App</AssemblyName>
+                  </PropertyGroup>
+                  <ItemGroup>
+                    <ProjectReference Include="../LibA/LibA.csproj" />
+                  </ItemGroup>
+                </Project>
+                """);
+
+            await File.WriteAllTextAsync(Path.Combine(libADir, "LibA.csproj"),
+                """
+                <Project Sdk="Microsoft.NET.Sdk">
+                  <PropertyGroup>
+                    <TargetFramework>net10.0</TargetFramework>
+                    <AssemblyName>Acme.ProjectScoped.LibA</AssemblyName>
+                  </PropertyGroup>
+                </Project>
+                """);
+
+            await File.WriteAllTextAsync(Path.Combine(libBDir, "LibB.csproj"),
+                """
+                <Project Sdk="Microsoft.NET.Sdk">
+                  <PropertyGroup>
+                    <TargetFramework>net10.0</TargetFramework>
+                    <AssemblyName>Acme.ProjectScoped.LibB</AssemblyName>
+                  </PropertyGroup>
+                </Project>
+                """);
+
+            await File.WriteAllTextAsync(Path.Combine(appDir, "Caller.cs"),
+                """
+                using Acme.Shared;
+
+                namespace Acme.App;
+
+                public class Caller
+                {
+                    public void Call()
+                    {
+                        var worker = new Worker();
+                        worker.Ping();
+                    }
+                }
+                """);
+
+            await File.WriteAllTextAsync(Path.Combine(libADir, "Worker.cs"),
+                """
+                namespace Acme.Shared;
+
+                public class Worker
+                {
+                    public void Ping()
+                    {
+                    }
+                }
+                """);
+
+            await File.WriteAllTextAsync(Path.Combine(libBDir, "Worker.cs"),
+                """
+                namespace Acme.Shared;
+
+                public class Worker
+                {
+                    public void Ping()
+                    {
+                    }
+                }
+                """);
+
+            RunGit(root, "init", "-b", "main");
+            RunGit(root, "config", "user.email", "test@example.com");
+            RunGit(root, "config", "user.name", "Test User");
+            RunGit(root, "add", ".");
+            RunGit(root, "commit", "-m", "initial");
+
+            return new ProjectScopedMethodCallsFixture(root);
         }
     }
 

--- a/tests/CodeLlmWiki.Ingestion.Tests/ProjectScopedCompilationProviderTests.cs
+++ b/tests/CodeLlmWiki.Ingestion.Tests/ProjectScopedCompilationProviderTests.cs
@@ -1,0 +1,237 @@
+using System.Diagnostics;
+using CodeLlmWiki.Ingestion.ProjectStructure.CallResolution;
+using Microsoft.CodeAnalysis;
+
+namespace CodeLlmWiki.Ingestion.Tests;
+
+public sealed class ProjectScopedCompilationProviderTests
+{
+    [Fact]
+    public async Task Build_ResolvesProjectScopedSemanticModel_ForOwnedSourceFile()
+    {
+        var fixture = await CompilationFixture.CreateAsync();
+        var provider = new ProjectScopedCompilationProvider();
+        var diagnostics = new List<IngestionDiagnostic>();
+
+        var context = provider.Build(
+            new ProjectScopedCompilationRequest(
+                RepositoryRoot: fixture.RepositoryPath,
+                SourceFiles: fixture.SourceFiles,
+                SourceTextByRelativePath: fixture.SourceTextByRelativePath,
+                ProjectAssemblyNameByPath: fixture.ProjectAssemblyNameByPath,
+                ProjectPaths: fixture.ProjectPaths,
+                References: BuildDefaultReferences()),
+            diagnostics);
+
+        var resolved = context.TryGetSemanticModel("src/App/Program.cs", out _, out var info);
+
+        Assert.True(resolved);
+        Assert.Equal(SemanticContextMode.ProjectScoped, info.Mode);
+        Assert.Equal("Acme.Compilations.App", info.AssemblyName);
+        Assert.EndsWith("src/App/App.csproj", info.ProjectPath, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public async Task Build_UsesFallbackGlobalSemanticModel_ForUnownedSourceFile()
+    {
+        var fixture = await CompilationFixture.CreateAsync();
+        var provider = new ProjectScopedCompilationProvider();
+        var diagnostics = new List<IngestionDiagnostic>();
+
+        var context = provider.Build(
+            new ProjectScopedCompilationRequest(
+                RepositoryRoot: fixture.RepositoryPath,
+                SourceFiles: fixture.SourceFiles,
+                SourceTextByRelativePath: fixture.SourceTextByRelativePath,
+                ProjectAssemblyNameByPath: fixture.ProjectAssemblyNameByPath,
+                ProjectPaths: fixture.ProjectPaths,
+                References: BuildDefaultReferences()),
+            diagnostics);
+
+        var resolved = context.TryGetSemanticModel("notes.cs", out _, out var info);
+
+        Assert.True(resolved);
+        Assert.Equal(SemanticContextMode.GlobalFallback, info.Mode);
+        Assert.Equal("CodeLlmWiki.CallGraph.Fallback", info.AssemblyName);
+        Assert.Null(info.ProjectPath);
+    }
+
+    private static IReadOnlyList<MetadataReference> BuildDefaultReferences()
+    {
+        var tpa = (string?)AppContext.GetData("TRUSTED_PLATFORM_ASSEMBLIES");
+        if (string.IsNullOrWhiteSpace(tpa))
+        {
+            return [];
+        }
+
+        return tpa
+            .Split(Path.PathSeparator, StringSplitOptions.RemoveEmptyEntries)
+            .Where(File.Exists)
+            .Select(path => MetadataReference.CreateFromFile(path))
+            .ToArray();
+    }
+
+    private sealed class CompilationFixture
+    {
+        private CompilationFixture(
+            string repositoryPath,
+            IReadOnlyList<string> sourceFiles,
+            IReadOnlyDictionary<string, string> sourceTextByRelativePath,
+            IReadOnlyList<string> projectPaths,
+            IReadOnlyDictionary<string, string> projectAssemblyNameByPath)
+        {
+            RepositoryPath = repositoryPath;
+            SourceFiles = sourceFiles;
+            SourceTextByRelativePath = sourceTextByRelativePath;
+            ProjectPaths = projectPaths;
+            ProjectAssemblyNameByPath = projectAssemblyNameByPath;
+        }
+
+        public string RepositoryPath { get; }
+        public IReadOnlyList<string> SourceFiles { get; }
+        public IReadOnlyDictionary<string, string> SourceTextByRelativePath { get; }
+        public IReadOnlyList<string> ProjectPaths { get; }
+        public IReadOnlyDictionary<string, string> ProjectAssemblyNameByPath { get; }
+
+        public static async Task<CompilationFixture> CreateAsync()
+        {
+            var root = Path.Combine(Path.GetTempPath(), $"codellmwiki-psc-provider-{Guid.NewGuid():N}", "fixture-repo");
+            Directory.CreateDirectory(root);
+
+            await File.WriteAllTextAsync(Path.Combine(root, "Sample.slnx"),
+                """
+                <Solution>
+                  <Project Path="src/App/App.csproj" />
+                  <Project Path="src/Lib/Lib.csproj" />
+                </Solution>
+                """);
+
+            var appDir = Path.Combine(root, "src", "App");
+            var libDir = Path.Combine(root, "src", "Lib");
+            Directory.CreateDirectory(appDir);
+            Directory.CreateDirectory(libDir);
+
+            var appProjectPath = Path.Combine(appDir, "App.csproj");
+            var libProjectPath = Path.Combine(libDir, "Lib.csproj");
+
+            await File.WriteAllTextAsync(appProjectPath,
+                """
+                <Project Sdk="Microsoft.NET.Sdk">
+                  <PropertyGroup>
+                    <TargetFramework>net10.0</TargetFramework>
+                    <AssemblyName>Acme.Compilations.App</AssemblyName>
+                  </PropertyGroup>
+                  <ItemGroup>
+                    <ProjectReference Include="../Lib/Lib.csproj" />
+                  </ItemGroup>
+                </Project>
+                """);
+
+            await File.WriteAllTextAsync(libProjectPath,
+                """
+                <Project Sdk="Microsoft.NET.Sdk">
+                  <PropertyGroup>
+                    <TargetFramework>net10.0</TargetFramework>
+                    <AssemblyName>Acme.Compilations.Lib</AssemblyName>
+                  </PropertyGroup>
+                </Project>
+                """);
+
+            var appProgramPath = Path.Combine(appDir, "Program.cs");
+            var libTypePath = Path.Combine(libDir, "Helper.cs");
+            var notesPath = Path.Combine(root, "notes.cs");
+
+            await File.WriteAllTextAsync(appProgramPath,
+                """
+                using Acme.Compilations.Lib;
+
+                namespace Acme.Compilations.App;
+
+                public static class Program
+                {
+                    public static void Run()
+                    {
+                        Helper.Ping();
+                    }
+                }
+                """);
+
+            await File.WriteAllTextAsync(libTypePath,
+                """
+                namespace Acme.Compilations.Lib;
+
+                public static class Helper
+                {
+                    public static void Ping()
+                    {
+                    }
+                }
+                """);
+
+            await File.WriteAllTextAsync(notesPath,
+                """
+                public static class Notes
+                {
+                    public static void Keep()
+                    {
+                    }
+                }
+                """);
+
+            RunGit(root, "init", "-b", "main");
+            RunGit(root, "config", "user.email", "test@example.com");
+            RunGit(root, "config", "user.name", "Test User");
+            RunGit(root, "add", ".");
+            RunGit(root, "commit", "-m", "initial");
+
+            var sourceFiles = new[]
+            {
+                "notes.cs",
+                "src/App/Program.cs",
+                "src/Lib/Helper.cs",
+            };
+
+            var sourceTextByRelativePath = sourceFiles.ToDictionary(
+                x => x,
+                x => File.ReadAllText(Path.Combine(root, x.Replace('/', Path.DirectorySeparatorChar))),
+                StringComparer.Ordinal);
+
+            return new CompilationFixture(
+                repositoryPath: root,
+                sourceFiles: sourceFiles,
+                sourceTextByRelativePath: sourceTextByRelativePath,
+                projectPaths: [appProjectPath, libProjectPath],
+                projectAssemblyNameByPath: new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase)
+                {
+                    [appProjectPath] = "Acme.Compilations.App",
+                    [libProjectPath] = "Acme.Compilations.Lib",
+                });
+        }
+    }
+
+    private static void RunGit(string workingDirectory, params string[] args)
+    {
+        var startInfo = new ProcessStartInfo
+        {
+            FileName = "git",
+            WorkingDirectory = workingDirectory,
+            RedirectStandardOutput = true,
+            RedirectStandardError = true,
+        };
+
+        foreach (var arg in args)
+        {
+            startInfo.ArgumentList.Add(arg);
+        }
+
+        using var process = Process.Start(startInfo)!;
+        process.WaitForExit();
+
+        if (process.ExitCode != 0)
+        {
+            var stdOut = process.StandardOutput.ReadToEnd();
+            var stdErr = process.StandardError.ReadToEnd();
+            throw new InvalidOperationException($"git {string.Join(' ', args)} failed: {stdOut}\n{stdErr}");
+        }
+    }
+}


### PR DESCRIPTION
## Summary\n- add a project-scoped Roslyn compilation provider and semantic-context contract for call resolution\n- route method-call capture through owning-project semantic models with deterministic fallback\n- keep unresolved call diagnostics explicit while improving primary internal resolution path\n- add multi-project method-call fixture coverage and dedicated provider tests\n\n## Verification\n- dotnet test tests/CodeLlmWiki.Ingestion.Tests/CodeLlmWiki.Ingestion.Tests.csproj\n- dotnet test tests/CodeLlmWiki.Cli.Tests/CodeLlmWiki.Cli.Tests.csproj\n\n## Linked issue\n- Closes #121