### PR TITLE
PRD 010: phase 5 bounded parallel semantic processing

### DIFF
--- a/src/CodeLlmWiki.Cli/CliApplication.cs
+++ b/src/CodeLlmWiki.Cli/CliApplication.cs
@@ -58,12 +58,15 @@ public sealed class CliApplication
             ?? config.MaxMergeEntriesPerFile;
         var metricComputationMdop = options.MetricComputationMaxDegreeOfParallelism
             ?? config.MetricComputationMaxDegreeOfParallelism;
+        var semanticCallGraphMdop = options.SemanticCallGraphMaxDegreeOfParallelism
+            ?? config.SemanticCallGraphMaxDegreeOfParallelism;
 
         var request = new IngestionRunRequest(
             RepositoryPath: options.RepositoryPath,
             ConfigPath: options.ConfigPath,
             OntologyPath: ontologyPath,
-            AllowPartialSuccess: allowPartial);
+            AllowPartialSuccess: allowPartial,
+            SemanticCallGraphMaxDegreeOfParallelism: semanticCallGraphMdop);
 
         var startedAtUtc = DateTimeOffset.UtcNow;
         var result = await _runner.RunAsync(request, cancellationToken);

--- a/src/CodeLlmWiki.Cli/Commands/IngestOptions.cs
+++ b/src/CodeLlmWiki.Cli/Commands/IngestOptions.cs
@@ -25,4 +25,7 @@ public sealed class IngestOptions
 
     [Option('d', "metric-mdop", Required = false, HelpText = "Max degree of parallelism for metric/rollup computation.")]
     public int? MetricComputationMaxDegreeOfParallelism { get; init; }
+
+    [Option('s', "semantic-mdop", Required = false, HelpText = "Max degree of parallelism for semantic call graph project processing.")]
+    public int? SemanticCallGraphMaxDegreeOfParallelism { get; init; }
 }

--- a/src/CodeLlmWiki.Cli/Config/IngestionCliConfig.cs
+++ b/src/CodeLlmWiki.Cli/Config/IngestionCliConfig.cs
@@ -7,7 +7,8 @@ public sealed record IngestionCliConfig(
     bool? AllowPartialSuccess,
     string? OutputRoot,
     [property: JsonPropertyName("max_merge_entries_per_file")] int? MaxMergeEntriesPerFile,
-    [property: JsonPropertyName("metric_computation_max_degree_of_parallelism")] int? MetricComputationMaxDegreeOfParallelism)
+    [property: JsonPropertyName("metric_computation_max_degree_of_parallelism")] int? MetricComputationMaxDegreeOfParallelism,
+    [property: JsonPropertyName("semantic_call_max_degree_of_parallelism")] int? SemanticCallGraphMaxDegreeOfParallelism)
 {
-    public static readonly IngestionCliConfig Empty = new(null, null, null, null, null);
+    public static readonly IngestionCliConfig Empty = new(null, null, null, null, null, null);
 }

--- a/src/CodeLlmWiki.Ingestion/IngestionExecutionContext.cs
+++ b/src/CodeLlmWiki.Ingestion/IngestionExecutionContext.cs
@@ -6,4 +6,5 @@ namespace CodeLlmWiki.Ingestion;
 public sealed record IngestionExecutionContext(
     string RepositoryPath,
     EntityId RepositoryId,
-    OntologyDefinition Ontology);
+    OntologyDefinition Ontology,
+    int? SemanticCallGraphMaxDegreeOfParallelism = null);

--- a/src/CodeLlmWiki.Ingestion/IngestionRunRequest.cs
+++ b/src/CodeLlmWiki.Ingestion/IngestionRunRequest.cs
@@ -4,4 +4,5 @@ public sealed record IngestionRunRequest(
     string RepositoryPath,
     string? ConfigPath,
     string OntologyPath,
-    bool AllowPartialSuccess);
+    bool AllowPartialSuccess,
+    int? SemanticCallGraphMaxDegreeOfParallelism = null);

--- a/src/CodeLlmWiki.Ingestion/IngestionRunner.cs
+++ b/src/CodeLlmWiki.Ingestion/IngestionRunner.cs
@@ -36,7 +36,11 @@ public sealed class IngestionRunner : IIngestionRunner
         var fullRepositoryPath = Path.GetFullPath(request.RepositoryPath);
         var repositoryId = _stableIdGenerator.Create(new EntityKey("repository", fullRepositoryPath));
 
-        var context = new IngestionExecutionContext(fullRepositoryPath, repositoryId, ontology.Definition);
+        var context = new IngestionExecutionContext(
+            RepositoryPath: fullRepositoryPath,
+            RepositoryId: repositoryId,
+            Ontology: ontology.Definition,
+            SemanticCallGraphMaxDegreeOfParallelism: request.SemanticCallGraphMaxDegreeOfParallelism);
 
         var pipelineResult = await _pipeline.ExecuteAsync(context, cancellationToken);
         var diagnostics = pipelineResult.Diagnostics.ToArray();

--- a/src/CodeLlmWiki.Ingestion/ProjectStructure/IProjectStructureAnalyzer.cs
+++ b/src/CodeLlmWiki.Ingestion/ProjectStructure/IProjectStructureAnalyzer.cs
@@ -2,5 +2,8 @@ namespace CodeLlmWiki.Ingestion.ProjectStructure;
 
 public interface IProjectStructureAnalyzer
 {
-    Task<ProjectStructureAnalysisResult> AnalyzeAsync(string repositoryPath, CancellationToken cancellationToken);
+    Task<ProjectStructureAnalysisResult> AnalyzeAsync(
+        string repositoryPath,
+        CancellationToken cancellationToken,
+        ProjectStructureAnalysisOptions? options = null);
 }

--- a/src/CodeLlmWiki.Ingestion/ProjectStructure/ProjectStructureAnalysisOptions.cs
+++ b/src/CodeLlmWiki.Ingestion/ProjectStructure/ProjectStructureAnalysisOptions.cs
@@ -1,0 +1,10 @@
+namespace CodeLlmWiki.Ingestion.ProjectStructure;
+
+public sealed record ProjectStructureAnalysisOptions(
+    int? SemanticCallGraphMaxDegreeOfParallelism = null)
+{
+    public static readonly ProjectStructureAnalysisOptions Default = new();
+
+    public int EffectiveSemanticCallGraphMaxDegreeOfParallelism =>
+        Math.Max(1, SemanticCallGraphMaxDegreeOfParallelism ?? 1);
+}

--- a/src/CodeLlmWiki.Ingestion/ProjectStructure/ProjectStructureAnalyzer.cs
+++ b/src/CodeLlmWiki.Ingestion/ProjectStructure/ProjectStructureAnalyzer.cs
@@ -2,6 +2,7 @@ using System.Xml.Linq;
 using System.Text.Json;
 using System.Diagnostics;
 using System.Globalization;
+using System.Collections.Concurrent;
 using CodeLlmWiki.Contracts.Graph;
 using CodeLlmWiki.Contracts.Identity;
 using CodeLlmWiki.Ingestion.Diagnostics;
@@ -25,6 +26,8 @@ public sealed class ProjectStructureAnalyzer : IProjectStructureAnalyzer
     private readonly ICallResolutionDiagnosticClassifier _callResolutionDiagnosticClassifier;
     private readonly IIngestionStageTelemetry _stageTelemetry;
     private readonly IProjectScopedCompilationProvider _projectScopedCompilationProvider;
+    private readonly object _externalStubGate = new();
+    private readonly object _unresolvedCallTargetGate = new();
 
     public ProjectStructureAnalyzer(
         IStableIdGenerator stableIdGenerator,
@@ -40,8 +43,12 @@ public sealed class ProjectStructureAnalyzer : IProjectStructureAnalyzer
         _projectScopedCompilationProvider = projectScopedCompilationProvider ?? new ProjectScopedCompilationProvider();
     }
 
-    public Task<ProjectStructureAnalysisResult> AnalyzeAsync(string repositoryPath, CancellationToken cancellationToken)
+    public Task<ProjectStructureAnalysisResult> AnalyzeAsync(
+        string repositoryPath,
+        CancellationToken cancellationToken,
+        ProjectStructureAnalysisOptions? options = null)
     {
+        var analysisOptions = options ?? ProjectStructureAnalysisOptions.Default;
         var triples = new List<SemanticTriple>();
         var diagnostics = new List<IngestionDiagnostic>();
 
@@ -270,6 +277,7 @@ public sealed class ProjectStructureAnalyzer : IProjectStructureAnalyzer
             projectAssemblyNameByPath,
             triples,
             diagnostics,
+            analysisOptions.EffectiveSemanticCallGraphMaxDegreeOfParallelism,
             cancellationToken);
 
         return Task.FromResult(new ProjectStructureAnalysisResult(repositoryId, triples, diagnostics));
@@ -283,6 +291,7 @@ public sealed class ProjectStructureAnalyzer : IProjectStructureAnalyzer
         IReadOnlyDictionary<string, string> projectAssemblyNameByPath,
         List<SemanticTriple> triples,
         List<IngestionDiagnostic> diagnostics,
+        int semanticCallGraphMaxDegreeOfParallelism,
         CancellationToken cancellationToken)
     {
         if (sourceFiles.Count == 0)
@@ -1031,7 +1040,8 @@ public sealed class ProjectStructureAnalyzer : IProjectStructureAnalyzer
                 externalStubIdByReference,
                 unresolvedCallTargetIdByText,
                 triples,
-                diagnostics);
+                diagnostics,
+                semanticCallGraphMaxDegreeOfParallelism);
             var callEdgeCountAfter = CountPredicateOccurrences(triples, CorePredicates.Calls);
             semanticCallGraphStage.SetCounters(
                 new Dictionary<string, long>
@@ -1039,6 +1049,8 @@ public sealed class ProjectStructureAnalyzer : IProjectStructureAnalyzer
                     ["method_count"] = methodIdByDeclarationLocation.Count,
                     ["call_edges"] = callEdgeCountAfter,
                     ["call_edges_added"] = Math.Max(0, callEdgeCountAfter - callEdgeCountBefore),
+                    ["semantic_mdop"] = Math.Max(1, semanticCallGraphMaxDegreeOfParallelism),
+                    ["semantic_projects"] = projectAssemblyNameByPath.Count,
                 });
         }
 
@@ -3172,7 +3184,8 @@ public sealed class ProjectStructureAnalyzer : IProjectStructureAnalyzer
         Dictionary<string, EntityId> externalStubIdByReference,
         Dictionary<string, EntityId> unresolvedCallTargetIdByText,
         List<SemanticTriple> triples,
-        List<IngestionDiagnostic> diagnostics)
+        List<IngestionDiagnostic> diagnostics,
+        int semanticCallGraphMaxDegreeOfParallelism)
     {
         if (sourceFiles.Count == 0)
         {
@@ -3190,11 +3203,94 @@ public sealed class ProjectStructureAnalyzer : IProjectStructureAnalyzer
                 References: references),
             diagnostics);
 
+        var projectBatches = BuildSemanticCallProjectBatches(repositoryRoot, sourceFiles, projectAssemblyNameByPath);
+        var effectiveMdop = Math.Max(1, semanticCallGraphMaxDegreeOfParallelism);
+        List<SemanticCallProjectBatchResult> projectResults;
+
+        if (effectiveMdop == 1 || projectBatches.Count <= 1)
+        {
+            projectResults = projectBatches
+                .Select(batch => ProcessSemanticCallProjectBatch(
+                    batch,
+                    semanticContext,
+                    typeIdByQualifiedName,
+                    methodCandidatesByTypeId,
+                    declaringTypeIdByMethodId,
+                    memberIdByDeclarationLocation,
+                    methodIdByDeclarationLocation,
+                    externalStubIdByReference,
+                    unresolvedCallTargetIdByText))
+                .ToList();
+        }
+        else
+        {
+            var bag = new ConcurrentBag<SemanticCallProjectBatchResult>();
+            Parallel.ForEach(
+                projectBatches,
+                new ParallelOptions
+                {
+                    MaxDegreeOfParallelism = effectiveMdop,
+                },
+                batch =>
+                {
+                    var result = ProcessSemanticCallProjectBatch(
+                        batch,
+                        semanticContext,
+                        typeIdByQualifiedName,
+                        methodCandidatesByTypeId,
+                        declaringTypeIdByMethodId,
+                        memberIdByDeclarationLocation,
+                        methodIdByDeclarationLocation,
+                        externalStubIdByReference,
+                        unresolvedCallTargetIdByText);
+                    bag.Add(result);
+                });
+            projectResults = bag.ToList();
+        }
+
+        var mergedDeclarationDependenciesByTypeId = new Dictionary<EntityId, HashSet<EntityId>>();
+        var mergedMethodBodyDependenciesByTypeId = new Dictionary<EntityId, HashSet<EntityId>>();
+
+        foreach (var result in projectResults)
+        {
+            MergeTypeDependencyMap(mergedDeclarationDependenciesByTypeId, result.DeclarationDependenciesByTypeId);
+            MergeTypeDependencyMap(mergedMethodBodyDependenciesByTypeId, result.MethodBodyDependenciesByTypeId);
+        }
+
+        var orderedTriples = projectResults
+            .SelectMany(x => x.Triples)
+            .OrderBy(CreateDeterministicTripleSortKey, StringComparer.Ordinal)
+            .ToArray();
+        triples.AddRange(orderedTriples);
+
+        var orderedDiagnostics = projectResults
+            .SelectMany(x => x.Diagnostics)
+            .OrderBy(x => x.Code, StringComparer.Ordinal)
+            .ThenBy(x => x.Message, StringComparer.Ordinal)
+            .ToArray();
+        diagnostics.AddRange(orderedDiagnostics);
+
+        EmitCboMetricsByType(typeIdByQualifiedName.Values, mergedDeclarationDependenciesByTypeId, mergedMethodBodyDependenciesByTypeId, triples);
+    }
+
+    private SemanticCallProjectBatchResult ProcessSemanticCallProjectBatch(
+        SemanticCallProjectBatch projectBatch,
+        IProjectScopedSemanticContext semanticContext,
+        IReadOnlyDictionary<string, EntityId> typeIdByQualifiedName,
+        IReadOnlyDictionary<EntityId, List<MethodRelationshipCandidate>> methodCandidatesByTypeId,
+        IReadOnlyDictionary<EntityId, EntityId> declaringTypeIdByMethodId,
+        IReadOnlyDictionary<MemberDeclarationLocationKey, EntityId> memberIdByDeclarationLocation,
+        IReadOnlyDictionary<MethodDeclarationLocationKey, EntityId> methodIdByDeclarationLocation,
+        Dictionary<string, EntityId> externalStubIdByReference,
+        Dictionary<string, EntityId> unresolvedCallTargetIdByText)
+    {
         var declarationDependenciesByTypeId = new Dictionary<EntityId, HashSet<EntityId>>();
         var methodBodyDependenciesByTypeId = new Dictionary<EntityId, HashSet<EntityId>>();
         var emittedMethodMetricIds = new HashSet<EntityId>();
+        var triples = new List<SemanticTriple>();
+        var diagnostics = new List<IngestionDiagnostic>();
 
-        foreach (var relativePath in sourceFiles.OrderBy(x => x, StringComparer.Ordinal))
+        foreach (var relativePath in projectBatch.SourceFiles)
         {
             if (!semanticContext.TryGetSemanticModel(relativePath, out var semanticModel, out _))
             {
@@ -3316,7 +3412,117 @@ public sealed class ProjectStructureAnalyzer : IProjectStructureAnalyzer
             }
         }
 
-        EmitCboMetricsByType(typeIdByQualifiedName.Values, declarationDependenciesByTypeId, methodBodyDependenciesByTypeId, triples);
+        return new SemanticCallProjectBatchResult(
+            projectBatch.ProjectSortKey,
+            triples,
+            diagnostics,
+            declarationDependenciesByTypeId,
+            methodBodyDependenciesByTypeId);
+    }
+
+    private static IReadOnlyList<SemanticCallProjectBatch> BuildSemanticCallProjectBatches(
+        string repositoryRoot,
+        IReadOnlyList<string> sourceFiles,
+        IReadOnlyDictionary<string, string> projectAssemblyNameByPath)
+    {
+        var projectContexts = projectAssemblyNameByPath.Keys
+            .Select(projectPath => new
+            {
+                ProjectPath = Path.GetFullPath(projectPath),
+                ProjectSortKey = ToRelativePath(repositoryRoot, Path.GetFullPath(projectPath)),
+                RelativeDirectory = ToRelativePath(repositoryRoot, Path.GetDirectoryName(projectPath) ?? string.Empty),
+            })
+            .OrderByDescending(x => x.RelativeDirectory.Length)
+            .ThenBy(x => x.RelativeDirectory, StringComparer.Ordinal)
+            .ToArray();
+
+        var filesByProjectSortKey = new Dictionary<string, List<string>>(StringComparer.Ordinal);
+        var fallbackFiles = new List<string>();
+
+        foreach (var relativePath in sourceFiles.Distinct(StringComparer.Ordinal).OrderBy(x => x, StringComparer.Ordinal))
+        {
+            string? matchedProjectSortKey = null;
+            foreach (var context in projectContexts)
+            {
+                if (IsSourceFileUnderProjectDirectory(relativePath, context.RelativeDirectory))
+                {
+                    matchedProjectSortKey = context.ProjectSortKey;
+                    break;
+                }
+            }
+
+            if (matchedProjectSortKey is null)
+            {
+                fallbackFiles.Add(relativePath);
+                continue;
+            }
+
+            if (!filesByProjectSortKey.TryGetValue(matchedProjectSortKey, out var files))
+            {
+                files = [];
+                filesByProjectSortKey[matchedProjectSortKey] = files;
+            }
+
+            files.Add(relativePath);
+        }
+
+        var batches = filesByProjectSortKey
+            .OrderBy(x => x.Key, StringComparer.Ordinal)
+            .Select(x => new SemanticCallProjectBatch(
+                x.Key,
+                x.Value.OrderBy(y => y, StringComparer.Ordinal).ToArray()))
+            .ToList();
+
+        if (fallbackFiles.Count > 0)
+        {
+            batches.Add(new SemanticCallProjectBatch(
+                "_fallback",
+                fallbackFiles.OrderBy(x => x, StringComparer.Ordinal).ToArray()));
+        }
+
+        return batches;
+    }
+
+    private static bool IsSourceFileUnderProjectDirectory(string relativeSourceFilePath, string relativeProjectDirectory)
+    {
+        if (string.IsNullOrWhiteSpace(relativeProjectDirectory) || relativeProjectDirectory == ".")
+        {
+            return true;
+        }
+
+        return relativeSourceFilePath.Equals(relativeProjectDirectory, StringComparison.Ordinal)
+               || relativeSourceFilePath.StartsWith(relativeProjectDirectory + "/", StringComparison.Ordinal);
+    }
+
+    private static void MergeTypeDependencyMap(
+        Dictionary<EntityId, HashSet<EntityId>> target,
+        IReadOnlyDictionary<EntityId, HashSet<EntityId>> source)
+    {
+        foreach (var pair in source)
+        {
+            if (!target.TryGetValue(pair.Key, out var targetSet))
+            {
+                targetSet = [];
+                target[pair.Key] = targetSet;
+            }
+
+            targetSet.UnionWith(pair.Value);
+        }
+    }
+
+    private static string CreateDeterministicTripleSortKey(SemanticTriple triple)
+    {
+        return $"{CreateDeterministicNodeSortKey(triple.Subject)}|{triple.Predicate.Value}|{CreateDeterministicNodeSortKey(triple.Object)}";
+    }
+
+    private static string CreateDeterministicNodeSortKey(GraphNode node)
+    {
+        return node switch
+        {
+            EntityNode entity => $"E:{entity.Id.Value}",
+            LiteralNode literal => $"L:{literal.Value?.ToString() ?? string.Empty}",
+            _ => node.ToString() ?? string.Empty,
+        };
     }
 
     private static void AppendTypeDependencies(
@@ -4711,27 +4917,30 @@ public sealed class ProjectStructureAnalyzer : IProjectStructureAnalyzer
         Dictionary<string, EntityId> unresolvedCallTargetIdByText,
         List<SemanticTriple> triples)
     {
-        var key = $"{resolutionReason}|{targetText}";
-        if (unresolvedCallTargetIdByText.TryGetValue(key, out var existing))
+        lock (_unresolvedCallTargetGate)
         {
-            return existing;
+            var key = $"{resolutionReason}|{targetText}";
+            if (unresolvedCallTargetIdByText.TryGetValue(key, out var existing))
+            {
+                return existing;
+            }
+
+            var unresolvedNaturalKey = $"{resolutionReason}:{targetText}";
+            var unresolvedId = _stableIdGenerator.Create(new EntityKey("unresolved-call-target", unresolvedNaturalKey));
+            unresolvedCallTargetIdByText[key] = unresolvedId;
+            AddEntityTriples(
+                triples,
+                unresolvedId,
+                "unresolved-call-target",
+                targetText,
+                $"unresolved-call/{targetText}");
+            triples.Add(new SemanticTriple(
+                new EntityNode(unresolvedId),
+                CorePredicates.ResolutionReason,
+                new LiteralNode(resolutionReason)));
+
+            return unresolvedId;
         }
-
-        var unresolvedNaturalKey = $"{resolutionReason}:{targetText}";
-        var unresolvedId = _stableIdGenerator.Create(new EntityKey("unresolved-call-target", unresolvedNaturalKey));
-        unresolvedCallTargetIdByText[key] = unresolvedId;
-        AddEntityTriples(
-            triples,
-            unresolvedId,
-            "unresolved-call-target",
-            targetText,
-            $"unresolved-call/{targetText}");
-        triples.Add(new SemanticTriple(
-            new EntityNode(unresolvedId),
-            CorePredicates.ResolutionReason,
-            new LiteralNode(resolutionReason)));
-
-        return unresolvedId;
     }
 
     private static string FormatDeclarationSourceLocation(DeclarationSourceLocation location)
@@ -4796,22 +5005,25 @@ public sealed class ProjectStructureAnalyzer : IProjectStructureAnalyzer
         Dictionary<string, EntityId> externalStubIdByReference,
         List<SemanticTriple> triples)
     {
-        if (externalStubIdByReference.TryGetValue(referenceName, out var existing))
+        lock (_externalStubGate)
         {
-            return existing;
+            if (externalStubIdByReference.TryGetValue(referenceName, out var existing))
+            {
+                return existing;
+            }
+
+            var stubId = _stableIdGenerator.Create(new EntityKey("external-type-stub", referenceName));
+            externalStubIdByReference[referenceName] = stubId;
+
+            AddEntityTriples(
+                triples,
+                stubId,
+                "external-type-stub",
+                referenceName,
+                $"external/{referenceName}");
+
+            return stubId;
         }
-
-        var stubId = _stableIdGenerator.Create(new EntityKey("external-type-stub", referenceName));
-        externalStubIdByReference[referenceName] = stubId;
-
-        AddEntityTriples(
-            triples,
-            stubId,
-            "external-type-stub",
-            referenceName,
-            $"external/{referenceName}");
-
-        return stubId;
     }
 
     private EntityId GetOrCreateUnresolvedReferenceId(
@@ -6080,6 +6292,17 @@ public sealed class ProjectStructureAnalyzer : IProjectStructureAnalyzer
             entry.EndsWith("/", StringComparison.Ordinal) &&
             relativeFilePath.StartsWith(entry, StringComparison.OrdinalIgnoreCase));
     }
+
+    private sealed record SemanticCallProjectBatch(
+        string ProjectSortKey,
+        IReadOnlyList<string> SourceFiles);
+
+    private sealed record SemanticCallProjectBatchResult(
+        string ProjectSortKey,
+        IReadOnlyList<SemanticTriple> Triples,
+        IReadOnlyList<IngestionDiagnostic> Diagnostics,
+        IReadOnlyDictionary<EntityId, HashSet<EntityId>> DeclarationDependenciesByTypeId,
+        IReadOnlyDictionary<EntityId, HashSet<EntityId>> MethodBodyDependenciesByTypeId);
 
     private sealed record ProjectDiscoveryResult(
         string Name,

--- a/src/CodeLlmWiki.Ingestion/ProjectStructure/ProjectStructureIngestionPipeline.cs
+++ b/src/CodeLlmWiki.Ingestion/ProjectStructure/ProjectStructureIngestionPipeline.cs
@@ -11,7 +11,11 @@ public sealed class ProjectStructureIngestionPipeline : IIngestionPipeline
 
     public async Task<IngestionPipelineResult> ExecuteAsync(IngestionExecutionContext context, CancellationToken cancellationToken)
     {
-        var result = await _analyzer.AnalyzeAsync(context.RepositoryPath, cancellationToken);
+        var result = await _analyzer.AnalyzeAsync(
+            context.RepositoryPath,
+            cancellationToken,
+            new ProjectStructureAnalysisOptions(
+                SemanticCallGraphMaxDegreeOfParallelism: context.SemanticCallGraphMaxDegreeOfParallelism));
         return new IngestionPipelineResult(result.Triples, result.Diagnostics);
     }
 }

--- a/tests/CodeLlmWiki.Cli.Tests/CliApplicationTests.cs
+++ b/tests/CodeLlmWiki.Cli.Tests/CliApplicationTests.cs
@@ -95,7 +95,8 @@ public sealed class CliApplicationTests
             {
               "ontologyPath": "./ontology/ontology.v1.yaml",
               "max_merge_entries_per_file": 7,
-              "metric_computation_max_degree_of_parallelism": 5
+              "metric_computation_max_degree_of_parallelism": 5,
+              "semantic_call_max_degree_of_parallelism": 2
             }
             """);
 
@@ -110,13 +111,16 @@ public sealed class CliApplicationTests
                 "--config", configPath,
                 "--max-merge-entries-per-file", "3",
                 "--metric-mdop", "4",
+                "--semantic-mdop", "6",
             ],
             CancellationToken.None);
 
         Assert.Equal(0, exitCode);
         Assert.NotNull(publisher.LastRequest);
+        Assert.NotNull(runner.LastRequest);
         Assert.Equal(3, publisher.LastRequest!.MaxMergeEntriesPerFile);
         Assert.Equal(4, publisher.LastRequest.MetricComputationMaxDegreeOfParallelism);
+        Assert.Equal(6, runner.LastRequest!.SemanticCallGraphMaxDegreeOfParallelism);
     }
 
     [Fact]

--- a/tests/CodeLlmWiki.Ingestion.Tests/IngestionRunnerTests.cs
+++ b/tests/CodeLlmWiki.Ingestion.Tests/IngestionRunnerTests.cs
@@ -190,6 +190,31 @@ public sealed class IngestionRunnerTests
         Assert.True(result.QualityGate!.Passed);
     }
 
+    [Fact]
+    public async Task RunAsync_PassesSemanticCallGraphMdop_IntoExecutionContext()
+    {
+        var pipeline = new CapturingPipeline();
+        var runner = new IngestionRunner(new OntologyLoader(), pipeline);
+        var ontologyPath = WriteTempFile(
+            """
+            version: "1.0.0"
+            predicates:
+              - id: "core:contains"
+            """);
+
+        var request = new IngestionRunRequest(
+            RepositoryPath: ".",
+            ConfigPath: null,
+            OntologyPath: ontologyPath,
+            AllowPartialSuccess: false,
+            SemanticCallGraphMaxDegreeOfParallelism: 7);
+
+        _ = await runner.RunAsync(request, CancellationToken.None);
+
+        Assert.NotNull(pipeline.LastContext);
+        Assert.Equal(7, pipeline.LastContext!.SemanticCallGraphMaxDegreeOfParallelism);
+    }
+
     private static string WriteTempFile(string content)
     {
         var path = Path.Combine(Path.GetTempPath(), $"{Guid.NewGuid():N}.yaml");
@@ -218,10 +243,12 @@ public sealed class IngestionRunnerTests
         }
 
         public bool WasCalled { get; private set; }
+        public IngestionExecutionContext? LastContext { get; private set; }
 
         public Task<IngestionPipelineResult> ExecuteAsync(IngestionExecutionContext context, CancellationToken cancellationToken)
         {
             WasCalled = true;
+            LastContext = context;
             return Task.FromResult(new IngestionPipelineResult(_triples, _diagnostics));
         }
     }

--- a/tests/CodeLlmWiki.Ingestion.Tests/MethodCallsVerticalSliceTests.cs
+++ b/tests/CodeLlmWiki.Ingestion.Tests/MethodCallsVerticalSliceTests.cs
@@ -1,4 +1,5 @@
 using System.Diagnostics;
+using CodeLlmWiki.Contracts.Graph;
 using CodeLlmWiki.Contracts.Identity;
 using CodeLlmWiki.Ingestion.ProjectStructure;
 using CodeLlmWiki.Query.ProjectStructure;
@@ -136,6 +137,31 @@ public sealed class MethodCallsVerticalSliceTests
         var secondSnapshot = BuildCallSnapshot(secondModel);
 
         Assert.Equal(firstSnapshot, secondSnapshot);
+    }
+
+    [Fact]
+    public async Task Query_ProjectScopedCallResolution_IsDeterministicAcrossParallelDegreeSettings()
+    {
+        var fixture = await ProjectScopedMethodCallsFixture.CreateAsync();
+        var analyzer = new ProjectStructureAnalyzer(new StableIdGenerator());
+
+        var serial = await analyzer.AnalyzeAsync(
+            fixture.RepositoryPath,
+            CancellationToken.None,
+            new ProjectStructureAnalysisOptions(SemanticCallGraphMaxDegreeOfParallelism: 1));
+        var parallelFirst = await analyzer.AnalyzeAsync(
+            fixture.RepositoryPath,
+            CancellationToken.None,
+            new ProjectStructureAnalysisOptions(SemanticCallGraphMaxDegreeOfParallelism: 4));
+        var parallelSecond = await analyzer.AnalyzeAsync(
+            fixture.RepositoryPath,
+            CancellationToken.None,
+            new ProjectStructureAnalysisOptions(SemanticCallGraphMaxDegreeOfParallelism: 4));
+
+        Assert.Equal(BuildTripleSnapshot(serial.Triples), BuildTripleSnapshot(parallelFirst.Triples));
+        Assert.Equal(BuildTripleSnapshot(parallelFirst.Triples), BuildTripleSnapshot(parallelSecond.Triples));
+        Assert.Equal(BuildDiagnosticSnapshot(serial.Diagnostics), BuildDiagnosticSnapshot(parallelFirst.Diagnostics));
+        Assert.Equal(BuildDiagnosticSnapshot(parallelFirst.Diagnostics), BuildDiagnosticSnapshot(parallelSecond.Diagnostics));
     }
 
     private sealed class MethodCallsFixture
@@ -376,6 +402,22 @@ public sealed class MethodCallsVerticalSliceTests
             .Where(x => x.Kind == MethodRelationKind.Calls && x.SourceMethodId == callMethod.Id)
             .Select(x =>
                 $"{x.SourceMethodId.Value}|{x.TargetMethodId?.Value ?? "-"}|{x.ResolutionStatus}|{x.ResolutionReason ?? "-"}|{x.ExternalTargetType?.DisplayText ?? "-"}")
+            .OrderBy(x => x, StringComparer.Ordinal)
+            .ToArray();
+    }
+
+    private static IReadOnlyList<string> BuildTripleSnapshot(IReadOnlyList<SemanticTriple> triples)
+    {
+        return triples
+            .Select(triple => $"{triple.Subject}|{triple.Predicate}|{triple.Object}")
+            .OrderBy(x => x, StringComparer.Ordinal)
+            .ToArray();
+    }
+
+    private static IReadOnlyList<string> BuildDiagnosticSnapshot(IReadOnlyList<IngestionDiagnostic> diagnostics)
+    {
+        return diagnostics
+            .Select(diagnostic => $"{diagnostic.Code}|{diagnostic.Message}")
             .OrderBy(x => x, StringComparer.Ordinal)
             .ToArray();
     }

--- a/tests/CodeLlmWiki.Ingestion.Tests/SemanticCallParallelPerformanceBudgetTests.cs
+++ b/tests/CodeLlmWiki.Ingestion.Tests/SemanticCallParallelPerformanceBudgetTests.cs
@@ -1,0 +1,164 @@
+using System.Diagnostics;
+using CodeLlmWiki.Contracts.Graph;
+using CodeLlmWiki.Contracts.Identity;
+using CodeLlmWiki.Ingestion.ProjectStructure;
+
+namespace CodeLlmWiki.Ingestion.Tests;
+
+public sealed class SemanticCallParallelPerformanceBudgetTests
+{
+    [Fact]
+    public async Task AnalyzeAsync_ParallelSemanticCallProcessing_IsDeterministic_AndWithinBudget()
+    {
+        var fixture = await ParallelSemanticFixture.CreateAsync();
+        var analyzer = new ProjectStructureAnalyzer(new StableIdGenerator());
+
+        var serialWatch = Stopwatch.StartNew();
+        var serial = await analyzer.AnalyzeAsync(
+            fixture.RepositoryPath,
+            CancellationToken.None,
+            new ProjectStructureAnalysisOptions(SemanticCallGraphMaxDegreeOfParallelism: 1));
+        serialWatch.Stop();
+
+        var parallelWatch = Stopwatch.StartNew();
+        var parallel = await analyzer.AnalyzeAsync(
+            fixture.RepositoryPath,
+            CancellationToken.None,
+            new ProjectStructureAnalysisOptions(SemanticCallGraphMaxDegreeOfParallelism: 4));
+        parallelWatch.Stop();
+
+        Assert.NotEmpty(parallel.Triples);
+        Assert.Equal(BuildTripleSnapshot(serial.Triples), BuildTripleSnapshot(parallel.Triples));
+        Assert.Equal(BuildDiagnosticSnapshot(serial.Diagnostics), BuildDiagnosticSnapshot(parallel.Diagnostics));
+
+        Assert.True(
+            parallelWatch.ElapsedMilliseconds <= (serialWatch.ElapsedMilliseconds * 3) + 1_500,
+            $"Parallel semantic processing overhead exceeded tolerance. serial={serialWatch.ElapsedMilliseconds}ms parallel={parallelWatch.ElapsedMilliseconds}ms");
+    }
+
+    private static IReadOnlyList<string> BuildTripleSnapshot(IReadOnlyList<SemanticTriple> triples)
+    {
+        return triples
+            .Select(triple => $"{triple.Subject}|{triple.Predicate}|{triple.Object}")
+            .OrderBy(x => x, StringComparer.Ordinal)
+            .ToArray();
+    }
+
+    private static IReadOnlyList<string> BuildDiagnosticSnapshot(IReadOnlyList<IngestionDiagnostic> diagnostics)
+    {
+        return diagnostics
+            .Select(diagnostic => $"{diagnostic.Code}|{diagnostic.Message}")
+            .OrderBy(x => x, StringComparer.Ordinal)
+            .ToArray();
+    }
+
+    private sealed class ParallelSemanticFixture
+    {
+        private ParallelSemanticFixture(string repositoryPath)
+        {
+            RepositoryPath = repositoryPath;
+        }
+
+        public string RepositoryPath { get; }
+
+        public static async Task<ParallelSemanticFixture> CreateAsync()
+        {
+            var root = Path.Combine(Path.GetTempPath(), $"codellmwiki-semantic-parallel-{Guid.NewGuid():N}", "fixture-repo");
+            Directory.CreateDirectory(root);
+
+            const int projectCount = 8;
+            const int workerCountPerProject = 8;
+
+            var slnx = new System.Text.StringBuilder();
+            slnx.AppendLine("<Solution>");
+            for (var i = 1; i <= projectCount; i++)
+            {
+                slnx.AppendLine($"  <Project Path=\"src/Project{i}/Project{i}.csproj\" />");
+            }
+
+            slnx.AppendLine("</Solution>");
+            await File.WriteAllTextAsync(Path.Combine(root, "Sample.slnx"), slnx.ToString());
+
+            for (var i = 1; i <= projectCount; i++)
+            {
+                var projectDir = Path.Combine(root, "src", $"Project{i}");
+                Directory.CreateDirectory(projectDir);
+
+                await File.WriteAllTextAsync(Path.Combine(projectDir, $"Project{i}.csproj"),
+                    $"""
+                    <Project Sdk=\"Microsoft.NET.Sdk\">
+                      <PropertyGroup>
+                        <TargetFramework>net10.0</TargetFramework>
+                        <AssemblyName>Perf.Project{i}</AssemblyName>
+                      </PropertyGroup>
+                    </Project>
+                    """);
+
+                for (var worker = 1; worker <= workerCountPerProject; worker++)
+                {
+                    await File.WriteAllTextAsync(Path.Combine(projectDir, $"Worker{worker}.cs"),
+                        $@"namespace Perf.Project{i};
+
+public class Worker{worker}
+{{
+    public void Ping()
+    {{
+        System.Console.WriteLine(""{i}:{worker}"");
+    }}
+}}");
+                }
+
+                var caller = new System.Text.StringBuilder();
+                caller.AppendLine($"namespace Perf.Project{i};");
+                caller.AppendLine();
+                caller.AppendLine("public class Caller");
+                caller.AppendLine("{");
+                caller.AppendLine("    public void CallAll()");
+                caller.AppendLine("    {");
+
+                for (var worker = 1; worker <= workerCountPerProject; worker++)
+                {
+                    caller.AppendLine($"        new Worker{worker}().Ping();");
+                }
+
+                caller.AppendLine("    }");
+                caller.AppendLine("}");
+                await File.WriteAllTextAsync(Path.Combine(projectDir, "Caller.cs"), caller.ToString());
+            }
+
+            RunGit(root, "init", "-b", "main");
+            RunGit(root, "config", "user.email", "test@example.com");
+            RunGit(root, "config", "user.name", "Test User");
+            RunGit(root, "add", ".");
+            RunGit(root, "commit", "-m", "initial");
+
+            return new ParallelSemanticFixture(root);
+        }
+    }
+
+    private static void RunGit(string workingDirectory, params string[] args)
+    {
+        var startInfo = new ProcessStartInfo
+        {
+            FileName = "git",
+            WorkingDirectory = workingDirectory,
+            RedirectStandardOutput = true,
+            RedirectStandardError = true,
+        };
+
+        foreach (var arg in args)
+        {
+            startInfo.ArgumentList.Add(arg);
+        }
+
+        using var process = Process.Start(startInfo)!;
+        process.WaitForExit();
+
+        if (process.ExitCode != 0)
+        {
+            var stdOut = process.StandardOutput.ReadToEnd();
+            var stdErr = process.StandardError.ReadToEnd();
+            throw new InvalidOperationException($"git {string.Join(' ', args)} failed: {stdOut}\n{stdErr}");
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- add bounded semantic call-graph project processing with configurable MDOP and deterministic merged triple/diagnostic ordering
- plumb semantic MDOP configuration from CLI/config into ingestion execution context and analyzer options
- harden with determinism and performance-budget tests for serial vs parallel semantic processing

## Testing
- dotnet test tests/CodeLlmWiki.Ingestion.Tests/CodeLlmWiki.Ingestion.Tests.csproj
- dotnet test tests/CodeLlmWiki.Cli.Tests/CodeLlmWiki.Cli.Tests.csproj

Closes #124