### PR TITLE
PRD 010: phase 6 diagnostics runbook and contract hardening

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -8,14 +8,16 @@ Use this file to rehydrate project context quickly for any new agent/session.
    - `/plans/BACKLOG.md`
 2. Read planning standards:
    - `/plans/README.md`
-3. Read implemented PRDs and plans:
+3. Read operator diagnostics runbook:
+   - `/docs/diagnostics-runbook.md`
+4. Read implemented PRDs and plans:
    - `/plans/001/001-phase-1-dotnet-project-structure.prd.md`
    - `/plans/001/001-phase-1-dotnet-project-structure.plan.md`
    - `/plans/002/002-phase-2-dotnet-namespace-type-declaration.prd.md`
    - `/plans/002/002-phase-2-dotnet-namespace-type-declaration.plan.md`
    - `/plans/003/003-phase-3-dotnet-method-extraction-and-relations.prd.md`
    - `/plans/003/003-phase-3-dotnet-method-extraction-and-relations.plan.md`
-4. If implementing a capability, read its linked issue file(s):
+5. If implementing a capability, read its linked issue file(s):
    - `/plans/{prd_id}/{prd_id}-{name}.issue.{issue_id}.md`
 
 ## Current Program State

--- a/docs/diagnostics-runbook.md
+++ b/docs/diagnostics-runbook.md
@@ -1,0 +1,116 @@
+# Ingestion Diagnostics Runbook
+
+Purpose: define run status meanings, diagnostic code contracts, likely causes, and first-response actions for `.NET` ingestion runs.
+
+## Run Statuses
+
+- `Succeeded`: run completed with no diagnostics.
+- `SucceededWithDiagnostics`: run completed and published artifacts, with warnings/non-fatal diagnostics.
+- `FailedQualityGate`: run completed analysis but failed the unresolved-call quality policy.
+- `Failed`: run could not complete required ingestion stages (for example invalid ontology or fatal publish failure).
+
+## Quality Gate
+
+- Gate ID: `quality:unresolved-call-ratio`
+- Metric: `unresolved_call_failures / total_call_resolution_attempts`
+- Default threshold: `0.25`
+- Failure behavior:
+  - status: `FailedQualityGate`
+  - exit code: `3`
+  - CLI stderr includes measured ratio and threshold.
+- Non-gating diagnostics (for this phase): `project:discovery:fallback`.
+
+## Stage Telemetry Contract
+
+- Emitted to `stderr` during execution.
+- Line format:
+  - start: `ingest_stage|event=start|stage=<stage_id>`
+  - end: `ingest_stage|event=end|stage=<stage_id>|duration_ms=<n>|...counters`
+- Stable stage IDs:
+  - `project_discovery`
+  - `source_snapshot`
+  - `declaration_scan`
+  - `semantic_call_graph`
+  - `endpoint_extraction`
+  - `query_projection`
+  - `wiki_render`
+  - `graphml_serialize`
+
+## Diagnostic Families
+
+### Call Resolution
+
+- `method:call:resolution:failed`
+  - Meaning: invocation target could not be resolved to a method declaration.
+  - Probable causes: incomplete semantic context, unknown symbol, missing references.
+  - Actions: inspect paired specific code and invocation location; verify project references/build graph.
+
+- `method:call:resolution:failed:symbol-unresolved`
+  - Meaning: Roslyn symbol lookup failed for invocation.
+  - Probable causes: unresolved identifiers, generated code not available, parse/binding gaps.
+  - Actions: confirm source snapshot completeness and owning-project semantic context.
+
+- `method:call:resolution:failed:missing-containing-type`
+  - Meaning: invocation symbol existed but containing type was missing.
+  - Probable causes: partial symbol metadata, edge-case language constructs.
+  - Actions: inspect invocation syntax and semantic model fallback path.
+
+- `method:call:internal-target-unmatched`
+  - Meaning: invocation bound to an internal type but no unique method declaration matched.
+  - Probable causes: overload ambiguity, signature normalization mismatch, duplicate declarations.
+  - Actions: inspect candidate methods for arity/signature conflicts; review method identity normalization.
+
+### Type Resolution
+
+- `type:resolution:fallback`
+  - Meaning: declaration-level type link could not resolve to internal or external stub with certainty.
+  - Probable causes: missing/ambiguous type names, unsupported syntax edge cases.
+  - Actions: inspect normalized type text and imports/aliases; confirm source declarations are indexed.
+
+### Project Discovery / Package Resolution
+
+- `project:discovery:msbuild`
+  - Meaning: project metadata was discovered through MSBuild evaluation.
+  - Actions: informational.
+
+- `project:discovery:fallback`
+  - Meaning: MSBuild discovery degraded and fallback parsing was used.
+  - Probable causes: environment-specific MSBuild issues, incomplete SDK context.
+  - Actions: inspect machine SDK/tooling state; compare fallback outputs with expected project metadata.
+  - Gate impact: warning-level, non-gating in this phase.
+
+- `package:resolved:available`
+  - Meaning: resolved package information was available from assets data.
+  - Actions: informational.
+
+- `package:resolved:not-available`
+  - Meaning: resolved package information could not be loaded.
+  - Probable causes: missing/invalid `project.assets.json`, restore not run.
+  - Actions: run restore for target project and re-run ingestion.
+
+### Method Relationship
+
+- `method:relationship:override:unresolved`
+  - Meaning: override target could not be mapped to a source declaration ID.
+  - Probable causes: source location mismatch, unavailable declaration in semantic context.
+  - Actions: verify project-scoped semantic context and declaration location mapping.
+
+## Run Artifact Expectations
+
+- `manifest.json` always includes:
+  - `Status`, `ExitCode`, `DiagnosticsSummary`
+- When quality gate is evaluated, manifest includes:
+  - `QualityGate.GateId`
+  - `QualityGate.Passed`
+  - `QualityGate.UnresolvedCallFailures`
+  - `QualityGate.TotalCallResolutionAttempts`
+  - `QualityGate.UnresolvedCallRatio`
+  - `QualityGate.Threshold`
+
+## Operator Workflow
+
+1. Check `Status` and `ExitCode` in `manifest.json`.
+2. If `FailedQualityGate`, capture ratio/threshold from stderr and manifest.
+3. Review `DiagnosticsSummary` for dominant code families.
+4. Use stage telemetry to isolate slow stages before deeper tuning.
+5. Re-run after fixes; compare status, gate values, and diagnostics family counts.

--- a/docs/diagnostics-runbook.md
+++ b/docs/diagnostics-runbook.md
@@ -25,7 +25,7 @@ Purpose: define run status meanings, diagnostic code contracts, likely causes, a
 - Emitted to `stderr` during execution.
 - Line format:
   - start: `ingest_stage|event=start|stage=<stage_id>`
-  - end: `ingest_stage|event=end|stage=<stage_id>|duration_ms=<n>|...counters`
+  - end: `ingest_stage|event=end|stage=<stage_id>|elapsed_ms=<n>|...counters`
 - Stable stage IDs:
   - `project_discovery`
   - `source_snapshot`

--- a/src/CodeLlmWiki.Ingestion/Diagnostics/CallResolutionDiagnosticCodes.cs
+++ b/src/CodeLlmWiki.Ingestion/Diagnostics/CallResolutionDiagnosticCodes.cs
@@ -5,4 +5,13 @@ public static class CallResolutionDiagnosticCodes
     public const string Aggregate = "method:call:resolution:failed";
     public const string SymbolUnresolved = "method:call:resolution:failed:symbol-unresolved";
     public const string MissingContainingType = "method:call:resolution:failed:missing-containing-type";
+    public const string InternalTargetUnmatched = "method:call:internal-target-unmatched";
+
+    public static readonly IReadOnlyList<string> All =
+    [
+        Aggregate,
+        SymbolUnresolved,
+        MissingContainingType,
+        InternalTargetUnmatched,
+    ];
 }

--- a/src/CodeLlmWiki.Ingestion/ProjectStructure/ProjectStructureAnalyzer.cs
+++ b/src/CodeLlmWiki.Ingestion/ProjectStructure/ProjectStructureAnalyzer.cs
@@ -4227,7 +4227,7 @@ public sealed class ProjectStructureAnalyzer : IProjectStructureAnalyzer
                     CorePredicates.Calls,
                     new EntityNode(unresolvedTargetId)));
                 diagnostics.Add(new IngestionDiagnostic(
-                    "method:call:internal-target-unmatched",
+                    CallResolutionDiagnosticCodes.InternalTargetUnmatched,
                     $"Invocation '{invocation}' resolved to internal type '{targetTypeQualifiedName}' but no unique method declaration could be matched in method '{sourceMethodId.Value}'."));
                 continue;
             }

--- a/src/CodeLlmWiki.Ingestion/Quality/UnresolvedCallRatioQualityGateEvaluator.cs
+++ b/src/CodeLlmWiki.Ingestion/Quality/UnresolvedCallRatioQualityGateEvaluator.cs
@@ -5,7 +5,6 @@ namespace CodeLlmWiki.Ingestion.Quality;
 public sealed class UnresolvedCallRatioQualityGateEvaluator : IUnresolvedCallRatioQualityGateEvaluator
 {
     public const string GateId = "quality:unresolved-call-ratio";
-    private const string InternalTargetUnmatchedCode = "method:call:internal-target-unmatched";
 
     public UnresolvedCallRatioQualityGateEvaluation Evaluate(UnresolvedCallRatioQualityGateRequest request)
     {
@@ -32,7 +31,7 @@ public sealed class UnresolvedCallRatioQualityGateEvaluator : IUnresolvedCallRat
     private static bool IsUnresolvedCallFailureDiagnostic(IngestionDiagnostic diagnostic)
     {
         return string.Equals(diagnostic.Code, CallResolutionDiagnosticCodes.Aggregate, StringComparison.Ordinal)
-               || string.Equals(diagnostic.Code, InternalTargetUnmatchedCode, StringComparison.Ordinal);
+               || string.Equals(diagnostic.Code, CallResolutionDiagnosticCodes.InternalTargetUnmatched, StringComparison.Ordinal);
     }
 
     private static double NormalizeThreshold(double threshold)

--- a/tests/CodeLlmWiki.Ingestion.Tests/DiagnosticsContractCompatibilityTests.cs
+++ b/tests/CodeLlmWiki.Ingestion.Tests/DiagnosticsContractCompatibilityTests.cs
@@ -1,0 +1,41 @@
+using CodeLlmWiki.Ingestion.Diagnostics;
+using CodeLlmWiki.Ingestion.Quality;
+
+namespace CodeLlmWiki.Ingestion.Tests;
+
+public sealed class DiagnosticsContractCompatibilityTests
+{
+    [Fact]
+    public void CallResolutionDiagnosticCodes_All_IsStable()
+    {
+        Assert.Equal(
+            new[]
+            {
+                "method:call:resolution:failed",
+                "method:call:resolution:failed:symbol-unresolved",
+                "method:call:resolution:failed:missing-containing-type",
+                "method:call:internal-target-unmatched",
+            },
+            CallResolutionDiagnosticCodes.All);
+    }
+
+    [Fact]
+    public void IngestionRunStatus_Names_AreStable()
+    {
+        Assert.Equal(
+            new[]
+            {
+                "Succeeded",
+                "SucceededWithDiagnostics",
+                "Failed",
+                "FailedQualityGate",
+            },
+            Enum.GetNames<IngestionRunStatus>());
+    }
+
+    [Fact]
+    public void UnresolvedCallRatioQualityGate_Id_IsStable()
+    {
+        Assert.Equal("quality:unresolved-call-ratio", UnresolvedCallRatioQualityGateEvaluator.GateId);
+    }
+}


### PR DESCRIPTION
## Summary
- add repo-level diagnostics runbook with run status meanings, quality-gate behavior, stage telemetry contract, and diagnostic remediation guidance
- add diagnostics contract compatibility tests for stable call-resolution taxonomy, run-status names, and quality-gate identifier
- centralize internal-target-unmatched call-resolution code in shared diagnostic constants

## Testing
- dotnet test tests/CodeLlmWiki.Ingestion.Tests/CodeLlmWiki.Ingestion.Tests.csproj
- dotnet test tests/CodeLlmWiki.Cli.Tests/CodeLlmWiki.Cli.Tests.csproj

Closes #125