### PR TITLE
PRD 010: phase 4 quality gate and run-status integration

### DIFF
--- a/src/CodeLlmWiki.Cli/CliApplication.cs
+++ b/src/CodeLlmWiki.Cli/CliApplication.cs
@@ -1,3 +1,4 @@
+using System.Globalization;
 using System.Text.Json;
 using CodeLlmWiki.Cli.Commands;
 using CodeLlmWiki.Cli.Config;
@@ -87,6 +88,16 @@ public sealed class CliApplication
             }
 
             return 1;
+        }
+
+        if (result.Status == IngestionRunStatus.FailedQualityGate && result.QualityGate is { } qualityGate)
+        {
+            Console.Error.WriteLine(
+                "Quality gate failed: unresolved-call-ratio "
+                + $"{qualityGate.UnresolvedCallRatio.ToString("0.####", CultureInfo.InvariantCulture)} "
+                + "exceeds threshold "
+                + $"{qualityGate.Threshold.ToString("0.####", CultureInfo.InvariantCulture)} "
+                + $"(unresolved={qualityGate.UnresolvedCallFailures}, total={qualityGate.TotalCallResolutionAttempts}).");
         }
 
         return result.ExitCode;

--- a/src/CodeLlmWiki.Cli/Features/Ingest/IngestionArtifactPublisher.cs
+++ b/src/CodeLlmWiki.Cli/Features/Ingest/IngestionArtifactPublisher.cs
@@ -114,7 +114,7 @@ public sealed class IngestionArtifactPublisher : IIngestionArtifactPublisher
                     });
             }
 
-            var shouldPromoteLatest = request.RunResult.Status != IngestionRunStatus.Failed;
+            var shouldPromoteLatest = request.RunResult.Status is not IngestionRunStatus.Failed and not IngestionRunStatus.FailedQualityGate;
             var manifest = BuildManifest(
                 request,
                 runId,
@@ -207,7 +207,16 @@ public sealed class IngestionArtifactPublisher : IIngestionArtifactPublisher
                 GraphMl: graphMlPath is null ? null : "graph/graph.graphml",
                 Manifest: "manifest.json"),
             LatestPromoted: latestPromoted,
-            Metrics: metricsSummary);
+            Metrics: metricsSummary,
+            QualityGate: request.RunResult.QualityGate is null
+                ? null
+                : new RunQualityGateSummary(
+                    GateId: request.RunResult.QualityGate.GateId,
+                    Passed: request.RunResult.QualityGate.Passed,
+                    UnresolvedCallFailures: request.RunResult.QualityGate.UnresolvedCallFailures,
+                    TotalCallResolutionAttempts: request.RunResult.QualityGate.TotalCallResolutionAttempts,
+                    UnresolvedCallRatio: request.RunResult.QualityGate.UnresolvedCallRatio,
+                    Threshold: request.RunResult.QualityGate.Threshold));
     }
 
     private static RunMetricsSummary BuildMetricsSummary(ProjectStructureWikiModel model)
@@ -373,7 +382,8 @@ public sealed class IngestionArtifactPublisher : IIngestionArtifactPublisher
         IReadOnlyList<DiagnosticSummary> DiagnosticsSummary,
         ArtifactReferences Artifacts,
         bool LatestPromoted,
-        RunMetricsSummary? Metrics);
+        RunMetricsSummary? Metrics,
+        RunQualityGateSummary? QualityGate);
 
     private sealed record ArtifactReferences(string? Wiki, string? GraphMl, string Manifest);
 
@@ -409,4 +419,12 @@ public sealed class IngestionArtifactPublisher : IIngestionArtifactPublisher
         int InsufficientNamespaceScopeCount,
         int InsufficientProjectScopeCount,
         bool RepositoryScopeInsufficient);
+
+    private sealed record RunQualityGateSummary(
+        string GateId,
+        bool Passed,
+        int UnresolvedCallFailures,
+        int TotalCallResolutionAttempts,
+        double UnresolvedCallRatio,
+        double Threshold);
 }

--- a/src/CodeLlmWiki.Ingestion/IngestionRunResult.cs
+++ b/src/CodeLlmWiki.Ingestion/IngestionRunResult.cs
@@ -1,5 +1,6 @@
 using CodeLlmWiki.Contracts.Graph;
 using CodeLlmWiki.Contracts.Identity;
+using CodeLlmWiki.Ingestion.Quality;
 
 namespace CodeLlmWiki.Ingestion;
 
@@ -8,4 +9,5 @@ public sealed record IngestionRunResult(
     int ExitCode,
     IReadOnlyList<IngestionDiagnostic> Diagnostics,
     EntityId RepositoryId,
-    IReadOnlyList<SemanticTriple> Triples);
+    IReadOnlyList<SemanticTriple> Triples,
+    UnresolvedCallRatioQualityGateEvidence? QualityGate = null);

--- a/src/CodeLlmWiki.Ingestion/IngestionRunStatus.cs
+++ b/src/CodeLlmWiki.Ingestion/IngestionRunStatus.cs
@@ -5,4 +5,5 @@ public enum IngestionRunStatus
     Succeeded = 0,
     SucceededWithDiagnostics = 1,
     Failed = 2,
+    FailedQualityGate = 3,
 }

--- a/src/CodeLlmWiki.Ingestion/IngestionRunner.cs
+++ b/src/CodeLlmWiki.Ingestion/IngestionRunner.cs
@@ -1,4 +1,6 @@
+using CodeLlmWiki.Contracts.Graph;
 using CodeLlmWiki.Contracts.Identity;
+using CodeLlmWiki.Ingestion.Quality;
 using CodeLlmWiki.Ontology;
 
 namespace CodeLlmWiki.Ingestion;
@@ -8,15 +10,18 @@ public sealed class IngestionRunner : IIngestionRunner
     private readonly IOntologyLoader _ontologyLoader;
     private readonly IIngestionPipeline _pipeline;
     private readonly IStableIdGenerator _stableIdGenerator;
+    private readonly IUnresolvedCallRatioQualityGateEvaluator _qualityGateEvaluator;
 
     public IngestionRunner(
         IOntologyLoader ontologyLoader,
         IIngestionPipeline pipeline,
-        IStableIdGenerator? stableIdGenerator = null)
+        IStableIdGenerator? stableIdGenerator = null,
+        IUnresolvedCallRatioQualityGateEvaluator? qualityGateEvaluator = null)
     {
         _ontologyLoader = ontologyLoader;
         _pipeline = pipeline;
         _stableIdGenerator = stableIdGenerator ?? new StableIdGenerator();
+        _qualityGateEvaluator = qualityGateEvaluator ?? new UnresolvedCallRatioQualityGateEvaluator();
     }
 
     public async Task<IngestionRunResult> RunAsync(IngestionRunRequest request, CancellationToken cancellationToken)
@@ -35,11 +40,11 @@ public sealed class IngestionRunner : IIngestionRunner
 
         var pipelineResult = await _pipeline.ExecuteAsync(context, cancellationToken);
         var diagnostics = pipelineResult.Diagnostics.ToArray();
-        var status = diagnostics.Length == 0
+        var baseStatus = diagnostics.Length == 0
             ? IngestionRunStatus.Succeeded
             : IngestionRunStatus.SucceededWithDiagnostics;
 
-        var exitCode = status switch
+        var baseExitCode = baseStatus switch
         {
             IngestionRunStatus.Succeeded => 0,
             IngestionRunStatus.SucceededWithDiagnostics when request.AllowPartialSuccess => 0,
@@ -47,6 +52,26 @@ public sealed class IngestionRunner : IIngestionRunner
             _ => 1,
         };
 
-        return new IngestionRunResult(status, exitCode, diagnostics, repositoryId, pipelineResult.Triples);
+        var qualityGate = _qualityGateEvaluator.Evaluate(
+            new UnresolvedCallRatioQualityGateRequest(
+                Diagnostics: diagnostics,
+                TotalCallResolutionAttempts: CountCallResolutionAttempts(pipelineResult.Triples)));
+        if (qualityGate.Passed)
+        {
+            return new IngestionRunResult(baseStatus, baseExitCode, diagnostics, repositoryId, pipelineResult.Triples, qualityGate.Evidence);
+        }
+
+        return new IngestionRunResult(
+            Status: IngestionRunStatus.FailedQualityGate,
+            ExitCode: 3,
+            Diagnostics: diagnostics,
+            RepositoryId: repositoryId,
+            Triples: pipelineResult.Triples,
+            QualityGate: qualityGate.Evidence);
+    }
+
+    private static int CountCallResolutionAttempts(IReadOnlyList<SemanticTriple> triples)
+    {
+        return triples.Count(x => x.Predicate == CorePredicates.Calls);
     }
 }

--- a/src/CodeLlmWiki.Ingestion/Quality/IUnresolvedCallRatioQualityGateEvaluator.cs
+++ b/src/CodeLlmWiki.Ingestion/Quality/IUnresolvedCallRatioQualityGateEvaluator.cs
@@ -1,0 +1,6 @@
+namespace CodeLlmWiki.Ingestion.Quality;
+
+public interface IUnresolvedCallRatioQualityGateEvaluator
+{
+    UnresolvedCallRatioQualityGateEvaluation Evaluate(UnresolvedCallRatioQualityGateRequest request);
+}

--- a/src/CodeLlmWiki.Ingestion/Quality/UnresolvedCallRatioQualityGateEvaluation.cs
+++ b/src/CodeLlmWiki.Ingestion/Quality/UnresolvedCallRatioQualityGateEvaluation.cs
@@ -1,0 +1,5 @@
+namespace CodeLlmWiki.Ingestion.Quality;
+
+public sealed record UnresolvedCallRatioQualityGateEvaluation(
+    bool Passed,
+    UnresolvedCallRatioQualityGateEvidence Evidence);

--- a/src/CodeLlmWiki.Ingestion/Quality/UnresolvedCallRatioQualityGateEvaluator.cs
+++ b/src/CodeLlmWiki.Ingestion/Quality/UnresolvedCallRatioQualityGateEvaluator.cs
@@ -1,0 +1,47 @@
+using CodeLlmWiki.Ingestion.Diagnostics;
+
+namespace CodeLlmWiki.Ingestion.Quality;
+
+public sealed class UnresolvedCallRatioQualityGateEvaluator : IUnresolvedCallRatioQualityGateEvaluator
+{
+    public const string GateId = "quality:unresolved-call-ratio";
+    private const string InternalTargetUnmatchedCode = "method:call:internal-target-unmatched";
+
+    public UnresolvedCallRatioQualityGateEvaluation Evaluate(UnresolvedCallRatioQualityGateRequest request)
+    {
+        var policy = request.Policy ?? UnresolvedCallRatioQualityGatePolicy.Default;
+        var threshold = NormalizeThreshold(policy.Threshold);
+        var unresolvedCallFailures = request.Diagnostics.Count(IsUnresolvedCallFailureDiagnostic);
+        var totalCallResolutionAttempts = Math.Max(0, request.TotalCallResolutionAttempts);
+        var unresolvedCallRatio = totalCallResolutionAttempts == 0
+            ? 0d
+            : (double)unresolvedCallFailures / totalCallResolutionAttempts;
+
+        var passed = totalCallResolutionAttempts == 0 || unresolvedCallRatio <= threshold;
+        var evidence = new UnresolvedCallRatioQualityGateEvidence(
+            GateId: GateId,
+            UnresolvedCallFailures: unresolvedCallFailures,
+            TotalCallResolutionAttempts: totalCallResolutionAttempts,
+            UnresolvedCallRatio: unresolvedCallRatio,
+            Threshold: threshold,
+            Passed: passed);
+
+        return new UnresolvedCallRatioQualityGateEvaluation(Passed: passed, Evidence: evidence);
+    }
+
+    private static bool IsUnresolvedCallFailureDiagnostic(IngestionDiagnostic diagnostic)
+    {
+        return string.Equals(diagnostic.Code, CallResolutionDiagnosticCodes.Aggregate, StringComparison.Ordinal)
+               || string.Equals(diagnostic.Code, InternalTargetUnmatchedCode, StringComparison.Ordinal);
+    }
+
+    private static double NormalizeThreshold(double threshold)
+    {
+        if (double.IsNaN(threshold) || double.IsInfinity(threshold))
+        {
+            return UnresolvedCallRatioQualityGatePolicy.DefaultThreshold;
+        }
+
+        return Math.Clamp(threshold, 0d, 1d);
+    }
+}

--- a/src/CodeLlmWiki.Ingestion/Quality/UnresolvedCallRatioQualityGateEvidence.cs
+++ b/src/CodeLlmWiki.Ingestion/Quality/UnresolvedCallRatioQualityGateEvidence.cs
@@ -1,0 +1,9 @@
+namespace CodeLlmWiki.Ingestion.Quality;
+
+public sealed record UnresolvedCallRatioQualityGateEvidence(
+    string GateId,
+    int UnresolvedCallFailures,
+    int TotalCallResolutionAttempts,
+    double UnresolvedCallRatio,
+    double Threshold,
+    bool Passed);

--- a/src/CodeLlmWiki.Ingestion/Quality/UnresolvedCallRatioQualityGatePolicy.cs
+++ b/src/CodeLlmWiki.Ingestion/Quality/UnresolvedCallRatioQualityGatePolicy.cs
@@ -1,0 +1,8 @@
+namespace CodeLlmWiki.Ingestion.Quality;
+
+public sealed record UnresolvedCallRatioQualityGatePolicy(double Threshold)
+{
+    public const double DefaultThreshold = 0.25d;
+
+    public static readonly UnresolvedCallRatioQualityGatePolicy Default = new(DefaultThreshold);
+}

--- a/src/CodeLlmWiki.Ingestion/Quality/UnresolvedCallRatioQualityGateRequest.cs
+++ b/src/CodeLlmWiki.Ingestion/Quality/UnresolvedCallRatioQualityGateRequest.cs
@@ -1,0 +1,6 @@
+namespace CodeLlmWiki.Ingestion.Quality;
+
+public sealed record UnresolvedCallRatioQualityGateRequest(
+    IReadOnlyList<IngestionDiagnostic> Diagnostics,
+    int TotalCallResolutionAttempts,
+    UnresolvedCallRatioQualityGatePolicy? Policy = null);

--- a/tests/CodeLlmWiki.Cli.Tests/CliApplicationTests.cs
+++ b/tests/CodeLlmWiki.Cli.Tests/CliApplicationTests.cs
@@ -2,6 +2,7 @@ using CodeLlmWiki.Cli;
 using CodeLlmWiki.Cli.Features.Ingest;
 using CodeLlmWiki.Contracts.Identity;
 using CodeLlmWiki.Ingestion;
+using CodeLlmWiki.Ingestion.Quality;
 
 namespace CodeLlmWiki.Cli.Tests;
 
@@ -116,6 +117,48 @@ public sealed class CliApplicationTests
         Assert.NotNull(publisher.LastRequest);
         Assert.Equal(3, publisher.LastRequest!.MaxMergeEntriesPerFile);
         Assert.Equal(4, publisher.LastRequest.MetricComputationMaxDegreeOfParallelism);
+    }
+
+    [Fact]
+    public async Task RunAsync_WritesQualityGateFailureDetailsToStderr()
+    {
+        var runner = new CapturingRunner
+        {
+            NextResult = new IngestionRunResult(
+                Status: IngestionRunStatus.FailedQualityGate,
+                ExitCode: 3,
+                Diagnostics: [new IngestionDiagnostic("method:call:resolution:failed", "failed")],
+                RepositoryId: new StableIdGenerator().Create(new EntityKey("repository", ".")),
+                Triples: [],
+                QualityGate: new UnresolvedCallRatioQualityGateEvidence(
+                    GateId: "quality:unresolved-call-ratio",
+                    UnresolvedCallFailures: 3,
+                    TotalCallResolutionAttempts: 4,
+                    UnresolvedCallRatio: 0.75d,
+                    Threshold: 0.25d,
+                    Passed: false)),
+        };
+        var publisher = new CapturingPublisher();
+        var app = new CliApplication(runner, publisher);
+
+        var originalError = Console.Error;
+        using var errorWriter = new StringWriter();
+        Console.SetError(errorWriter);
+
+        try
+        {
+            var exitCode = await app.RunAsync(["ingest", "--path", "."], CancellationToken.None);
+
+            Assert.Equal(3, exitCode);
+            var stderr = errorWriter.ToString();
+            Assert.Contains("Quality gate failed", stderr, StringComparison.Ordinal);
+            Assert.Contains("0.75", stderr, StringComparison.Ordinal);
+            Assert.Contains("0.25", stderr, StringComparison.Ordinal);
+        }
+        finally
+        {
+            Console.SetError(originalError);
+        }
     }
 
     private static string WriteTempFile(string content)

--- a/tests/CodeLlmWiki.Cli.Tests/IngestionArtifactPublisherTests.cs
+++ b/tests/CodeLlmWiki.Cli.Tests/IngestionArtifactPublisherTests.cs
@@ -5,6 +5,7 @@ using CodeLlmWiki.Cli.Features.Ingest;
 using CodeLlmWiki.Contracts.Identity;
 using CodeLlmWiki.Ingestion;
 using CodeLlmWiki.Ingestion.ProjectStructure;
+using CodeLlmWiki.Ingestion.Quality;
 using CodeLlmWiki.Ingestion.Telemetry;
 
 namespace CodeLlmWiki.Cli.Tests;
@@ -129,6 +130,57 @@ public sealed class IngestionArtifactPublisherTests
         Assert.True(File.Exists(markerPath));
         Assert.True(File.Exists(result.ManifestPath));
         Assert.True(File.Exists(Path.Combine(result.RunDirectory, "graph", "graph.graphml")));
+    }
+
+    [Fact]
+    public async Task PublishAsync_DoesNotPromoteLatest_WhenQualityGateFailed_AndEmitsQualityEvidence()
+    {
+        var outputRoot = Path.Combine(Path.GetTempPath(), $"codellmwiki-artifacts-quality-failed-{Guid.NewGuid():N}");
+        var latestDirectory = Path.Combine(outputRoot, "latest");
+        Directory.CreateDirectory(latestDirectory);
+        var markerPath = Path.Combine(latestDirectory, "marker.txt");
+        await File.WriteAllTextAsync(markerPath, "preserve");
+
+        var runResult = new IngestionRunResult(
+            Status: IngestionRunStatus.FailedQualityGate,
+            ExitCode: 3,
+            Diagnostics:
+            [
+                new IngestionDiagnostic("method:call:resolution:failed", "failed"),
+                new IngestionDiagnostic("method:call:internal-target-unmatched", "failed"),
+            ],
+            RepositoryId: default,
+            Triples: [],
+            QualityGate: new UnresolvedCallRatioQualityGateEvidence(
+                GateId: "quality:unresolved-call-ratio",
+                UnresolvedCallFailures: 2,
+                TotalCallResolutionAttempts: 4,
+                UnresolvedCallRatio: 0.5d,
+                Threshold: 0.25d,
+                Passed: false));
+
+        var publisher = new IngestionArtifactPublisher();
+        var result = await publisher.PublishAsync(
+            new IngestionArtifactPublishRequest(
+                RepositoryPath: ".",
+                OutputRootPath: outputRoot,
+                StartedAtUtc: new DateTimeOffset(2026, 1, 1, 0, 0, 0, TimeSpan.Zero),
+                CompletedAtUtc: new DateTimeOffset(2026, 1, 1, 0, 0, 5, TimeSpan.Zero),
+                RunResult: runResult),
+            CancellationToken.None);
+
+        Assert.True(result.Succeeded);
+        Assert.False(result.LatestPromoted);
+        Assert.True(File.Exists(markerPath));
+
+        var manifest = JsonDocument.Parse(await File.ReadAllTextAsync(result.ManifestPath));
+        var qualityGate = manifest.RootElement.GetProperty("QualityGate");
+        Assert.Equal("quality:unresolved-call-ratio", qualityGate.GetProperty("GateId").GetString());
+        Assert.False(qualityGate.GetProperty("Passed").GetBoolean());
+        Assert.Equal(2, qualityGate.GetProperty("UnresolvedCallFailures").GetInt32());
+        Assert.Equal(4, qualityGate.GetProperty("TotalCallResolutionAttempts").GetInt32());
+        Assert.Equal(0.5d, qualityGate.GetProperty("UnresolvedCallRatio").GetDouble(), 8);
+        Assert.Equal(0.25d, qualityGate.GetProperty("Threshold").GetDouble(), 8);
     }
 
     [Fact]

--- a/tests/CodeLlmWiki.Ingestion.Tests/IngestionRunnerTests.cs
+++ b/tests/CodeLlmWiki.Ingestion.Tests/IngestionRunnerTests.cs
@@ -1,4 +1,5 @@
 using CodeLlmWiki.Contracts.Graph;
+using CodeLlmWiki.Contracts.Identity;
 using CodeLlmWiki.Ingestion;
 using CodeLlmWiki.Ontology;
 
@@ -113,6 +114,82 @@ public sealed class IngestionRunnerTests
         Assert.Equal(0, result.ExitCode);
     }
 
+    [Fact]
+    public async Task RunAsync_ReturnsFailedQualityGate_WhenUnresolvedCallRatioExceedsThreshold()
+    {
+        var methodId = new EntityId("method:source");
+        var unresolvedTargetId = new EntityId("unresolved-call-target:1");
+        var callPredicate = CorePredicates.Calls;
+        var callTriples = new[]
+        {
+            new SemanticTriple(new EntityNode(methodId), callPredicate, new EntityNode(unresolvedTargetId)),
+            new SemanticTriple(new EntityNode(methodId), callPredicate, new EntityNode(unresolvedTargetId)),
+            new SemanticTriple(new EntityNode(methodId), callPredicate, new EntityNode(unresolvedTargetId)),
+            new SemanticTriple(new EntityNode(methodId), callPredicate, new EntityNode(unresolvedTargetId)),
+        };
+
+        var pipeline = new CapturingPipeline(
+            diagnostics:
+            [
+                new IngestionDiagnostic("method:call:resolution:failed", "failed 1"),
+                new IngestionDiagnostic("method:call:internal-target-unmatched", "failed 2"),
+            ],
+            triples: callTriples);
+        var runner = new IngestionRunner(new OntologyLoader(), pipeline);
+        var ontologyPath = WriteTempFile(
+            """
+            version: "1.0.0"
+            predicates:
+              - id: "core:contains"
+            """);
+
+        var request = new IngestionRunRequest(
+            RepositoryPath: ".",
+            ConfigPath: null,
+            OntologyPath: ontologyPath,
+            AllowPartialSuccess: true);
+
+        var result = await runner.RunAsync(request, CancellationToken.None);
+
+        Assert.Equal(IngestionRunStatus.FailedQualityGate, result.Status);
+        Assert.Equal(3, result.ExitCode);
+        Assert.NotNull(result.QualityGate);
+        Assert.False(result.QualityGate!.Passed);
+        Assert.Equal(2, result.QualityGate.UnresolvedCallFailures);
+        Assert.Equal(4, result.QualityGate.TotalCallResolutionAttempts);
+        Assert.Equal(0.5d, result.QualityGate.UnresolvedCallRatio, 8);
+    }
+
+    [Fact]
+    public async Task RunAsync_ProjectDiscoveryFallbackRemainsWarningLevel_AndNonGating()
+    {
+        var pipeline = new CapturingPipeline(
+            diagnostics:
+            [
+                new IngestionDiagnostic("project:discovery:fallback", "fallback warning"),
+            ]);
+        var runner = new IngestionRunner(new OntologyLoader(), pipeline);
+        var ontologyPath = WriteTempFile(
+            """
+            version: "1.0.0"
+            predicates:
+              - id: "core:contains"
+            """);
+
+        var request = new IngestionRunRequest(
+            RepositoryPath: ".",
+            ConfigPath: null,
+            OntologyPath: ontologyPath,
+            AllowPartialSuccess: false);
+
+        var result = await runner.RunAsync(request, CancellationToken.None);
+
+        Assert.Equal(IngestionRunStatus.SucceededWithDiagnostics, result.Status);
+        Assert.Equal(2, result.ExitCode);
+        Assert.NotNull(result.QualityGate);
+        Assert.True(result.QualityGate!.Passed);
+    }
+
     private static string WriteTempFile(string content)
     {
         var path = Path.Combine(Path.GetTempPath(), $"{Guid.NewGuid():N}.yaml");
@@ -123,10 +200,21 @@ public sealed class IngestionRunnerTests
     private sealed class CapturingPipeline : IIngestionPipeline
     {
         private readonly IReadOnlyList<IngestionDiagnostic> _diagnostics;
+        private readonly IReadOnlyList<SemanticTriple> _triples;
 
-        public CapturingPipeline(IReadOnlyList<IngestionDiagnostic>? diagnostics = null)
+        public CapturingPipeline(
+            IReadOnlyList<IngestionDiagnostic>? diagnostics = null,
+            IReadOnlyList<SemanticTriple>? triples = null)
         {
             _diagnostics = diagnostics ?? [];
+            _triples = triples
+                ??
+                [
+                    new SemanticTriple(
+                        new EntityNode(new EntityId("repository:fixture")),
+                        new PredicateId("core:contains"),
+                        new LiteralNode("noop")),
+                ];
         }
 
         public bool WasCalled { get; private set; }
@@ -134,13 +222,7 @@ public sealed class IngestionRunnerTests
         public Task<IngestionPipelineResult> ExecuteAsync(IngestionExecutionContext context, CancellationToken cancellationToken)
         {
             WasCalled = true;
-
-            var triple = new SemanticTriple(
-                new EntityNode(context.RepositoryId),
-                new PredicateId("core:contains"),
-                new LiteralNode("noop"));
-
-            return Task.FromResult(new IngestionPipelineResult([triple], _diagnostics));
+            return Task.FromResult(new IngestionPipelineResult(_triples, _diagnostics));
         }
     }
 }

--- a/tests/CodeLlmWiki.Ingestion.Tests/UnresolvedCallRatioQualityGateEvaluatorTests.cs
+++ b/tests/CodeLlmWiki.Ingestion.Tests/UnresolvedCallRatioQualityGateEvaluatorTests.cs
@@ -1,0 +1,70 @@
+using CodeLlmWiki.Ingestion.Diagnostics;
+using CodeLlmWiki.Ingestion.Quality;
+
+namespace CodeLlmWiki.Ingestion.Tests;
+
+public sealed class UnresolvedCallRatioQualityGateEvaluatorTests
+{
+    [Fact]
+    public void Evaluate_ReturnsFailed_WhenRatioExceedsThreshold()
+    {
+        var evaluator = new UnresolvedCallRatioQualityGateEvaluator();
+        var diagnostics = new[]
+        {
+            new IngestionDiagnostic(CallResolutionDiagnosticCodes.Aggregate, "failed 1"),
+            new IngestionDiagnostic(CallResolutionDiagnosticCodes.Aggregate, "failed 2"),
+            new IngestionDiagnostic("method:call:internal-target-unmatched", "failed 3"),
+            new IngestionDiagnostic("project:discovery:fallback", "warning"),
+        };
+
+        var evaluation = evaluator.Evaluate(new UnresolvedCallRatioQualityGateRequest(
+            Diagnostics: diagnostics,
+            TotalCallResolutionAttempts: 5,
+            Policy: new UnresolvedCallRatioQualityGatePolicy(Threshold: 0.5)));
+
+        Assert.False(evaluation.Passed);
+        Assert.Equal("quality:unresolved-call-ratio", evaluation.Evidence.GateId);
+        Assert.Equal(3, evaluation.Evidence.UnresolvedCallFailures);
+        Assert.Equal(5, evaluation.Evidence.TotalCallResolutionAttempts);
+        Assert.Equal(0.6d, evaluation.Evidence.UnresolvedCallRatio, 8);
+        Assert.Equal(0.5d, evaluation.Evidence.Threshold, 8);
+    }
+
+    [Fact]
+    public void Evaluate_ReturnsPassed_WhenRatioEqualsThreshold()
+    {
+        var evaluator = new UnresolvedCallRatioQualityGateEvaluator();
+        var diagnostics = new[]
+        {
+            new IngestionDiagnostic(CallResolutionDiagnosticCodes.Aggregate, "failed 1"),
+            new IngestionDiagnostic("method:call:internal-target-unmatched", "failed 2"),
+        };
+
+        var evaluation = evaluator.Evaluate(new UnresolvedCallRatioQualityGateRequest(
+            Diagnostics: diagnostics,
+            TotalCallResolutionAttempts: 4,
+            Policy: new UnresolvedCallRatioQualityGatePolicy(Threshold: 0.5)));
+
+        Assert.True(evaluation.Passed);
+        Assert.Equal(0.5d, evaluation.Evidence.UnresolvedCallRatio, 8);
+    }
+
+    [Fact]
+    public void Evaluate_ReturnsPassedWithZeroRatio_WhenNoCallAttempts()
+    {
+        var evaluator = new UnresolvedCallRatioQualityGateEvaluator();
+
+        var evaluation = evaluator.Evaluate(new UnresolvedCallRatioQualityGateRequest(
+            Diagnostics:
+            [
+                new IngestionDiagnostic(CallResolutionDiagnosticCodes.Aggregate, "failed 1"),
+                new IngestionDiagnostic("method:call:internal-target-unmatched", "failed 2"),
+            ],
+            TotalCallResolutionAttempts: 0,
+            Policy: new UnresolvedCallRatioQualityGatePolicy(Threshold: 0.1)));
+
+        Assert.True(evaluation.Passed);
+        Assert.Equal(0d, evaluation.Evidence.UnresolvedCallRatio, 8);
+        Assert.Equal(2, evaluation.Evidence.UnresolvedCallFailures);
+    }
+}


### PR DESCRIPTION
## Summary
- add a dedicated unresolved-call-ratio quality gate module with global default threshold and typed evidence
- integrate gate evaluation into ingestion run completion with explicit FailedQualityGate status and exit code mapping
- surface gate evidence in run manifests and emit CLI failure output with measured ratio and threshold

## Testing
- dotnet test tests/CodeLlmWiki.Ingestion.Tests/CodeLlmWiki.Ingestion.Tests.csproj
- dotnet test tests/CodeLlmWiki.Cli.Tests/CodeLlmWiki.Cli.Tests.csproj

Closes #123